### PR TITLE
Increase MAX_PATCH_PLANES

### DIFF
--- a/codemp/qcommon/cm_patch.h
+++ b/codemp/qcommon/cm_patch.h
@@ -41,7 +41,7 @@ properly.
 
 
 #define	MAX_FACETS			1024
-#define	MAX_PATCH_PLANES	2048
+#define	MAX_PATCH_PLANES	4096
 
 typedef struct patchPlane_s {
 	float	plane[4];


### PR DESCRIPTION
Increased so that Jedi_Council_GCX will work with OpenJK. Don't think
increasing will break anything, so why not?
