### PR TITLE
Replace malloc.h with stdlib.h

### DIFF
--- a/codeJK2/icarus/blockstream.h
+++ b/codeJK2/icarus/blockstream.h
@@ -25,10 +25,7 @@ This file is part of Jedi Knight 2.
 #pragma warning(disable : 4514)  //unreffed inline func removed
 
 #include <stdio.h>
-
-#if !defined(_WIN32) && !defined(MACOS_X)
-#include <malloc.h>
-#endif
+#include <stdlib.h>
 
 #pragma warning (push, 3)	//go back down to 3 for the stl include
 #include <list>


### PR DESCRIPTION
OLD: No need to include malloc.h on OS X.

Replace malloc with stdlib (https://github.com/JACoders/OpenJK/pull/414#commitcomment-4422882)
