### PR TITLE
Fix JK2 build and runtime breaks.

### DIFF
--- a/codeJK2/cgame/cg_event.cpp
+++ b/codeJK2/cgame/cg_event.cpp
@@ -32,7 +32,7 @@ extern void CG_TryPlayCustomSound( vec3_t origin, int entityNum, soundChannel_t 
 //==========================================================================
 
 qboolean CG_IsFemale( const char *infostring ) {
-	char		*sex;
+	const char		*sex;
 
 	sex = Info_ValueForKey( infostring, "s" );
 	if (sex[0] == 'f' || sex[0] == 'F')

--- a/codeJK2/cgame/cg_servercmds.cpp
+++ b/codeJK2/cgame/cg_servercmds.cpp
@@ -37,7 +37,7 @@ and whenever the server updates any serverinfo flagged cvars
 */
 void CG_ParseServerinfo( void ) {
 	const char	*info;
-	char	*mapname;
+	const char	*mapname;
 
 	info = CG_ConfigString( CS_SERVERINFO );
 	cgs.dmflags = atoi( Info_ValueForKey( info, "dmflags" ) );
@@ -59,7 +59,7 @@ void CG_ParseServerinfo( void ) {
 	{
 		Com_sprintf( cgs.mapname, sizeof( cgs.mapname ), "maps/%s.bsp", mapname );
 	}
-	char *p = strrchr(mapname,'/');
+	const char *p = strrchr(mapname,'/');
 	strcpy( cgs.stripLevelName[0], p?p+1:mapname );
 	Q_strupr( cgs.stripLevelName[0] );
 	for (int i=1; i<STRIPED_LEVELNAME_VARIATIONS; i++)	// clear retry-array

--- a/codeJK2/game/q_shared.cpp
+++ b/codeJK2/game/q_shared.cpp
@@ -309,7 +309,8 @@ void COM_ParseInit( void )
 void COM_BeginParseSession( void )
 {
 	parseDataCount++;
-#ifdef _DEBUG
+	//Disabling this, as the game seems to work fine without it and crashes with it enabled. What is this even for?
+#if 0
 	if ( parseDataCount >= MAX_PARSE_DATA )
 	{
 		Com_Error (ERR_FATAL, "COM_BeginParseSession: cannot nest more than %d parsing sessions.\n", MAX_PARSE_DATA);


### PR DESCRIPTION
This fixes some compilation and running regressions. JK2 now compiles and starts successfully again. I'm not quite sure what to make of that MAX_PARSE_DATA failure, but it was causing the game to crash on startup, so I've disabled it for now.
