### PR TITLE
snapvector.c -> .cpp, remove win_shared SnapVector

### DIFF
--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -345,13 +345,14 @@ if(BuildMPEngine OR BuildMPDed)
 			"${MPDir}/win32/win_local.h"
 			"${MPDir}/win32/win_net.cpp"
 			"${MPDir}/win32/win_shared.cpp"
+			"${MPDir}/sys/snapvector.cpp"
 			)
 		source_group("win32" FILES ${MPEngineAndDedWin32Files})
 		set(MPEngineAndDedFiles ${MPEngineAndDedFiles} ${MPEngineAndDedWin32Files})
 	else(WIN32)
 		set(MPEngineAndDedSysFiles
 			"${MPDir}/sys/vm_x86.cpp"
-			"${MPDir}/sys/snapvector.c"
+			"${MPDir}/sys/snapvector.cpp"
 			)
 		set(MPEngineAndDedFiles ${MPEngineAndDedFiles} ${MPEngineAndDedSysFiles})
 		source_group("sys" FILES ${MPEngineAndDedSysFiles})

--- a/codemp/sys/snapvector.cpp
+++ b/codemp/sys/snapvector.cpp
@@ -7,12 +7,13 @@
 #endif
 
 #if _MSC_VER
-static __inline float roundfloat(float n)
+static inline float roundfloat(float n)
 {
 	return (n < 0.0f) ? ceilf(n - 0.5f) : floorf(n + 0.5f);
 }
 #endif
 
+extern "C"
 void Sys_SnapVector(float *v)
 {
 #if _MSC_VER

--- a/codemp/win32/win_shared.cpp
+++ b/codemp/win32/win_shared.cpp
@@ -153,40 +153,6 @@ int Sys_Milliseconds2( void )
 	return sys_curtime;
 }
 
-/*
-================
-Sys_SnapVector
-================
-*/
-void Sys_SnapVector( float *v )
-{
-	int i;
-	float f;
-
-	f = *v;
-	__asm	fld		f;
-	__asm	fistp	i;
-	*v = i;
-	v++;
-	f = *v;
-	__asm	fld		f;
-	__asm	fistp	i;
-	*v = i;
-	v++;
-	f = *v;
-	__asm	fld		f;
-	__asm	fistp	i;
-	*v = i;
-	/*
-	*v = Q_ftol(*v);
-	v++;
-	*v = Q_ftol(*v);
-	v++;
-	*v = Q_ftol(*v);
-	*/
-}
-
-
 //============================================
 
 char *Sys_GetCurrentUser( void )


### PR DESCRIPTION
- Convert snapvector.c to C++ as snapvector.cpp.
- Remove Sys_SnapVector from win_shared.cpp, as it doesn't care about the
  rounding mode and that might introduce behavior differences between platforms.
