### PR TITLE
Fix for issue #178

### DIFF
--- a/codemp/game/g_main.c
+++ b/codemp/game/g_main.c
@@ -41,6 +41,11 @@ qboolean G_EntIsBreakable( int entityNum );
 qboolean G_EntIsRemovableUsable( int entNum );
 void CP_FindCombatPointWaypoints( void );
 
+void SetNPCGlobals( gentity_t *ent );
+void SaveNPCGlobals(void);
+void RestoreNPCGlobals(void);
+extern gNPC_t *NPCInfo;
+
 /*
 ================
 vmMain
@@ -3065,7 +3070,13 @@ void G_RunThink (gentity_t *ent) {
 runicarus:
 	if ( ent->inuse )
 	{
+		SaveNPCGlobals();
+		if(NPCInfo == NULL && ent->NPC != NULL)
+		{
+			SetNPCGlobals( ent );
+		}
 		trap_ICARUS_MaintainTaskManager(ent->s.number);
+		RestoreNPCGlobals();
 	}
 }
 


### PR DESCRIPTION
When doing G_RunThink for NPCs, it will skip the NPC_Think function and only run icarus when it hasn't reached the nextthink time.
Which means that the NPCGlobals such as NPCInfo will not be set for this run of icarus.
This causes null pointer crashes when icarus needs to access the npc globals.
