### PR TITLE
[JK2SP] Fix x86-64 save game invalid #SQR chunk length error.

### DIFF
--- a/codeJK2/icarus/Instance.cpp
+++ b/codeJK2/icarus/Instance.cpp
@@ -535,7 +535,7 @@ int ICARUS_Instance::LoadSequencers( void )
 	int			numSequencers;
 
 	//Get the number of sequencers to load
-	m_interface->I_ReadSaveData( INT_ID('#','S','Q','R'), &numSequencers, sizeof( &numSequencers ), NULL );
+	m_interface->I_ReadSaveData( INT_ID('#','S','Q','R'), &numSequencers, sizeof( numSequencers ), NULL );
 	
 	//Load all sequencers
 	for ( int i = 0; i < numSequencers; i++ )


### PR DESCRIPTION
I think this fixes the JK2 SP save game support for x86-64 because it was storing the number of sequences as 4 bytes and reading it as 8...
