### PR TITLE
Use system zlib headers if we're using system zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,12 @@ else()
 	option(UseInternalPNG "Whether to use the included libpng instead of a locally installed one" OFF)
 endif()
 
+if(WIN32 OR APPLE)
+	option(UseInternalJPEG "Whether to use the included libjpeg instead of a locally installed one" ON)
+else()
+	option(UseInternalJPEG "Whether to use the included libjpeg instead of a locally installed one" OFF)
+endif()
+
 if(APPLE)
 	option(MakeApplicationBundles "Whether to build .app application bundles for engines built" ON)
 else()
@@ -190,6 +196,10 @@ endif()
 # Settings
 if(BuildPortableVersion)
 	set(SharedDefines ${SharedDefines} "_PORTABLE_VERSION")
+endif()
+
+if(UseInternalJPEG)
+	set(SharedDefines ${SharedDefines} "USE_INTERNAL_JPEG")
 endif()
 
 set(OpenJKLibDir "${CMAKE_SOURCE_DIR}/lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,10 @@ if(UseInternalJPEG)
 	set(SharedDefines ${SharedDefines} "USE_INTERNAL_JPEG")
 endif()
 
+if(UseInternalZlib)
+	set(SharedDefines ${SharedDefines} "USE_INTERNAL_ZLIB")
+endif()
+
 set(OpenJKLibDir "${CMAKE_SOURCE_DIR}/lib")
 
 if(NOT MSVC)

--- a/code/qcommon/files.h
+++ b/code/qcommon/files.h
@@ -25,7 +25,11 @@ This file is part of Jedi Academy.
    Structures local to the files_* modules.
 */
 
+#ifdef USE_INTERNAL_ZLIB
 #include "zlib/zlib.h"
+#else
+#include <zlib.h>
+#endif
 #include "minizip/unzip.h"
 
 #define MAX_ZPATH			256

--- a/code/rd-common/tr_image_jpg.cpp
+++ b/code/rd-common/tr_image_jpg.cpp
@@ -11,8 +11,12 @@
  * (stdio.h is sufficient on ANSI-conforming systems.)
  * You may also wish to include "jerror.h".
  */
+#ifdef USE_INTERNAL_JPEG
 #define JPEG_INTERNALS
 #include "jpeg-8c/jpeglib.h"
+#else
+#include <jpeglib.h>
+#endif
 
 static void R_JPGErrorExit(j_common_ptr cinfo)
 {

--- a/code/rd-vanilla/CMakeLists.txt
+++ b/code/rd-vanilla/CMakeLists.txt
@@ -18,9 +18,15 @@ if(BuildSPRdVanilla OR BuildJK2SPRdVanilla)
 	# Files
 
 	# JPEG
-	file(GLOB_RECURSE J_SRC "${OpenJKLibDir}/jpeg-8c/*.c" "${OpenJKLibDir}/jpeg-8c/*.h")
-	source_group("jpeg-8c" FILES ${J_SRC})
-	set(SPRDVanillaFiles ${SPRDVanillaFiles} ${J_SRC})
+	if(UseInternalJPEG)
+		file(GLOB_RECURSE J_SRC "${OpenJKLibDir}/jpeg-8c/*.c" "${OpenJKLibDir}/jpeg-8c/*.h")
+		source_group("jpeg-8c" FILES ${J_SRC})
+		set(SPRDVanillaFiles ${SPRDVanillaFiles} ${J_SRC})
+	else()
+		find_package(JPEG REQUIRED)
+		set(SPRDVanillaRendererIncludeDirectories ${SPRDVanillaRendererIncludeDirectories} ${JPEG_INCLUDE_DIR})
+		set(SPRDVanillaRendererLibraries ${SPRDVanillaRendererLibraries} ${JPEG_LIBRARIES})
+	endif()
 
 	# GHOUL 2
 	set(SPRDVanillaG2Files

--- a/codemp/client/cl_parse.cpp
+++ b/codemp/client/cl_parse.cpp
@@ -3,7 +3,12 @@
 #include "client.h"
 #include "cl_cgameapi.h"
 #include "qcommon/stringed_ingame.h"
+
+#ifdef USE_INTERNAL_ZLIB
 #include "zlib/zlib.h"
+#else
+#include <zlib.h>
+#endif
 
 static char hiddenCvarVal[128];
 

--- a/codemp/rd-common/tr_image_jpg.cpp
+++ b/codemp/rd-common/tr_image_jpg.cpp
@@ -7,8 +7,12 @@
  * (stdio.h is sufficient on ANSI-conforming systems.)
  * You may also wish to include "jerror.h".
  */
+#ifdef USE_INTERNAL_JPEG
 #define JPEG_INTERNALS
 #include "jpeg-8c/jpeglib.h"
+#else
+#include <jpeglib.h>
+#endif
 
 static void R_JPGErrorExit(j_common_ptr cinfo)
 {

--- a/codemp/rd-vanilla/CMakeLists.txt
+++ b/codemp/rd-vanilla/CMakeLists.txt
@@ -79,9 +79,15 @@ set(MPVanillaRendererCommonFiles
 source_group("common" FILES ${MPVanillaRendererCommonFiles})
 set(MPVanillaRendererFiles ${MPVanillaRendererFiles} ${MPVanillaRendererCommonFiles})
 
-file(GLOB_RECURSE MPVanillaRendererJpegFiles "${OpenJKLibDir}/jpeg-8c/*.c" "${OpenJKLibDir}/jpeg-8c/*.h")
-source_group("jpeg-8c" FILES ${MPVanillaRendererJpegFiles})
-set(MPVanillaRendererFiles ${MPVanillaRendererFiles} ${MPVanillaRendererJpegFiles})
+if(UseInternalJPEG)
+	file(GLOB_RECURSE MPVanillaRendererJpegFiles "${OpenJKLibDir}/jpeg-8c/*.c" "${OpenJKLibDir}/jpeg-8c/*.h")
+	source_group("jpeg-8c" FILES ${MPVanillaRendererJpegFiles})
+	set(MPVanillaRendererFiles ${MPVanillaRendererFiles} ${MPVanillaRendererJpegFiles})
+else()
+	find_package(JPEG REQUIRED)
+	set(MPVanillaRendererIncludeDirectories ${MPVanillaRendererIncludeDirectories} ${JPEG_INCLUDE_DIR})
+	set(MPVanillaRendererLibraries ${MPVanillaRendererLibraries} ${JPEG_LIBRARIES})
+endif()
 
 if(UseInternalPNG)
 	set(MPVanillaRendererLibPngFiles

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -2,7 +2,13 @@
 
 #include "server.h"
 #include "qcommon/stringed_ingame.h"
+
+#ifdef USE_INTERNAL_ZLIB
 #include "zlib/zlib.h"
+#else
+#include <zlib.h>
+#endif
+
 #include "server/sv_gameapi.h"
 
 static void SV_CloseDownload( client_t *cl );

--- a/lib/minizip/ioapi.c
+++ b/lib/minizip/ioapi.c
@@ -10,7 +10,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef USE_INTERNAL_ZLIB
 #include "../zlib/zlib.h"
+#else
+#include <zlib.h>
+#endif
+
 #include "ioapi.h"
 
 

--- a/lib/minizip/unzip.h
+++ b/lib/minizip/unzip.h
@@ -48,7 +48,12 @@
 extern "C" {
 #endif
 
+#ifdef USE_INTERNAL_ZLIB
 #include "zlib/zlib.h"
+#else
+#include <zlib.h>
+#endif
+
 #include "ioapi.h"
 
 #define NOUNCRYPT


### PR DESCRIPTION
As I mentioned on #604, distributions like Debian don't like using embedded/bundled code copies, so I'm planning to link OpenJK in Debian contrib to the system zlib. It seems better to use headers that correspond exactly to the system zlib, rather than the header that is bundled in OpenJK.

(This also means I can delete the zlib directory entirely in the Debian package, to know for sure that I'm not using the bundled copy and reduce the number of things I have to do a copyright/license audit on...)