### PR TITLE
[SP] Corrected build error by changing second declaration of S_Music_f() to S_StopMusic_f()

### DIFF
--- a/code/client/snd_dma.cpp
+++ b/code/client/snd_dma.cpp
@@ -36,7 +36,7 @@ This file is part of Jedi Academy.
 static void S_Play_f(void);
 static void S_SoundList_f(void);
 static void S_Music_f(void);
-static void S_Music_f(void);
+static void S_StopMusic_f(void);
 static void S_SetDynamicMusic_f(void);
 
 void S_Update_();


### PR DESCRIPTION
Another declaration was added for S_Music_f() with commit https://github.com/JACoders/OpenJK/commit/0e66cd33fefbd646cffeaec0e5a3c628a05c9ff1 . The declaration was changed to S_StopMusic_f() as intended.
