### PR TITLE
clean player name before using it in filename.  prevents weird cases whe...

### DIFF
--- a/codemp/server/sv_ccmds.cpp
+++ b/codemp/server/sv_ccmds.cpp
@@ -1027,7 +1027,7 @@ void SV_AutoRecordDemo( client_t *cl ) {
 	Com_sprintf( demoFolderName, sizeof( demoFolderName ), "%s %s", Cvar_VariableString( "mapname" ), folderDate );
 	// sanitize filename
 	for ( char **start = demoNames; start - demoNames < (ptrdiff_t)ARRAY_LEN( demoNames ); start++ ) {
-		Q_strstrip( *start, "\n\r;?*<>|\\/\"", "" );
+		Q_strstrip( *start, "\n\r;?*<>|\\/\"", NULL );
 	}
 	Com_sprintf( demoName, sizeof( demoName ), "autorecord/%s/%s", demoFolderName, demoFileName );
 	SV_RecordDemo( cl, demoName );


### PR DESCRIPTION
...n

saving files with (possibly invalid) utf-8 sequences in them.  also strips
color codes because they render oddly on commandline.
