### PR TITLE
Allow using an external libjpeg-turbo or libjpeg8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,12 @@ else()
 	option(UseInternalPNG "Whether to use the included libpng instead of a locally installed one" OFF)
 endif()
 
+if(WIN32 OR APPLE)
+	option(UseInternalJPEG "Whether to use the included libjpeg instead of a locally installed one" ON)
+else()
+	option(UseInternalJPEG "Whether to use the included libjpeg instead of a locally installed one" OFF)
+endif()
+
 if(APPLE)
 	option(MakeApplicationBundles "Whether to build .app application bundles for engines built" ON)
 else()
@@ -190,6 +196,10 @@ endif()
 # Settings
 if(BuildPortableVersion)
 	set(SharedDefines ${SharedDefines} "_PORTABLE_VERSION")
+endif()
+
+if(UseInternalJPEG)
+	set(SharedDefines ${SharedDefines} "USE_INTERNAL_JPEG")
 endif()
 
 set(OpenJKLibDir "${CMAKE_SOURCE_DIR}/lib")

--- a/code/rd-common/tr_image_jpg.cpp
+++ b/code/rd-common/tr_image_jpg.cpp
@@ -11,8 +11,12 @@
  * (stdio.h is sufficient on ANSI-conforming systems.)
  * You may also wish to include "jerror.h".
  */
+#ifdef USE_INTERNAL_JPEG
 #define JPEG_INTERNALS
 #include "jpeg-8c/jpeglib.h"
+#else
+#include <jpeglib.h>
+#endif
 
 static void R_JPGErrorExit(j_common_ptr cinfo)
 {

--- a/code/rd-vanilla/CMakeLists.txt
+++ b/code/rd-vanilla/CMakeLists.txt
@@ -18,9 +18,15 @@ if(BuildSPRdVanilla OR BuildJK2SPRdVanilla)
 	# Files
 
 	# JPEG
-	file(GLOB_RECURSE J_SRC "${OpenJKLibDir}/jpeg-8c/*.c" "${OpenJKLibDir}/jpeg-8c/*.h")
-	source_group("jpeg-8c" FILES ${J_SRC})
-	set(SPRDVanillaFiles ${SPRDVanillaFiles} ${J_SRC})
+	if(UseInternalJPEG)
+		file(GLOB_RECURSE J_SRC "${OpenJKLibDir}/jpeg-8c/*.c" "${OpenJKLibDir}/jpeg-8c/*.h")
+		source_group("jpeg-8c" FILES ${J_SRC})
+		set(SPRDVanillaFiles ${SPRDVanillaFiles} ${J_SRC})
+	else()
+		find_package(JPEG REQUIRED)
+		set(SPRDVanillaRendererIncludeDirectories ${SPRDVanillaRendererIncludeDirectories} ${JPEG_INCLUDE_DIR})
+		set(SPRDVanillaRendererLibraries ${SPRDVanillaRendererLibraries} ${JPEG_LIBRARIES})
+	endif()
 
 	# GHOUL 2
 	set(SPRDVanillaG2Files

--- a/codemp/rd-common/tr_image_jpg.cpp
+++ b/codemp/rd-common/tr_image_jpg.cpp
@@ -7,8 +7,12 @@
  * (stdio.h is sufficient on ANSI-conforming systems.)
  * You may also wish to include "jerror.h".
  */
+#ifdef USE_INTERNAL_JPEG
 #define JPEG_INTERNALS
 #include "jpeg-8c/jpeglib.h"
+#else
+#include <jpeglib.h>
+#endif
 
 static void R_JPGErrorExit(j_common_ptr cinfo)
 {

--- a/codemp/rd-vanilla/CMakeLists.txt
+++ b/codemp/rd-vanilla/CMakeLists.txt
@@ -79,9 +79,15 @@ set(MPVanillaRendererCommonFiles
 source_group("common" FILES ${MPVanillaRendererCommonFiles})
 set(MPVanillaRendererFiles ${MPVanillaRendererFiles} ${MPVanillaRendererCommonFiles})
 
-file(GLOB_RECURSE MPVanillaRendererJpegFiles "${OpenJKLibDir}/jpeg-8c/*.c" "${OpenJKLibDir}/jpeg-8c/*.h")
-source_group("jpeg-8c" FILES ${MPVanillaRendererJpegFiles})
-set(MPVanillaRendererFiles ${MPVanillaRendererFiles} ${MPVanillaRendererJpegFiles})
+if(UseInternalJPEG)
+	file(GLOB_RECURSE MPVanillaRendererJpegFiles "${OpenJKLibDir}/jpeg-8c/*.c" "${OpenJKLibDir}/jpeg-8c/*.h")
+	source_group("jpeg-8c" FILES ${MPVanillaRendererJpegFiles})
+	set(MPVanillaRendererFiles ${MPVanillaRendererFiles} ${MPVanillaRendererJpegFiles})
+else()
+	find_package(JPEG REQUIRED)
+	set(MPVanillaRendererIncludeDirectories ${MPVanillaRendererIncludeDirectories} ${JPEG_INCLUDE_DIR})
+	set(MPVanillaRendererLibraries ${MPVanillaRendererLibraries} ${JPEG_LIBRARIES})
+endif()
 
 if(UseInternalPNG)
 	set(MPVanillaRendererLibPngFiles


### PR DESCRIPTION
The JPEG code in OpenJK is basically the same as in ioquake3, which requires either its own  bundled copy of IJG libjpeg 8c, an external copy of IJG libjpeg >= 8, or any vaguely recent version of jpeg-turbo with the jpeg8-compatible MEM_SRCDST_SUPPORTED feature enabled.

Distributions like Debian don't like to use embedded/bundled code copies: it makes it harder to fix security bugs. This branch allows the jpeg-8c directory to be unused, or deleted entirely, when the system libjpeg is suitable.

I've made it default to use the bundled libjpeg on Windows or Mac, or a system libjpeg on Linux, since libjpeg is ubiquitous, and most Linux distributions use libjpeg-turbo these days. If you don't like that default, changing it (e.g. to default to the bundled copy everywhere) would be fine.