### PR TITLE
64-bit: fix a whole load of "error: cast from x to 'int' loses precision"

### DIFF
--- a/code/client/cl_cgame.cpp
+++ b/code/client/cl_cgame.cpp
@@ -1171,7 +1171,7 @@ Ghoul2 Insert End
 	  return 0;
 
 	case CG_Z_MALLOC:
-		return (int)Z_Malloc(args[1], (memtag_t) args[2], qfalse);
+		return (intptr_t)Z_Malloc(args[1], (memtag_t) args[2], qfalse);
 
 	case CG_Z_FREE:
 		Z_Free((void *) VMA(1));
@@ -1234,11 +1234,11 @@ Ghoul2 Insert End
 		return 0;
 
 	case CG_OPENJK_MENU_PAINT:
-		Menu_Paint( (menuDef_t *)VMA(1), (int)VMA(2) );
+		Menu_Paint( (menuDef_t *)VMA(1), (intptr_t)VMA(2) );
 		return 0;
 
 	case CG_OPENJK_GETMENU_BYNAME:
-		return (int)Menus_FindByName( (const char *)VMA(1) );
+		return (intptr_t)Menus_FindByName( (const char *)VMA(1) );
 
 	case CG_UI_STRING_INIT:
 		String_Init();

--- a/code/client/cl_cin.cpp
+++ b/code/client/cl_cin.cpp
@@ -910,8 +910,8 @@ static void readQuadInfo( byte *qData )
 	cinTable[currentHandle].VQ0 = cinTable[currentHandle].VQNormal;
 	cinTable[currentHandle].VQ1 = cinTable[currentHandle].VQBuffer;
 
-	cinTable[currentHandle].t[0] = (0 - (unsigned int)cin.linbuf)+(unsigned int)cin.linbuf+cinTable[currentHandle].screenDelta;
-	cinTable[currentHandle].t[1] = (0 - ((unsigned int)cin.linbuf + cinTable[currentHandle].screenDelta))+(unsigned int)cin.linbuf;
+	cinTable[currentHandle].t[0] = (0 - (uintptr_t)cin.linbuf)+(uintptr_t)cin.linbuf+cinTable[currentHandle].screenDelta;
+	cinTable[currentHandle].t[1] = (0 - ((uintptr_t)cin.linbuf + cinTable[currentHandle].screenDelta))+(uintptr_t)cin.linbuf;
 
 	cinTable[currentHandle].drawX = cinTable[currentHandle].CIN_WIDTH;
 	cinTable[currentHandle].drawY = cinTable[currentHandle].CIN_HEIGHT;

--- a/code/client/snd_mem.cpp
+++ b/code/client/snd_mem.cpp
@@ -118,7 +118,7 @@ void DumpChunks(void)
 		memcpy (str, data_p, 4);
 		data_p += 4;
 		iff_chunk_len = GetLittleLong();
-		Com_Printf ("0x%x : %s (%d)\n", (int)(data_p - 4), str, iff_chunk_len);
+		Com_Printf ("0x%x : %s (%d)\n", (intptr_t)(data_p - 4), str, iff_chunk_len);
 		data_p += (iff_chunk_len + 1) & ~1;
 	} while (data_p < iff_end);
 }

--- a/code/qcommon/MiniHeap.h
+++ b/code/qcommon/MiniHeap.h
@@ -68,7 +68,7 @@ CMiniHeap(int size)
 // give me some space from the heap please
 char *MiniHeapAlloc(int size)
 {
-	if (size < (mSize - ((int)mCurrentHeap - (int)mHeap)))
+	if (size < (mSize - ((intptr_t)mCurrentHeap - (intptr_t)mHeap)))
 	{
 		char *tempAddress =  mCurrentHeap;
 		mCurrentHeap += size;

--- a/code/qcommon/cm_polylib.cpp
+++ b/code/qcommon/cm_polylib.cpp
@@ -267,7 +267,7 @@ winding_t	*CopyWinding (winding_t *w)
 	winding_t	*c;
 
 	c = AllocWinding (w->numpoints);
-	size = (int)((winding_t *)0)->p[w->numpoints];
+	size = (intptr_t)((winding_t *)0)->p[w->numpoints];
 	memcpy (c, w, size);
 	return c;
 }

--- a/code/qcommon/msg.cpp
+++ b/code/qcommon/msg.cpp
@@ -941,7 +941,7 @@ plyer_state_t communication
 */
 
 // using the stringizing operator to save typing...
-#define	PSF(x) #x,(int)&((playerState_t*)0)->x
+#define	PSF(x) #x,(intptr_t)&((playerState_t*)0)->x
 
 static const netField_t	playerStateFields[] = 
 {


### PR DESCRIPTION
One step closer to compiling on 64bit Linux (Arch Linux). This error stopped my build process, now I get to the linking process, where SDL2 fails.

```
/usr/lib/gcc/x86_64-unknown-linux-gnu/4.8.1/../../../../lib/libSDL2.so: undefined reference to `SDL_TLSCreate'
/usr/lib/gcc/x86_64-unknown-linux-gnu/4.8.1/../../../../lib/libSDL2.so: undefined reference to `SDL_TLSGet'
/usr/lib/gcc/x86_64-unknown-linux-gnu/4.8.1/../../../../lib/libSDL2.so: undefined reference to `SDL_TLSSet'
```
