### PR TITLE
Fix savegame on 64bit

### DIFF
--- a/code/game/g_savegame.cpp
+++ b/code/game/g_savegame.cpp
@@ -221,7 +221,7 @@ static intptr_t GetGEntityNum(gentity_t* ent)
 	//	way that the level_locals_t alertEvents struct contains a count of which ones are valid, so I'm guessing
 	//	that some of them aren't (valid)...
 	//
-	int iReturnIndex = ent - g_entities;
+	ptrdiff_t iReturnIndex = ent - g_entities;
 
 	if (iReturnIndex < 0 || iReturnIndex >= MAX_GENTITIES)
 	{	
@@ -279,7 +279,7 @@ static AIGroupInfo_t *GetGroupPtr(intptr_t iGroupNum)
 /////////// gclient_t * ////////
 //
 //
-static int GetGClientNum(gclient_t *c, gentity_t *ent)
+static intptr_t GetGClientNum(gclient_t *c, gentity_t *ent)
 {
 	// unfortunately, I now need to see if this is a INT_ID('r','e','a','l') client (and therefore resolve to an enum), or
 	//	whether it's one of the NPC or SP_misc_weapon_shooter
@@ -301,7 +301,7 @@ static int GetGClientNum(gclient_t *c, gentity_t *ent)
 	}
 }
 
-static gclient_t *GetGClientPtr(int c)
+static gclient_t *GetGClientPtr(intptr_t c)
 {
 	if (c == -1)
 	{
@@ -394,7 +394,7 @@ static void EnumerateField(const save_field_t *pField, const byte *pbBase)
 		break;
 
 	case F_GENTITY:
-		*(int *)pv = GetGEntityNum(*(gentity_t **)pv);
+		*(intptr_t *)pv = GetGEntityNum(*(gentity_t **)pv);
 		break;
 
 	case F_GROUP:
@@ -402,7 +402,7 @@ static void EnumerateField(const save_field_t *pField, const byte *pbBase)
 		break;
 
 	case F_GCLIENT:
-		*(int *)pv = GetGClientNum(*(gclient_t **)pv, (gentity_t *) pbBase);
+		*(intptr_t *)pv = GetGClientNum(*(gclient_t **)pv, (gentity_t *) pbBase);
 		break;
 
 	case F_ITEM:
@@ -539,7 +539,7 @@ static void EvaluateField(const save_field_t *pField, byte *pbBase, byte *pbOrig
 		break;
 
 	case F_GENTITY:
-		*(gentity_t **)pv = GetGEntityPtr(*(int *)pv);
+		*(gentity_t **)pv = GetGEntityPtr(*(intptr_t *)pv);
 		break;
 
 	case F_GROUP:
@@ -547,7 +547,7 @@ static void EvaluateField(const save_field_t *pField, byte *pbBase, byte *pbOrig
 		break;
 
 	case F_GCLIENT:
-		*(gclient_t **)pv = GetGClientPtr(*(int *)pv);
+		*(gclient_t **)pv = GetGClientPtr(*(intptr_t *)pv);
 		break;
 
 	case F_ITEM:


### PR DESCRIPTION
This makes the saving/loading work on my 64bit Linux.

Every time I tried to load a save made by the game, this error occurred:
ERROR: Loaded chunk ID (GHL2) does not match requested chunk ID (GCLI)

I tracked the problem's origin down here: https://github.com/jakubadler/OpenJK/blob/cbf692cb1aa35eabccb38a12f694ea58dc951cec/code/game/g_savegame.cpp#L984
There is a `-2` cast to `int` stored in the file, which isn't the same as `-2` cast to pointer, so this condition doesn't evaluate true when it should, hence the missing chunk.
So I made the `GetGClientPtr` and `GetGClientNum` functions to work with `inptr_t` instead of `int`. I also modified the `GetGEntityNum` and `GetGEntityPtr` the same way, because they also stored pointers as `int`, though they didn't seem to cause problems.
