### PR TITLE
Remove old mp3 copyright header include

### DIFF
--- a/codemp/client/snd_mp3.cpp
+++ b/codemp/client/snd_mp3.cpp
@@ -9,7 +9,6 @@
 #include "client.h"
 #include "snd_mp3.h"					// only included directly by a few snd_xxxx.cpp files plus this one
 #include "mp3code/mp3struct.h"	// keep this rather awful file secret from the rest of the program
-#include "mp3code/copyright.h"
 
 // expects data already loaded, filename arg is for error printing only
 //


### PR DESCRIPTION
Doesn't compile anymore because of this header being gone.
