### PR TITLE
fix: build on OSX was broken, because of abs(double) include cmath.

### DIFF
--- a/code/client/cl_cin.cpp
+++ b/code/client/cl_cin.cpp
@@ -38,6 +38,9 @@ This file is part of Jedi Academy.
 #include "client.h"
 #include "client_ui.h"	// CHC
 #include "snd_local.h"
+#ifndef _WIN32
+#include <cmath>
+#endif
 
 #define MAXSIZE				8
 #define MINSIZE				4


### PR DESCRIPTION
http://stackoverflow.com/questions/1374037/ambiguous-overload-call-to-absdouble

math.h is the outdated math library, which only contains abs(int),
the C++ version -- cmath.h includes the overload. Apparently GCC
and Windows already overload the abs() inside math.h, because this
only broke on OSX.
