### PR TITLE
Use offsetof in offset functions.

### DIFF
--- a/code/game/fields.h
+++ b/code/game/fields.h
@@ -30,13 +30,13 @@ This file is part of Jedi Academy.
 #define MAX_GHOULINST_SIZE	16384
 
 #ifndef FOFS
-#define	FOFS(x) ((size_t)&(((gentity_t *)0)->x))	// usually already defined in qshared.h
+#define	FOFS(x) offsetof(gentity_t, x)	// usually already defined in qshared.h
 #endif
-#define	STOFS(x) ((size_t)&(((spawn_temp_t *)0)->x))
-#define	LLOFS(x) ((size_t)&(((level_locals_t *)0)->x))
-#define	CLOFS(x) ((size_t)&(((gclient_t *)0)->x))
-#define NPCOFS(x) ((size_t)&(((gNPC_t *)0)->x)) 
-#define VHOFS(x) ((size_t)&(((Vehicle_t *)0)->x)) 
+#define	STOFS(x) offsetof(spawn_temp_t, x)
+#define	LLOFS(x) offsetof(level_locals_t, x)
+#define	CLOFS(x) offsetof(gclient_t, x)
+#define NPCOFS(x) offsetof(gNPC_t, x) 
+#define VHOFS(x) offsetof(Vehicle_t, x)
 
 //
 #define strFOFS(x)	 #x,FOFS(x)

--- a/code/game/g_shared.h
+++ b/code/game/g_shared.h
@@ -29,7 +29,7 @@ This file is part of Jedi Academy.
 #include "hitlocs.h"
 #include "bset.h"
 
-#define	FOFS(x) ((size_t)&(((gentity_t *)0)->x))
+#define	FOFS(x) offsetof(gentity_t, x)
 
 #ifdef _XBOX
 #define MAX_NPC_WATER_UPDATE_PER_FRAME	2	// maxmum number of NPCs that will get updated water infromation per frame

--- a/code/game/g_vehicles.h
+++ b/code/game/g_vehicles.h
@@ -81,7 +81,7 @@ typedef struct
 //NOTE: this MUST stay up to date with the number of variables in the vehFields table!!!
 #define NUM_VWEAP_PARMS	25
 
-#define	VWFOFS(x) ((size_t)&(((vehWeaponInfo_t *)0)->x))
+#define	VWFOFS(x) offsetof(vehWeaponInfo_t, x)
 
 #define MAX_VEH_WEAPONS	16	//sigh... no more than 16 different vehicle weapons
 #define VEH_WEAPON_BASE	0
@@ -370,7 +370,7 @@ typedef struct
 	bool (*Inhabited)( Vehicle_t *pVeh );
 } vehicleInfo_t;
 
-#define	VFOFS(x) ((size_t)&(((vehicleInfo_t *)0)->x))
+#define	VFOFS(x) offsetof(vehicleInfo_t, x)
 
 #define MAX_VEHICLES	16	//sigh... no more than 64 individual vehicles
 extern vehicleInfo_t g_vehicleInfo[MAX_VEHICLES];

--- a/code/game/q_shared.h
+++ b/code/game/q_shared.h
@@ -80,6 +80,7 @@ This file is part of Jedi Academy.
 #include <time.h>
 #include <ctype.h>
 #include <limits.h>
+#include <stddef.h>
 //=======================================================================
 
 //Ignore __attribute__ on non-gcc platforms

--- a/codeJK2/game/fields.h
+++ b/codeJK2/game/fields.h
@@ -30,12 +30,12 @@ This file is part of Jedi Knight 2.
 #define MAX_GHOULINST_SIZE	16384
 
 #ifndef FOFS
-#define	FOFS(x) ((int)&(((gentity_t *)0)->x))	// usually already defined in qshared.h
+#define	FOFS(x) offsetof(gentity_t, x)	// usually already defined in qshared.h
 #endif
-#define	STOFS(x) ((int)&(((spawn_temp_t *)0)->x))
-#define	LLOFS(x) ((int)&(((level_locals_t *)0)->x))
-#define	CLOFS(x) ((int)&(((gclient_t *)0)->x))
-#define NPCOFS(x) ((int)&(((gNPC_t *)0)->x)) 
+#define STOFS(x) offsetof(spawn_temp_t, x)
+#define LLOFS(x) offsetof(level_locals_t, x)
+#define CLOFS(x) offsetof(gclient_t, x)
+#define NPCOFS(x) offsetof(gNPC_t, x) 
 //
 #define strFOFS(x)	 #x,FOFS(x)
 #define	strSTOFS(x)  #x,STOFS(x)

--- a/codeJK2/game/g_shared.h
+++ b/codeJK2/game/g_shared.h
@@ -27,7 +27,7 @@ This file is part of Jedi Knight 2.
 #include "../cgame/cg_public.h"
 #include "bset.h"
 
-#define	FOFS(x) ((int)&(((gentity_t *)0)->x))
+#define	FOFS(x) offsetof(gentity_t, x)
 
 typedef enum 
 {

--- a/codeJK2/game/q_shared.h
+++ b/codeJK2/game/q_shared.h
@@ -59,7 +59,7 @@ This file is part of Jedi Knight 2.
 #include <stdlib.h>
 #include <time.h>
 #include <ctype.h>
-
+#include <stddef.h>
 
 // this is the define for determining if we have an asm version of a C function
 #if (defined _M_IX86 || defined __i386__) && !defined __sun__  && !defined __LCC__

--- a/codemp/botlib/be_ai_goal.cpp
+++ b/codemp/botlib/be_ai_goal.cpp
@@ -118,7 +118,7 @@ typedef struct iteminfo_s
 	int number;							//number of the item info
 } iteminfo_t;
 
-#define ITEMINFO_OFS(x)	(size_t)&(((iteminfo_t *)0)->x)
+#define ITEMINFO_OFS(x)	offsetof(iteminfo_t, x)
 
 fielddef_t iteminfo_fields[] =
 {

--- a/codemp/botlib/be_ai_weap.cpp
+++ b/codemp/botlib/be_ai_weap.cpp
@@ -31,8 +31,8 @@
 //#define DEBUG_AI_WEAP
 
 //structure field offsets
-#define WEAPON_OFS(x) (size_t)&(((weaponinfo_t *)0)->x)
-#define PROJECTILE_OFS(x) (size_t)&(((projectileinfo_t *)0)->x)
+#define WEAPON_OFS(x) offsetof(weaponinfo_t, x)
+#define PROJECTILE_OFS(x) offsetof(projectileinfo_t, x)
 
 //weapon definition // bk001212 - static
 static fielddef_t weaponinfo_fields[] =

--- a/codemp/game/bg_vehicles.h
+++ b/codemp/game/bg_vehicles.h
@@ -62,7 +62,7 @@ typedef struct
 //NOTE: this MUST stay up to date with the number of variables in the vehFields table!!!
 #define NUM_VWEAP_PARMS	25
 
-#define	VWFOFS(x) ((size_t)&(((vehWeaponInfo_t *)0)->x))
+#define	VWFOFS(x) offsetof(vehWeaponInfo_t, x)
 
 #define MAX_VEH_WEAPONS	16	//sigh... no more than 16 different vehicle weapons
 #define VEH_WEAPON_BASE	0
@@ -355,7 +355,7 @@ typedef struct
 } vehicleInfo_t;
 
 
-#define	VFOFS(x) ((size_t)&(((vehicleInfo_t *)0)->x))
+#define	VFOFS(x) offsetof(vehicleInfo_t, x)
 
 #define MAX_VEHICLES	16	//sigh... no more than 64 individual vehicles
 #define VEHICLE_BASE	0

--- a/codemp/game/g_local.h
+++ b/codemp/game/g_local.h
@@ -1525,7 +1525,7 @@ int BotAIStartFrame( int time );
 extern	level_locals_t	level;
 extern	gentity_t		g_entities[MAX_GENTITIES];
 
-#define	FOFS(x) ((size_t)&(((gentity_t *)0)->x))
+#define	FOFS(x) offsetof(gentity_t, x)
 
 void	trap_Print( const char *fmt );
 void	trap_Error( const char *fmt );

--- a/codemp/qcommon/q_shared.h
+++ b/codemp/qcommon/q_shared.h
@@ -82,6 +82,7 @@
 #include <ctype.h>
 #include <limits.h>
 #include <errno.h>
+#include <stddef.h>
 
 //Ignore __attribute__ on non-gcc platforms
 #if !defined(__GNUC__) && !defined(__attribute__)


### PR DESCRIPTION
Let's restore some sanity, shall we?

The old macros looked crazy and they basically used the same code used in the offsetof() definition inside ANSI C. Compilers may provide even more optimized versions. http://en.wikipedia.org/wiki/Offsetof
