### PR TITLE
Use virtual screen dimensions instead of primary monitor dimension. Fixes #60

### DIFF
--- a/codemp/win32/win_input.cpp
+++ b/codemp/win32/win_input.cpp
@@ -174,6 +174,9 @@ IN_RawMouse
 */
 void IN_RawMouse( int *mx, int *my )
 {
+	// force the mouse to the center, just to be consistent with default mouse behaviour
+	SetCursorPos (window_center_x, window_center_y);
+
 	*mx = rawDeltaX;
 	*my = rawDeltaY;
 	rawDeltaX = rawDeltaY = 0;
@@ -225,8 +228,8 @@ void IN_ActivateWin32Mouse( void ) {
 	int			width, height;
 	RECT		window_rect;
 
-	width = GetSystemMetrics (SM_CXSCREEN);
-	height = GetSystemMetrics (SM_CYSCREEN);
+	width = GetSystemMetrics (SM_CXVIRTUALSCREEN);
+	height = GetSystemMetrics (SM_CYVIRTUALSCREEN);
 
 	GetWindowRect ( g_wv.hWnd, &window_rect);
 	if (window_rect.left < 0)


### PR DESCRIPTION
Windows mouse activation code was using the width/height of the screen of the primary display monitor when calculating the bounds of the window's center coordinates. This meant that weird coordinates were being calculated when the window was outside the primary display monitor.

This commit fixes the issue by using the width/height of the virtual screen (the bounding rectangle of all display monitors) instead.
