### PR TITLE
Fixed segfault in R_FogFactor

### DIFF
--- a/code/rd-vanilla/tr_image.cpp
+++ b/code/rd-vanilla/tr_image.cpp
@@ -1216,6 +1216,7 @@ and for each vertex of transparent shaders in fog dynamically
 */
 float	R_FogFactor( float s, float t ) {
 	float	d;
+	int index;
 
 	s -= 1.0/512;
 	if ( s < 0 ) {
@@ -1231,11 +1232,15 @@ float	R_FogFactor( float s, float t ) {
 	// we need to leave a lot of clamp range
 	s *= 8;
 
-	if ( s > 1.0 ) {
-		s = 1.0;
+	index = (int)( s * (FOG_TABLE_SIZE-1));
+	if ( index > FOG_TABLE_SIZE-1 ) {
+		index = FOG_TABLE_SIZE-1;
+	}
+	if( index < 0 ){
+		index = 0;
 	}
 
-	d = tr.fogTable[ (int)(s * (FOG_TABLE_SIZE-1)) ];
+	d = tr.fogTable[ index ];
 
 	return d;
 }


### PR DESCRIPTION
An out of bounds array lookup was occurring in 64bit Debian, when on the "race" level of Jedi Academy, I believe that these changes to R_FogFactor fix this.

This was due to an issue with converting a float into an array index. I will not totally guarantee the correctness of this code, as I did not check all uses of this function, and the corresponding fog Table array.

I'd also like to add that you folks have done a great job patching up  this code-base. Being able to play Jedi Academy on linux is awesome, as this was one of my favourite games when I was younger. 
