### PR TITLE
Shared: fixed terminal mode and signal handlers on unix

### DIFF
--- a/code/qcommon/common.cpp
+++ b/code/qcommon/common.cpp
@@ -1565,7 +1565,7 @@ Field_Clear
 ==================
 */
 void Field_Clear( field_t *edit ) {
-	edit->buffer[0] = 0;
+	memset(edit->buffer, 0, MAX_EDIT_LINE);
 	edit->cursor = 0;
 	edit->scroll = 0;
 }

--- a/codemp/qcommon/common.cpp
+++ b/codemp/qcommon/common.cpp
@@ -1634,7 +1634,7 @@ Field_Clear
 ==================
 */
 void Field_Clear( field_t *edit ) {
-	edit->buffer[0] = 0;
+	memset(edit->buffer, 0, MAX_EDIT_LINE);
 	edit->cursor = 0;
 	edit->scroll = 0;
 }

--- a/shared/sys/sys_main.cpp
+++ b/shared/sys/sys_main.cpp
@@ -657,8 +657,8 @@ int main ( int argc, char* argv[] )
 	int		i;
 	char	commandLine[ MAX_STRING_CHARS ] = { 0 };
 
-	CON_Init();
 	Sys_PlatformInit();
+	CON_Init();
 
 	// get the initial time base
 	Sys_Milliseconds();

--- a/shared/sys/sys_unix.cpp
+++ b/shared/sys/sys_unix.cpp
@@ -10,6 +10,7 @@
 #include <pwd.h>
 #include <libgen.h>
 #include <sched.h>
+#include <signal.h>
 
 #include "qcommon/qcommon.h"
 #include "qcommon/q_shared.h"
@@ -23,6 +24,18 @@ static char homePath[ MAX_OSPATH ] = { 0 };
 
 void Sys_PlatformInit( void )
 {
+	const char* term = getenv( "TERM" );
+
+	signal( SIGHUP, Sys_SigHandler );
+	signal( SIGQUIT, Sys_SigHandler );
+	signal( SIGTRAP, Sys_SigHandler );
+	signal( SIGIOT, Sys_SigHandler );
+	signal( SIGBUS, Sys_SigHandler );
+
+	if (isatty( STDIN_FILENO ) && !( term && ( !strcmp( term, "raw" ) || !strcmp( term, "dumb" ) ) ))
+		stdinIsATTY = qtrue;
+	else
+		stdinIsATTY = qfalse;
 }
 
 void Sys_PlatformExit( void )


### PR DESCRIPTION
without this atty mode is always disabled on unix and command history
doesn't work