### PR TITLE
avoid NORETURN macro on function pointer

### DIFF
--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -452,7 +452,7 @@ void G_SayTo( gentity_t *ent, gentity_t *other, int mode, int color, const char 
 // g_main.c
 //
 void G_RunThink (gentity_t *ent);
-void QDECL NORETURN G_Error( const char *fmt, ... );
+void NORETURN QDECL G_Error( const char *fmt, ... );
 void SetInUse(gentity_t *ent);
 void ClearInUse(gentity_t *ent);
 qboolean PInUse(unsigned int entNum);

--- a/code/game/g_public.h
+++ b/code/game/g_public.h
@@ -146,7 +146,9 @@ typedef struct {
 	void	(*FlushCamFile)();
 
 	// abort the game
-	NORETURN void	(*Error)( int, const char *fmt, ... );
+	// (this is not NORETURN because MSVC's version of NORETURN is not
+	// supported for function pointers)
+	__attribute__((noreturn)) void	(*Error)( int, const char *fmt, ... );
 
 	// get current time for profiling reasons
 	// this should NOT be used for any game related tasks,


### PR DESCRIPTION
__attribute__((noreturn)), the gcc implementation of NORETURN, is fine
on function pointers, but __declspec(noreturn), the MSVC implementation,
is not.

---

See https://github.com/JACoders/OpenJK/commit/4a09de600ce0c1cdc0e03fc134e192077589957c for discussion