### PR TITLE
Missing header for Linux build

### DIFF
--- a/codemp/sys/sys_unix.cpp
+++ b/codemp/sys/sys_unix.cpp
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <pwd.h>
+#include <libgen.h>
 
 #include "qcommon/qcommon.h"
 #include "qcommon/q_shared.h"


### PR DESCRIPTION
dirname() requires "libgen.h"
tested on arch linux
