### PR TITLE
Change Raven and Activision copyright to include older years

### DIFF
--- a/code/Ragl/graph_region.h
+++ b/code/Ragl/graph_region.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ragl/graph_triangulate.h
+++ b/code/Ragl/graph_triangulate.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ragl/graph_vs.h
+++ b/code/Ragl/graph_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ragl/kdtree_vs.h
+++ b/code/Ragl/kdtree_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ragl/ragl_common.h
+++ b/code/Ragl/ragl_common.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/array_vs.h
+++ b/code/Ratl/array_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/bits_vs.h
+++ b/code/Ratl/bits_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/grid_vs.h
+++ b/code/Ratl/grid_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/handle_pool_vs.h
+++ b/code/Ratl/handle_pool_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/hash_pool_vs.h
+++ b/code/Ratl/hash_pool_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/heap_vs.h
+++ b/code/Ratl/heap_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/list_vs.h
+++ b/code/Ratl/list_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/map_vs.h
+++ b/code/Ratl/map_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/pool_vs.h
+++ b/code/Ratl/pool_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/queue_vs.h
+++ b/code/Ratl/queue_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/ratl.cpp
+++ b/code/Ratl/ratl.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/ratl_common.h
+++ b/code/Ratl/ratl_common.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/scheduler_vs.h
+++ b/code/Ratl/scheduler_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/stack_vs.h
+++ b/code/Ratl/stack_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/string_vs.h
+++ b/code/Ratl/string_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ratl/vector_vs.h
+++ b/code/Ratl/vector_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ravl/CBounds.cpp
+++ b/code/Ravl/CBounds.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ravl/CBounds.h
+++ b/code/Ravl/CBounds.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ravl/CMatrix.h
+++ b/code/Ravl/CMatrix.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ravl/CVec.cpp
+++ b/code/Ravl/CVec.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Ravl/CVec.h
+++ b/code/Ravl/CVec.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Rufl/hfile.cpp
+++ b/code/Rufl/hfile.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Rufl/hfile.h
+++ b/code/Rufl/hfile.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Rufl/hstring.cpp
+++ b/code/Rufl/hstring.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/Rufl/hstring.h
+++ b/code/Rufl/hstring.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_ATSTMain.cpp
+++ b/code/cgame/FX_ATSTMain.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_Blaster.cpp
+++ b/code/cgame/FX_Blaster.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_Bowcaster.cpp
+++ b/code/cgame/FX_Bowcaster.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_BryarPistol.cpp
+++ b/code/cgame/FX_BryarPistol.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_Concussion.cpp
+++ b/code/cgame/FX_Concussion.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_DEMP2.cpp
+++ b/code/cgame/FX_DEMP2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_Disruptor.cpp
+++ b/code/cgame/FX_Disruptor.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_Emplaced.cpp
+++ b/code/cgame/FX_Emplaced.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_Flechette.cpp
+++ b/code/cgame/FX_Flechette.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_HeavyRepeater.cpp
+++ b/code/cgame/FX_HeavyRepeater.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_NoghriShot.cpp
+++ b/code/cgame/FX_NoghriShot.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_RocketLauncher.cpp
+++ b/code/cgame/FX_RocketLauncher.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FX_TuskenShot.cpp
+++ b/code/cgame/FX_TuskenShot.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FxPrimitives.cpp
+++ b/code/cgame/FxPrimitives.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FxPrimitives.h
+++ b/code/cgame/FxPrimitives.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FxScheduler.cpp
+++ b/code/cgame/FxScheduler.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FxScheduler.h
+++ b/code/cgame/FxScheduler.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FxSystem.cpp
+++ b/code/cgame/FxSystem.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FxSystem.h
+++ b/code/cgame/FxSystem.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FxTemplate.cpp
+++ b/code/cgame/FxTemplate.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FxUtil.cpp
+++ b/code/cgame/FxUtil.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/FxUtil.h
+++ b/code/cgame/FxUtil.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/animtable.h
+++ b/code/cgame/animtable.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_camera.cpp
+++ b/code/cgame/cg_camera.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_camera.h
+++ b/code/cgame/cg_camera.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_consolecmds.cpp
+++ b/code/cgame/cg_consolecmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_credits.cpp
+++ b/code/cgame/cg_credits.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_draw.cpp
+++ b/code/cgame/cg_draw.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_drawtools.cpp
+++ b/code/cgame/cg_drawtools.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_effects.cpp
+++ b/code/cgame/cg_effects.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_ents.cpp
+++ b/code/cgame/cg_ents.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_event.cpp
+++ b/code/cgame/cg_event.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_headers.cpp
+++ b/code/cgame/cg_headers.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_headers.h
+++ b/code/cgame/cg_headers.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_info.cpp
+++ b/code/cgame/cg_info.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_lights.cpp
+++ b/code/cgame/cg_lights.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_localents.cpp
+++ b/code/cgame/cg_localents.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_marks.cpp
+++ b/code/cgame/cg_marks.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_media.h
+++ b/code/cgame/cg_media.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_players.cpp
+++ b/code/cgame/cg_players.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_playerstate.cpp
+++ b/code/cgame/cg_playerstate.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_predict.cpp
+++ b/code/cgame/cg_predict.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_public.h
+++ b/code/cgame/cg_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_scoreboard.cpp
+++ b/code/cgame/cg_scoreboard.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_servercmds.cpp
+++ b/code/cgame/cg_servercmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_snapshot.cpp
+++ b/code/cgame/cg_snapshot.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_syscalls.cpp
+++ b/code/cgame/cg_syscalls.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_text.cpp
+++ b/code/cgame/cg_text.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_view.cpp
+++ b/code/cgame/cg_view.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/cg_weapons.cpp
+++ b/code/cgame/cg_weapons.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/common_headers.h
+++ b/code/cgame/common_headers.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/cgame/strip_objectives.h
+++ b/code/cgame/strip_objectives.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/cl_cgame.cpp
+++ b/code/client/cl_cgame.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/cl_cin.cpp
+++ b/code/client/cl_cin.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/client/cl_console.cpp
+++ b/code/client/cl_console.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/client/cl_input.cpp
+++ b/code/client/cl_input.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/client/cl_mp3.cpp
+++ b/code/client/cl_mp3.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/cl_mp3.h
+++ b/code/client/cl_mp3.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/cl_parse.cpp
+++ b/code/client/cl_parse.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/cl_scrn.cpp
+++ b/code/client/cl_scrn.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/client/cl_ui.cpp
+++ b/code/client/cl_ui.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/client_ui.h
+++ b/code/client/client_ui.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/keycodes.h
+++ b/code/client/keycodes.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/keys.h
+++ b/code/client/keys.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/snd_ambient.cpp
+++ b/code/client/snd_ambient.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/snd_ambient.h
+++ b/code/client/snd_ambient.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/snd_dma.cpp
+++ b/code/client/snd_dma.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/snd_local.h
+++ b/code/client/snd_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/snd_mem.cpp
+++ b/code/client/snd_mem.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/snd_mix.cpp
+++ b/code/client/snd_mix.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/snd_music.cpp
+++ b/code/client/snd_music.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/snd_music.h
+++ b/code/client/snd_music.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/snd_public.h
+++ b/code/client/snd_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/vmachine.cpp
+++ b/code/client/vmachine.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/client/vmachine.h
+++ b/code/client/vmachine.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Animal.cpp
+++ b/code/game/AI_Animal.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_AssassinDroid.cpp
+++ b/code/game/AI_AssassinDroid.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Atst.cpp
+++ b/code/game/AI_Atst.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_BobaFett.cpp
+++ b/code/game/AI_BobaFett.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Civilian.cpp
+++ b/code/game/AI_Civilian.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Default.cpp
+++ b/code/game/AI_Default.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Droid.cpp
+++ b/code/game/AI_Droid.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_GalakMech.cpp
+++ b/code/game/AI_GalakMech.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Grenadier.cpp
+++ b/code/game/AI_Grenadier.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_HazardTrooper.cpp
+++ b/code/game/AI_HazardTrooper.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Howler.cpp
+++ b/code/game/AI_Howler.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_ImperialProbe.cpp
+++ b/code/game/AI_ImperialProbe.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Interrogator.cpp
+++ b/code/game/AI_Interrogator.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Jedi.cpp
+++ b/code/game/AI_Jedi.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Mark1.cpp
+++ b/code/game/AI_Mark1.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Mark2.cpp
+++ b/code/game/AI_Mark2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_MineMonster.cpp
+++ b/code/game/AI_MineMonster.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Rancor.cpp
+++ b/code/game/AI_Rancor.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Remote.cpp
+++ b/code/game/AI_Remote.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_RocketTrooper.cpp
+++ b/code/game/AI_RocketTrooper.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_SaberDroid.cpp
+++ b/code/game/AI_SaberDroid.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_SandCreature.cpp
+++ b/code/game/AI_SandCreature.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Seeker.cpp
+++ b/code/game/AI_Seeker.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Sentry.cpp
+++ b/code/game/AI_Sentry.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Sniper.cpp
+++ b/code/game/AI_Sniper.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Stormtrooper.cpp
+++ b/code/game/AI_Stormtrooper.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Tusken.cpp
+++ b/code/game/AI_Tusken.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Utils.cpp
+++ b/code/game/AI_Utils.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AI_Wampa.cpp
+++ b/code/game/AI_Wampa.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/AnimalNPC.cpp
+++ b/code/game/AnimalNPC.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/FighterNPC.cpp
+++ b/code/game/FighterNPC.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/G_Timer.cpp
+++ b/code/game/G_Timer.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC.cpp
+++ b/code/game/NPC.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_behavior.cpp
+++ b/code/game/NPC_behavior.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_combat.cpp
+++ b/code/game/NPC_combat.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_goal.cpp
+++ b/code/game/NPC_goal.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_misc.cpp
+++ b/code/game/NPC_misc.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_move.cpp
+++ b/code/game/NPC_move.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_reactions.cpp
+++ b/code/game/NPC_reactions.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_senses.cpp
+++ b/code/game/NPC_senses.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_sounds.cpp
+++ b/code/game/NPC_sounds.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_spawn.cpp
+++ b/code/game/NPC_spawn.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_stats.cpp
+++ b/code/game/NPC_stats.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/NPC_utils.cpp
+++ b/code/game/NPC_utils.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/Q3_Interface.cpp
+++ b/code/game/Q3_Interface.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/Q3_Interface.h
+++ b/code/game/Q3_Interface.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/SpeederNPC.cpp
+++ b/code/game/SpeederNPC.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/WalkerNPC.cpp
+++ b/code/game/WalkerNPC.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/ai.h
+++ b/code/game/ai.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/anims.h
+++ b/code/game/anims.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/b_local.h
+++ b/code/game/b_local.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/b_public.h
+++ b/code/game/b_public.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bg_local.h
+++ b/code/game/bg_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bg_misc.cpp
+++ b/code/game/bg_misc.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bg_pangles.cpp
+++ b/code/game/bg_pangles.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bg_panimate.cpp
+++ b/code/game/bg_panimate.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bg_pmove.cpp
+++ b/code/game/bg_pmove.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bg_slidemove.cpp
+++ b/code/game/bg_slidemove.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bg_vehicleLoad.cpp
+++ b/code/game/bg_vehicleLoad.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bset.h
+++ b/code/game/bset.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/bstate.h
+++ b/code/game/bstate.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/channels.h
+++ b/code/game/channels.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/common_headers.h
+++ b/code/game/common_headers.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/dmstates.h
+++ b/code/game/dmstates.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/events.h
+++ b/code/game/events.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/fields.h
+++ b/code/game/fields.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_active.cpp
+++ b/code/game/g_active.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_breakable.cpp
+++ b/code/game/g_breakable.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_camera.cpp
+++ b/code/game/g_camera.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_client.cpp
+++ b/code/game/g_client.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_cmds.cpp
+++ b/code/game/g_cmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_combat.cpp
+++ b/code/game/g_combat.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_emplaced.cpp
+++ b/code/game/g_emplaced.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_functions.cpp
+++ b/code/game/g_functions.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_functions.h
+++ b/code/game/g_functions.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_fx.cpp
+++ b/code/game/g_fx.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_inventory.cpp
+++ b/code/game/g_inventory.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_itemLoad.cpp
+++ b/code/game/g_itemLoad.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_items.cpp
+++ b/code/game/g_items.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_items.h
+++ b/code/game/g_items.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_main.cpp
+++ b/code/game/g_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_mem.cpp
+++ b/code/game/g_mem.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_misc.cpp
+++ b/code/game/g_misc.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_misc_model.cpp
+++ b/code/game/g_misc_model.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_missile.cpp
+++ b/code/game/g_missile.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_mover.cpp
+++ b/code/game/g_mover.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_nav.cpp
+++ b/code/game/g_nav.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_nav.h
+++ b/code/game/g_nav.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_navigator.cpp
+++ b/code/game/g_navigator.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_navigator.h
+++ b/code/game/g_navigator.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_navnew.cpp
+++ b/code/game/g_navnew.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_object.cpp
+++ b/code/game/g_object.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_objectives.cpp
+++ b/code/game/g_objectives.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_public.h
+++ b/code/game/g_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_rail.cpp
+++ b/code/game/g_rail.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_ref.cpp
+++ b/code/game/g_ref.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_roff.cpp
+++ b/code/game/g_roff.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_roff.h
+++ b/code/game/g_roff.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_savegame.cpp
+++ b/code/game/g_savegame.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_session.cpp
+++ b/code/game/g_session.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_shared.h
+++ b/code/game/g_shared.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_spawn.cpp
+++ b/code/game/g_spawn.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_svcmds.cpp
+++ b/code/game/g_svcmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_target.cpp
+++ b/code/game/g_target.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_trigger.cpp
+++ b/code/game/g_trigger.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_turret.cpp
+++ b/code/game/g_turret.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_usable.cpp
+++ b/code/game/g_usable.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_utils.cpp
+++ b/code/game/g_utils.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_vehicles.cpp
+++ b/code/game/g_vehicles.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_vehicles.h
+++ b/code/game/g_vehicles.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_weapon.cpp
+++ b/code/game/g_weapon.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/g_weaponLoad.cpp
+++ b/code/game/g_weaponLoad.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/genericparser2.cpp
+++ b/code/game/genericparser2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/genericparser2.h
+++ b/code/game/genericparser2.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/ghoul2_shared.h
+++ b/code/game/ghoul2_shared.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/hitlocs.h
+++ b/code/game/hitlocs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/npc_headers.h
+++ b/code/game/npc_headers.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/objectives.h
+++ b/code/game/objectives.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/say.h
+++ b/code/game/say.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/statindex.h
+++ b/code/game/statindex.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/surfaceflags.h
+++ b/code/game/surfaceflags.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/teams.h
+++ b/code/game/teams.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/weapons.h
+++ b/code/game/weapons.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_atst.cpp
+++ b/code/game/wp_atst.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_blaster_pistol.cpp
+++ b/code/game/wp_blaster_pistol.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_blaster_rifle.cpp
+++ b/code/game/wp_blaster_rifle.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_bot_laser.cpp
+++ b/code/game/wp_bot_laser.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_bowcaster.cpp
+++ b/code/game/wp_bowcaster.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_concussion.cpp
+++ b/code/game/wp_concussion.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_demp2.cpp
+++ b/code/game/wp_demp2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_det_pack.cpp
+++ b/code/game/wp_det_pack.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_disruptor.cpp
+++ b/code/game/wp_disruptor.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_emplaced_gun.cpp
+++ b/code/game/wp_emplaced_gun.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_flechette.cpp
+++ b/code/game/wp_flechette.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_melee.cpp
+++ b/code/game/wp_melee.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_noghri_stick.cpp
+++ b/code/game/wp_noghri_stick.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_repeater.cpp
+++ b/code/game/wp_repeater.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_rocket_launcher.cpp
+++ b/code/game/wp_rocket_launcher.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_saber.cpp
+++ b/code/game/wp_saber.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_saber.h
+++ b/code/game/wp_saber.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_saberLoad.cpp
+++ b/code/game/wp_saberLoad.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_stun_baton.cpp
+++ b/code/game/wp_stun_baton.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_thermal.cpp
+++ b/code/game/wp_thermal.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_trip_mine.cpp
+++ b/code/game/wp_trip_mine.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/game/wp_tusken.cpp
+++ b/code/game/wp_tusken.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ghoul2/G2.h
+++ b/code/ghoul2/G2.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ghoul2/ghoul2_gore.h
+++ b/code/ghoul2/ghoul2_gore.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/BlockStream.cpp
+++ b/code/icarus/BlockStream.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/IcarusImplementation.cpp
+++ b/code/icarus/IcarusImplementation.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/IcarusImplementation.h
+++ b/code/icarus/IcarusImplementation.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/IcarusInterface.h
+++ b/code/icarus/IcarusInterface.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/Sequence.cpp
+++ b/code/icarus/Sequence.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/Sequencer.cpp
+++ b/code/icarus/Sequencer.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/StdAfx.h
+++ b/code/icarus/StdAfx.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/TaskManager.cpp
+++ b/code/icarus/TaskManager.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/blockstream.h
+++ b/code/icarus/blockstream.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/sequence.h
+++ b/code/icarus/sequence.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/sequencer.h
+++ b/code/icarus/sequencer.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/icarus/taskmanager.h
+++ b/code/icarus/taskmanager.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/MiniHeap.h
+++ b/code/qcommon/MiniHeap.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cm_load.cpp
+++ b/code/qcommon/cm_load.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cm_local.h
+++ b/code/qcommon/cm_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cm_patch.cpp
+++ b/code/qcommon/cm_patch.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cm_patch.h
+++ b/code/qcommon/cm_patch.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cm_polylib.cpp
+++ b/code/qcommon/cm_polylib.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cm_polylib.h
+++ b/code/qcommon/cm_polylib.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cm_public.h
+++ b/code/qcommon/cm_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cm_test.cpp
+++ b/code/qcommon/cm_test.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cm_trace.cpp
+++ b/code/qcommon/cm_trace.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/cmd.cpp
+++ b/code/qcommon/cmd.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/qcommon/common.cpp
+++ b/code/qcommon/common.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/qcommon/cvar.cpp
+++ b/code/qcommon/cvar.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/qcommon/files.cpp
+++ b/code/qcommon/files.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/qcommon/matcomp.cpp
+++ b/code/qcommon/matcomp.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/msg.cpp
+++ b/code/qcommon/msg.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/net_chan.cpp
+++ b/code/qcommon/net_chan.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/q_math.cpp
+++ b/code/qcommon/q_math.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/qcommon/q_shared.cpp
+++ b/code/qcommon/q_shared.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/qcommon/qfiles.h
+++ b/code/qcommon/qfiles.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/sstring.h
+++ b/code/qcommon/sstring.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/stringed_ingame.cpp
+++ b/code/qcommon/stringed_ingame.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/stringed_ingame.h
+++ b/code/qcommon/stringed_ingame.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/stringed_interface.cpp
+++ b/code/qcommon/stringed_interface.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/stringed_interface.h
+++ b/code/qcommon/stringed_interface.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/strip.cpp
+++ b/code/qcommon/strip.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/stv_version.h
+++ b/code/qcommon/stv_version.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/tags.h
+++ b/code/qcommon/tags.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/timing.h
+++ b/code/qcommon/timing.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/qcommon/z_memman_pc.cpp
+++ b/code/qcommon/z_memman_pc.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-common/mdx_format.h
+++ b/code/rd-common/mdx_format.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-common/tr_common.h
+++ b/code/rd-common/tr_common.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-common/tr_font.cpp
+++ b/code/rd-common/tr_font.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-common/tr_font.h
+++ b/code/rd-common/tr_font.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-common/tr_image_jpg.cpp
+++ b/code/rd-common/tr_image_jpg.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-common/tr_image_load.cpp
+++ b/code/rd-common/tr_image_load.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-common/tr_image_png.cpp
+++ b/code/rd-common/tr_image_png.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-common/tr_image_tga.cpp
+++ b/code/rd-common/tr_image_tga.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-common/tr_noise.cpp
+++ b/code/rd-common/tr_noise.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-common/tr_public.h
+++ b/code/rd-common/tr_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-common/tr_types.h
+++ b/code/rd-common/tr_types.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/G2_API.cpp
+++ b/code/rd-vanilla/G2_API.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/G2_bolts.cpp
+++ b/code/rd-vanilla/G2_bolts.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/G2_bones.cpp
+++ b/code/rd-vanilla/G2_bones.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/G2_misc.cpp
+++ b/code/rd-vanilla/G2_misc.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/G2_surfaces.cpp
+++ b/code/rd-vanilla/G2_surfaces.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/qgl.h
+++ b/code/rd-vanilla/qgl.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_WorldEffects.cpp
+++ b/code/rd-vanilla/tr_WorldEffects.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_WorldEffects.h
+++ b/code/rd-vanilla/tr_WorldEffects.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_arb.cpp
+++ b/code/rd-vanilla/tr_arb.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_backend.cpp
+++ b/code/rd-vanilla/tr_backend.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_bsp.cpp
+++ b/code/rd-vanilla/tr_bsp.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_cmds.cpp
+++ b/code/rd-vanilla/tr_cmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_curve.cpp
+++ b/code/rd-vanilla/tr_curve.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_draw.cpp
+++ b/code/rd-vanilla/tr_draw.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_ghoul2.cpp
+++ b/code/rd-vanilla/tr_ghoul2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_image.cpp
+++ b/code/rd-vanilla/tr_image.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_init.cpp
+++ b/code/rd-vanilla/tr_init.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_light.cpp
+++ b/code/rd-vanilla/tr_light.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_local.h
+++ b/code/rd-vanilla/tr_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_main.cpp
+++ b/code/rd-vanilla/tr_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_marks.cpp
+++ b/code/rd-vanilla/tr_marks.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_mesh.cpp
+++ b/code/rd-vanilla/tr_mesh.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_model.cpp
+++ b/code/rd-vanilla/tr_model.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_quicksprite.cpp
+++ b/code/rd-vanilla/tr_quicksprite.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_quicksprite.h
+++ b/code/rd-vanilla/tr_quicksprite.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_scene.cpp
+++ b/code/rd-vanilla/tr_scene.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_shade.cpp
+++ b/code/rd-vanilla/tr_shade.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_shade_calc.cpp
+++ b/code/rd-vanilla/tr_shade_calc.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_shader.cpp
+++ b/code/rd-vanilla/tr_shader.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_shadows.cpp
+++ b/code/rd-vanilla/tr_shadows.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_skin.cpp
+++ b/code/rd-vanilla/tr_skin.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_sky.cpp
+++ b/code/rd-vanilla/tr_sky.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_stl.cpp
+++ b/code/rd-vanilla/tr_stl.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_stl.h
+++ b/code/rd-vanilla/tr_stl.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_subs.cpp
+++ b/code/rd-vanilla/tr_subs.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/code/rd-vanilla/tr_surface.cpp
+++ b/code/rd-vanilla/tr_surface.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_surfacesprites.cpp
+++ b/code/rd-vanilla/tr_surfacesprites.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/rd-vanilla/tr_world.cpp
+++ b/code/rd-vanilla/tr_world.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/exe_headers.cpp
+++ b/code/server/exe_headers.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/exe_headers.h
+++ b/code/server/exe_headers.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/server.h
+++ b/code/server/server.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/sv_ccmds.cpp
+++ b/code/server/sv_ccmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/sv_client.cpp
+++ b/code/server/sv_client.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/sv_game.cpp
+++ b/code/server/sv_game.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/sv_init.cpp
+++ b/code/server/sv_init.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/sv_main.cpp
+++ b/code/server/sv_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/sv_savegame.cpp
+++ b/code/server/sv_savegame.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/sv_snapshot.cpp
+++ b/code/server/sv_snapshot.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/server/sv_world.cpp
+++ b/code/server/sv_world.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/gameinfo.cpp
+++ b/code/ui/gameinfo.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/gameinfo.h
+++ b/code/ui/gameinfo.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/menudef.h
+++ b/code/ui/menudef.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/ui_atoms.cpp
+++ b/code/ui/ui_atoms.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/ui_connect.cpp
+++ b/code/ui/ui_connect.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/ui_public.h
+++ b/code/ui/ui_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/ui_saber.cpp
+++ b/code/ui/ui_saber.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/ui_shared.cpp
+++ b/code/ui/ui_shared.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/ui_shared.h
+++ b/code/ui/ui_shared.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/code/ui/ui_syscalls.cpp
+++ b/code/ui/ui_syscalls.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_ATSTMain.cpp
+++ b/codeJK2/cgame/FX_ATSTMain.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_Blaster.cpp
+++ b/codeJK2/cgame/FX_Blaster.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_Bowcaster.cpp
+++ b/codeJK2/cgame/FX_Bowcaster.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_BryarPistol.cpp
+++ b/codeJK2/cgame/FX_BryarPistol.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_DEMP2.cpp
+++ b/codeJK2/cgame/FX_DEMP2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_Disruptor.cpp
+++ b/codeJK2/cgame/FX_Disruptor.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_Emplaced.cpp
+++ b/codeJK2/cgame/FX_Emplaced.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_Flechette.cpp
+++ b/codeJK2/cgame/FX_Flechette.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_HeavyRepeater.cpp
+++ b/codeJK2/cgame/FX_HeavyRepeater.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FX_RocketLauncher.cpp
+++ b/codeJK2/cgame/FX_RocketLauncher.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FxPrimitives.cpp
+++ b/codeJK2/cgame/FxPrimitives.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FxPrimitives.h
+++ b/codeJK2/cgame/FxPrimitives.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FxScheduler.cpp
+++ b/codeJK2/cgame/FxScheduler.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FxScheduler.h
+++ b/codeJK2/cgame/FxScheduler.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FxSystem.cpp
+++ b/codeJK2/cgame/FxSystem.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FxSystem.h
+++ b/codeJK2/cgame/FxSystem.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FxTemplate.cpp
+++ b/codeJK2/cgame/FxTemplate.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FxUtil.cpp
+++ b/codeJK2/cgame/FxUtil.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/FxUtil.h
+++ b/codeJK2/cgame/FxUtil.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/animtable.h
+++ b/codeJK2/cgame/animtable.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_camera.cpp
+++ b/codeJK2/cgame/cg_camera.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_camera.h
+++ b/codeJK2/cgame/cg_camera.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_consolecmds.cpp
+++ b/codeJK2/cgame/cg_consolecmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_credits.cpp
+++ b/codeJK2/cgame/cg_credits.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_draw.cpp
+++ b/codeJK2/cgame/cg_draw.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_drawtools.cpp
+++ b/codeJK2/cgame/cg_drawtools.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_effects.cpp
+++ b/codeJK2/cgame/cg_effects.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_ents.cpp
+++ b/codeJK2/cgame/cg_ents.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_event.cpp
+++ b/codeJK2/cgame/cg_event.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_info.cpp
+++ b/codeJK2/cgame/cg_info.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_lights.cpp
+++ b/codeJK2/cgame/cg_lights.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_local.h
+++ b/codeJK2/cgame/cg_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_localents.cpp
+++ b/codeJK2/cgame/cg_localents.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_main.cpp
+++ b/codeJK2/cgame/cg_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_marks.cpp
+++ b/codeJK2/cgame/cg_marks.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_media.h
+++ b/codeJK2/cgame/cg_media.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_players.cpp
+++ b/codeJK2/cgame/cg_players.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_playerstate.cpp
+++ b/codeJK2/cgame/cg_playerstate.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_predict.cpp
+++ b/codeJK2/cgame/cg_predict.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_public.h
+++ b/codeJK2/cgame/cg_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_scoreboard.cpp
+++ b/codeJK2/cgame/cg_scoreboard.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_servercmds.cpp
+++ b/codeJK2/cgame/cg_servercmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_snapshot.cpp
+++ b/codeJK2/cgame/cg_snapshot.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_syscalls.cpp
+++ b/codeJK2/cgame/cg_syscalls.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_text.cpp
+++ b/codeJK2/cgame/cg_text.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_view.cpp
+++ b/codeJK2/cgame/cg_view.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/cg_weapons.cpp
+++ b/codeJK2/cgame/cg_weapons.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/cgame/strip_objectives.h
+++ b/codeJK2/cgame/strip_objectives.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Atst.cpp
+++ b/codeJK2/game/AI_Atst.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Default.cpp
+++ b/codeJK2/game/AI_Default.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Droid.cpp
+++ b/codeJK2/game/AI_Droid.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_GalakMech.cpp
+++ b/codeJK2/game/AI_GalakMech.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Grenadier.cpp
+++ b/codeJK2/game/AI_Grenadier.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Howler.cpp
+++ b/codeJK2/game/AI_Howler.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_ImperialProbe.cpp
+++ b/codeJK2/game/AI_ImperialProbe.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Interrogator.cpp
+++ b/codeJK2/game/AI_Interrogator.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Jedi.cpp
+++ b/codeJK2/game/AI_Jedi.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Mark1.cpp
+++ b/codeJK2/game/AI_Mark1.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Mark2.cpp
+++ b/codeJK2/game/AI_Mark2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_MineMonster.cpp
+++ b/codeJK2/game/AI_MineMonster.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Remote.cpp
+++ b/codeJK2/game/AI_Remote.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Seeker.cpp
+++ b/codeJK2/game/AI_Seeker.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Sentry.cpp
+++ b/codeJK2/game/AI_Sentry.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Sniper.cpp
+++ b/codeJK2/game/AI_Sniper.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Stormtrooper.cpp
+++ b/codeJK2/game/AI_Stormtrooper.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/AI_Utils.cpp
+++ b/codeJK2/game/AI_Utils.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/G_Timer.cpp
+++ b/codeJK2/game/G_Timer.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/ai.h
+++ b/codeJK2/game/ai.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/anims.h
+++ b/codeJK2/game/anims.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/b_local.h
+++ b/codeJK2/game/b_local.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/b_public.h
+++ b/codeJK2/game/b_public.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/bg_local.h
+++ b/codeJK2/game/bg_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/bg_misc.cpp
+++ b/codeJK2/game/bg_misc.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/bg_pangles.cpp
+++ b/codeJK2/game/bg_pangles.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/bg_panimate.cpp
+++ b/codeJK2/game/bg_panimate.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/bg_pmove.cpp
+++ b/codeJK2/game/bg_pmove.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/bg_public.h
+++ b/codeJK2/game/bg_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/bg_slidemove.cpp
+++ b/codeJK2/game/bg_slidemove.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/bset.h
+++ b/codeJK2/game/bset.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/bstate.h
+++ b/codeJK2/game/bstate.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/channels.h
+++ b/codeJK2/game/channels.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/characters.h
+++ b/codeJK2/game/characters.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/dmstates.h
+++ b/codeJK2/game/dmstates.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/events.h
+++ b/codeJK2/game/events.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/fields.h
+++ b/codeJK2/game/fields.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_ICARUS.cpp
+++ b/codeJK2/game/g_ICARUS.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_active.cpp
+++ b/codeJK2/game/g_active.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_breakable.cpp
+++ b/codeJK2/game/g_breakable.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_camera.cpp
+++ b/codeJK2/game/g_camera.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_client.cpp
+++ b/codeJK2/game/g_client.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_cmds.cpp
+++ b/codeJK2/game/g_cmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_combat.cpp
+++ b/codeJK2/game/g_combat.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_functions.cpp
+++ b/codeJK2/game/g_functions.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_functions.h
+++ b/codeJK2/game/g_functions.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_fx.cpp
+++ b/codeJK2/game/g_fx.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_headers.h
+++ b/codeJK2/game/g_headers.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_icarus.h
+++ b/codeJK2/game/g_icarus.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_inventory.cpp
+++ b/codeJK2/game/g_inventory.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_itemLoad.cpp
+++ b/codeJK2/game/g_itemLoad.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_items.cpp
+++ b/codeJK2/game/g_items.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_items.h
+++ b/codeJK2/game/g_items.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_local.h
+++ b/codeJK2/game/g_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_main.cpp
+++ b/codeJK2/game/g_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_mem.cpp
+++ b/codeJK2/game/g_mem.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_misc.cpp
+++ b/codeJK2/game/g_misc.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_misc_model.cpp
+++ b/codeJK2/game/g_misc_model.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_missile.cpp
+++ b/codeJK2/game/g_missile.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_mover.cpp
+++ b/codeJK2/game/g_mover.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_nav.cpp
+++ b/codeJK2/game/g_nav.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_navigator.cpp
+++ b/codeJK2/game/g_navigator.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_navigator.h
+++ b/codeJK2/game/g_navigator.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_navnew.cpp
+++ b/codeJK2/game/g_navnew.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_object.cpp
+++ b/codeJK2/game/g_object.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_objectives.cpp
+++ b/codeJK2/game/g_objectives.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_public.h
+++ b/codeJK2/game/g_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_ref.cpp
+++ b/codeJK2/game/g_ref.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_roff.cpp
+++ b/codeJK2/game/g_roff.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_roff.h
+++ b/codeJK2/game/g_roff.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_savegame.cpp
+++ b/codeJK2/game/g_savegame.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_session.cpp
+++ b/codeJK2/game/g_session.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_shared.h
+++ b/codeJK2/game/g_shared.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_spawn.cpp
+++ b/codeJK2/game/g_spawn.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_svcmds.cpp
+++ b/codeJK2/game/g_svcmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_target.cpp
+++ b/codeJK2/game/g_target.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_trigger.cpp
+++ b/codeJK2/game/g_trigger.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_turret.cpp
+++ b/codeJK2/game/g_turret.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_usable.cpp
+++ b/codeJK2/game/g_usable.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_utils.cpp
+++ b/codeJK2/game/g_utils.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_weapon.cpp
+++ b/codeJK2/game/g_weapon.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/game/g_weaponLoad.cpp
+++ b/codeJK2/game/g_weaponLoad.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/BlockStream.cpp
+++ b/codeJK2/icarus/BlockStream.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/Instance.cpp
+++ b/codeJK2/icarus/Instance.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/Sequence.cpp
+++ b/codeJK2/icarus/Sequence.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/Sequencer.cpp
+++ b/codeJK2/icarus/Sequencer.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/TaskManager.cpp
+++ b/codeJK2/icarus/TaskManager.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/blockstream.h
+++ b/codeJK2/icarus/blockstream.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/instance.h
+++ b/codeJK2/icarus/instance.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/sequence.h
+++ b/codeJK2/icarus/sequence.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/sequencer.h
+++ b/codeJK2/icarus/sequencer.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codeJK2/icarus/taskmanager.h
+++ b/codeJK2/icarus/taskmanager.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/Ratl/bits_vs.h
+++ b/codemp/Ratl/bits_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/Ratl/ratl_common.h
+++ b/codemp/Ratl/ratl_common.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/Ratl/vector_vs.h
+++ b/codemp/Ratl/vector_vs.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/Ravl/CVec.h
+++ b/codemp/Ravl/CVec.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/aasfile.h
+++ b/codemp/botlib/aasfile.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas.h
+++ b/codemp/botlib/be_aas.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_bsp.h
+++ b/codemp/botlib/be_aas_bsp.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_bspq3.cpp
+++ b/codemp/botlib/be_aas_bspq3.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_cluster.cpp
+++ b/codemp/botlib/be_aas_cluster.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_cluster.h
+++ b/codemp/botlib/be_aas_cluster.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_debug.cpp
+++ b/codemp/botlib/be_aas_debug.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_debug.h
+++ b/codemp/botlib/be_aas_debug.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_def.h
+++ b/codemp/botlib/be_aas_def.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_entity.cpp
+++ b/codemp/botlib/be_aas_entity.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_entity.h
+++ b/codemp/botlib/be_aas_entity.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_file.cpp
+++ b/codemp/botlib/be_aas_file.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_file.h
+++ b/codemp/botlib/be_aas_file.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_funcs.h
+++ b/codemp/botlib/be_aas_funcs.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_main.cpp
+++ b/codemp/botlib/be_aas_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_main.h
+++ b/codemp/botlib/be_aas_main.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_move.cpp
+++ b/codemp/botlib/be_aas_move.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_move.h
+++ b/codemp/botlib/be_aas_move.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_optimize.cpp
+++ b/codemp/botlib/be_aas_optimize.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_optimize.h
+++ b/codemp/botlib/be_aas_optimize.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_reach.cpp
+++ b/codemp/botlib/be_aas_reach.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_reach.h
+++ b/codemp/botlib/be_aas_reach.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_route.cpp
+++ b/codemp/botlib/be_aas_route.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_route.h
+++ b/codemp/botlib/be_aas_route.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_routealt.cpp
+++ b/codemp/botlib/be_aas_routealt.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_routealt.h
+++ b/codemp/botlib/be_aas_routealt.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_sample.cpp
+++ b/codemp/botlib/be_aas_sample.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_aas_sample.h
+++ b/codemp/botlib/be_aas_sample.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_char.cpp
+++ b/codemp/botlib/be_ai_char.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_char.h
+++ b/codemp/botlib/be_ai_char.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_chat.cpp
+++ b/codemp/botlib/be_ai_chat.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_chat.h
+++ b/codemp/botlib/be_ai_chat.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_gen.cpp
+++ b/codemp/botlib/be_ai_gen.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_gen.h
+++ b/codemp/botlib/be_ai_gen.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_goal.cpp
+++ b/codemp/botlib/be_ai_goal.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_goal.h
+++ b/codemp/botlib/be_ai_goal.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_move.cpp
+++ b/codemp/botlib/be_ai_move.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_move.h
+++ b/codemp/botlib/be_ai_move.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_weap.cpp
+++ b/codemp/botlib/be_ai_weap.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_weap.h
+++ b/codemp/botlib/be_ai_weap.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_weight.cpp
+++ b/codemp/botlib/be_ai_weight.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ai_weight.h
+++ b/codemp/botlib/be_ai_weight.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ea.cpp
+++ b/codemp/botlib/be_ea.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_ea.h
+++ b/codemp/botlib/be_ea.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_interface.cpp
+++ b/codemp/botlib/be_interface.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/be_interface.h
+++ b/codemp/botlib/be_interface.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/botlib.h
+++ b/codemp/botlib/botlib.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_crc.cpp
+++ b/codemp/botlib/l_crc.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_crc.h
+++ b/codemp/botlib/l_crc.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_libvar.cpp
+++ b/codemp/botlib/l_libvar.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_libvar.h
+++ b/codemp/botlib/l_libvar.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_log.cpp
+++ b/codemp/botlib/l_log.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_log.h
+++ b/codemp/botlib/l_log.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_memory.cpp
+++ b/codemp/botlib/l_memory.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_memory.h
+++ b/codemp/botlib/l_memory.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_precomp.cpp
+++ b/codemp/botlib/l_precomp.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_precomp.h
+++ b/codemp/botlib/l_precomp.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_script.cpp
+++ b/codemp/botlib/l_script.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_script.h
+++ b/codemp/botlib/l_script.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_struct.cpp
+++ b/codemp/botlib/l_struct.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_struct.h
+++ b/codemp/botlib/l_struct.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/botlib/l_utils.h
+++ b/codemp/botlib/l_utils.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/animtable.h
+++ b/codemp/cgame/animtable.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_consolecmds.c
+++ b/codemp/cgame/cg_consolecmds.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/cgame/cg_cvar.c
+++ b/codemp/cgame/cg_cvar.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_drawtools.c
+++ b/codemp/cgame/cg_drawtools.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_effects.c
+++ b/codemp/cgame/cg_effects.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_ents.c
+++ b/codemp/cgame/cg_ents.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/cgame/cg_event.c
+++ b/codemp/cgame/cg_event.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_info.c
+++ b/codemp/cgame/cg_info.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_light.c
+++ b/codemp/cgame/cg_light.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_local.h
+++ b/codemp/cgame/cg_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/cgame/cg_localents.c
+++ b/codemp/cgame/cg_localents.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/cgame/cg_marks.c
+++ b/codemp/cgame/cg_marks.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_newDraw.c
+++ b/codemp/cgame/cg_newDraw.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_playerstate.c
+++ b/codemp/cgame/cg_playerstate.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_predict.c
+++ b/codemp/cgame/cg_predict.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_public.h
+++ b/codemp/cgame/cg_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_saga.c
+++ b/codemp/cgame/cg_saga.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_scoreboard.c
+++ b/codemp/cgame/cg_scoreboard.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_servercmds.c
+++ b/codemp/cgame/cg_servercmds.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/cgame/cg_snapshot.c
+++ b/codemp/cgame/cg_snapshot.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_spawn.c
+++ b/codemp/cgame/cg_spawn.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_syscalls.c
+++ b/codemp/cgame/cg_syscalls.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/cgame/cg_turret.c
+++ b/codemp/cgame/cg_turret.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_view.c
+++ b/codemp/cgame/cg_view.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_weaponinit.c
+++ b/codemp/cgame/cg_weaponinit.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_weapons.c
+++ b/codemp/cgame/cg_weapons.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/cg_xcvar.h
+++ b/codemp/cgame/cg_xcvar.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_blaster.c
+++ b/codemp/cgame/fx_blaster.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_bowcaster.c
+++ b/codemp/cgame/fx_bowcaster.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_bryarpistol.c
+++ b/codemp/cgame/fx_bryarpistol.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_demp2.c
+++ b/codemp/cgame/fx_demp2.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_disruptor.c
+++ b/codemp/cgame/fx_disruptor.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_flechette.c
+++ b/codemp/cgame/fx_flechette.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_force.c
+++ b/codemp/cgame/fx_force.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_heavyrepeater.c
+++ b/codemp/cgame/fx_heavyrepeater.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_local.h
+++ b/codemp/cgame/fx_local.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/cgame/fx_rocketlauncher.c
+++ b/codemp/cgame/fx_rocketlauncher.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FXExport.cpp
+++ b/codemp/client/FXExport.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FXExport.h
+++ b/codemp/client/FXExport.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FxPrimitives.cpp
+++ b/codemp/client/FxPrimitives.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FxPrimitives.h
+++ b/codemp/client/FxPrimitives.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FxScheduler.cpp
+++ b/codemp/client/FxScheduler.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FxScheduler.h
+++ b/codemp/client/FxScheduler.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FxSystem.cpp
+++ b/codemp/client/FxSystem.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FxSystem.h
+++ b/codemp/client/FxSystem.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FxTemplate.cpp
+++ b/codemp/client/FxTemplate.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FxUtil.cpp
+++ b/codemp/client/FxUtil.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/FxUtil.h
+++ b/codemp/client/FxUtil.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/cl_cgame.cpp
+++ b/codemp/client/cl_cgame.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/cl_cin.cpp
+++ b/codemp/client/cl_cin.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/client/cl_console.cpp
+++ b/codemp/client/cl_console.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/client/cl_input.cpp
+++ b/codemp/client/cl_input.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/cl_keys.cpp
+++ b/codemp/client/cl_keys.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/client/cl_lan.cpp
+++ b/codemp/client/cl_lan.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/cl_lan.h
+++ b/codemp/client/cl_lan.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/client/cl_net_chan.cpp
+++ b/codemp/client/cl_net_chan.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/cl_parse.cpp
+++ b/codemp/client/cl_parse.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/client/cl_scrn.cpp
+++ b/codemp/client/cl_scrn.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/client/cl_ui.cpp
+++ b/codemp/client/cl_ui.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/client.h
+++ b/codemp/client/client.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/keys.h
+++ b/codemp/client/keys.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_ambient.cpp
+++ b/codemp/client/snd_ambient.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_ambient.h
+++ b/codemp/client/snd_ambient.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_dma.cpp
+++ b/codemp/client/snd_dma.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_local.h
+++ b/codemp/client/snd_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_mem.cpp
+++ b/codemp/client/snd_mem.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_mix.cpp
+++ b/codemp/client/snd_mix.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_mp3.cpp
+++ b/codemp/client/snd_mp3.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_mp3.h
+++ b/codemp/client/snd_mp3.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_music.cpp
+++ b/codemp/client/snd_music.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_music.h
+++ b/codemp/client/snd_music.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/client/snd_public.h
+++ b/codemp/client/snd_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/AnimalNPC.c
+++ b/codemp/game/AnimalNPC.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/FighterNPC.c
+++ b/codemp/game/FighterNPC.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC.c
+++ b/codemp/game/NPC.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Atst.c
+++ b/codemp/game/NPC_AI_Atst.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Default.c
+++ b/codemp/game/NPC_AI_Default.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Droid.c
+++ b/codemp/game/NPC_AI_Droid.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_GalakMech.c
+++ b/codemp/game/NPC_AI_GalakMech.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Grenadier.c
+++ b/codemp/game/NPC_AI_Grenadier.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Howler.c
+++ b/codemp/game/NPC_AI_Howler.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_ImperialProbe.c
+++ b/codemp/game/NPC_AI_ImperialProbe.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Interrogator.c
+++ b/codemp/game/NPC_AI_Interrogator.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Jedi.c
+++ b/codemp/game/NPC_AI_Jedi.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Mark1.c
+++ b/codemp/game/NPC_AI_Mark1.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Mark2.c
+++ b/codemp/game/NPC_AI_Mark2.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_MineMonster.c
+++ b/codemp/game/NPC_AI_MineMonster.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Rancor.c
+++ b/codemp/game/NPC_AI_Rancor.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Remote.c
+++ b/codemp/game/NPC_AI_Remote.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Seeker.c
+++ b/codemp/game/NPC_AI_Seeker.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Sentry.c
+++ b/codemp/game/NPC_AI_Sentry.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Sniper.c
+++ b/codemp/game/NPC_AI_Sniper.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Stormtrooper.c
+++ b/codemp/game/NPC_AI_Stormtrooper.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Utils.c
+++ b/codemp/game/NPC_AI_Utils.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_AI_Wampa.c
+++ b/codemp/game/NPC_AI_Wampa.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_behavior.c
+++ b/codemp/game/NPC_behavior.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_combat.c
+++ b/codemp/game/NPC_combat.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_goal.c
+++ b/codemp/game/NPC_goal.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_misc.c
+++ b/codemp/game/NPC_misc.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_move.c
+++ b/codemp/game/NPC_move.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_reactions.c
+++ b/codemp/game/NPC_reactions.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_senses.c
+++ b/codemp/game/NPC_senses.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_sounds.c
+++ b/codemp/game/NPC_sounds.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_spawn.c
+++ b/codemp/game/NPC_spawn.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_stats.c
+++ b/codemp/game/NPC_stats.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/NPC_utils.c
+++ b/codemp/game/NPC_utils.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/SpeederNPC.c
+++ b/codemp/game/SpeederNPC.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/WalkerNPC.c
+++ b/codemp/game/WalkerNPC.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/ai.h
+++ b/codemp/game/ai.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/ai_main.c
+++ b/codemp/game/ai_main.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/ai_main.h
+++ b/codemp/game/ai_main.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/ai_util.c
+++ b/codemp/game/ai_util.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/ai_wpnav.c
+++ b/codemp/game/ai_wpnav.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/anims.h
+++ b/codemp/game/anims.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/b_local.h
+++ b/codemp/game/b_local.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/b_public.h
+++ b/codemp/game/b_public.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_g2_utils.c
+++ b/codemp/game/bg_g2_utils.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_local.h
+++ b/codemp/game/bg_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_misc.c
+++ b/codemp/game/bg_misc.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_panimate.c
+++ b/codemp/game/bg_panimate.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_saber.c
+++ b/codemp/game/bg_saber.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_saberLoad.c
+++ b/codemp/game/bg_saberLoad.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_saga.c
+++ b/codemp/game/bg_saga.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_saga.h
+++ b/codemp/game/bg_saga.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_slidemove.c
+++ b/codemp/game/bg_slidemove.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_vehicleLoad.c
+++ b/codemp/game/bg_vehicleLoad.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_vehicles.h
+++ b/codemp/game/bg_vehicles.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_weapons.c
+++ b/codemp/game/bg_weapons.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/bg_weapons.h
+++ b/codemp/game/bg_weapons.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/chars.h
+++ b/codemp/game/chars.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_ICARUScb.c
+++ b/codemp/game/g_ICARUScb.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_ICARUScb.h
+++ b/codemp/game/g_ICARUScb.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_active.c
+++ b/codemp/game/g_active.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/game/g_bot.c
+++ b/codemp/game/g_bot.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_client.c
+++ b/codemp/game/g_client.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/game/g_cmds.c
+++ b/codemp/game/g_cmds.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/game/g_combat.c
+++ b/codemp/game/g_combat.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_cvar.c
+++ b/codemp/game/g_cvar.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_exphysics.c
+++ b/codemp/game/g_exphysics.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_items.c
+++ b/codemp/game/g_items.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_local.h
+++ b/codemp/game/g_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/game/g_log.c
+++ b/codemp/game/g_log.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_main.c
+++ b/codemp/game/g_main.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/game/g_mem.c
+++ b/codemp/game/g_mem.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_misc.c
+++ b/codemp/game/g_misc.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_missile.c
+++ b/codemp/game/g_missile.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_mover.c
+++ b/codemp/game/g_mover.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/game/g_nav.c
+++ b/codemp/game/g_nav.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_nav.h
+++ b/codemp/game/g_nav.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_navnew.c
+++ b/codemp/game/g_navnew.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_object.c
+++ b/codemp/game/g_object.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_public.h
+++ b/codemp/game/g_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_saga.c
+++ b/codemp/game/g_saga.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_session.c
+++ b/codemp/game/g_session.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/game/g_spawn.c
+++ b/codemp/game/g_spawn.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_svcmds.c
+++ b/codemp/game/g_svcmds.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/game/g_syscalls.c
+++ b/codemp/game/g_syscalls.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/game/g_target.c
+++ b/codemp/game/g_target.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_team.c
+++ b/codemp/game/g_team.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_team.h
+++ b/codemp/game/g_team.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_timer.c
+++ b/codemp/game/g_timer.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_trigger.c
+++ b/codemp/game/g_trigger.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_turret.c
+++ b/codemp/game/g_turret.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_turret_G2.c
+++ b/codemp/game/g_turret_G2.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_utils.c
+++ b/codemp/game/g_utils.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_vehicleTurret.c
+++ b/codemp/game/g_vehicleTurret.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_vehicles.c
+++ b/codemp/game/g_vehicles.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_weapon.c
+++ b/codemp/game/g_weapon.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/g_xcvar.h
+++ b/codemp/game/g_xcvar.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/inv.h
+++ b/codemp/game/inv.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/match.h
+++ b/codemp/game/match.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/npc_headers.h
+++ b/codemp/game/npc_headers.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/surfaceflags.h
+++ b/codemp/game/surfaceflags.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/teams.h
+++ b/codemp/game/teams.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/w_force.c
+++ b/codemp/game/w_force.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/w_saber.c
+++ b/codemp/game/w_saber.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/game/w_saber.h
+++ b/codemp/game/w_saber.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ghoul2/G2.h
+++ b/codemp/ghoul2/G2.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ghoul2/G2_gore.cpp
+++ b/codemp/ghoul2/G2_gore.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ghoul2/G2_gore.h
+++ b/codemp/ghoul2/G2_gore.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ghoul2/g2_local.h
+++ b/codemp/ghoul2/g2_local.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ghoul2/ghoul2_shared.h
+++ b/codemp/ghoul2/ghoul2_shared.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/BlockStream.cpp
+++ b/codemp/icarus/BlockStream.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/GameInterface.cpp
+++ b/codemp/icarus/GameInterface.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/GameInterface.h
+++ b/codemp/icarus/GameInterface.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/Instance.cpp
+++ b/codemp/icarus/Instance.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/Interface.cpp
+++ b/codemp/icarus/Interface.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/Memory.cpp
+++ b/codemp/icarus/Memory.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/Q3_Interface.cpp
+++ b/codemp/icarus/Q3_Interface.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/Q3_Interface.h
+++ b/codemp/icarus/Q3_Interface.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/Q3_Registers.cpp
+++ b/codemp/icarus/Q3_Registers.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/Q3_Registers.h
+++ b/codemp/icarus/Q3_Registers.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/Sequence.cpp
+++ b/codemp/icarus/Sequence.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/Sequencer.cpp
+++ b/codemp/icarus/Sequencer.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/TaskManager.cpp
+++ b/codemp/icarus/TaskManager.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/blockstream.h
+++ b/codemp/icarus/blockstream.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/icarus.h
+++ b/codemp/icarus/icarus.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/instance.h
+++ b/codemp/icarus/instance.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/interface.h
+++ b/codemp/icarus/interface.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/interpreter.h
+++ b/codemp/icarus/interpreter.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/sequence.h
+++ b/codemp/icarus/sequence.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/sequencer.h
+++ b/codemp/icarus/sequencer.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/taskmanager.h
+++ b/codemp/icarus/taskmanager.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/icarus/tokenizer.h
+++ b/codemp/icarus/tokenizer.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/null/null_client.cpp
+++ b/codemp/null/null_client.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/null/null_input.cpp
+++ b/codemp/null/null_input.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/null/null_renderer.cpp
+++ b/codemp/null/null_renderer.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/null/null_snddma.cpp
+++ b/codemp/null/null_snddma.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/GenericParser2.cpp
+++ b/codemp/qcommon/GenericParser2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/GenericParser2.h
+++ b/codemp/qcommon/GenericParser2.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/MiniHeap.h
+++ b/codemp/qcommon/MiniHeap.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/RoffSystem.cpp
+++ b/codemp/qcommon/RoffSystem.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/RoffSystem.h
+++ b/codemp/qcommon/RoffSystem.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cm_load.cpp
+++ b/codemp/qcommon/cm_load.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cm_local.h
+++ b/codemp/qcommon/cm_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cm_patch.cpp
+++ b/codemp/qcommon/cm_patch.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cm_patch.h
+++ b/codemp/qcommon/cm_patch.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cm_polylib.cpp
+++ b/codemp/qcommon/cm_polylib.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cm_polylib.h
+++ b/codemp/qcommon/cm_polylib.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cm_public.h
+++ b/codemp/qcommon/cm_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cm_test.cpp
+++ b/codemp/qcommon/cm_test.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cm_trace.cpp
+++ b/codemp/qcommon/cm_trace.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/cmd.cpp
+++ b/codemp/qcommon/cmd.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/common.cpp
+++ b/codemp/qcommon/common.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/cvar.cpp
+++ b/codemp/qcommon/cvar.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/disablewarnings.h
+++ b/codemp/qcommon/disablewarnings.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/game_version.h
+++ b/codemp/qcommon/game_version.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/huffman.cpp
+++ b/codemp/qcommon/huffman.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/matcomp.cpp
+++ b/codemp/qcommon/matcomp.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/matcomp.h
+++ b/codemp/qcommon/matcomp.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/msg.cpp
+++ b/codemp/qcommon/msg.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/net_chan.cpp
+++ b/codemp/qcommon/net_chan.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/net_ip.cpp
+++ b/codemp/qcommon/net_ip.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/q_math.c
+++ b/codemp/qcommon/q_math.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/q_math.cpp
+++ b/codemp/qcommon/q_math.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/q_platform.h
+++ b/codemp/qcommon/q_platform.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/q_shared.c
+++ b/codemp/qcommon/q_shared.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/q_shared.cpp
+++ b/codemp/qcommon/q_shared.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/q_shared.h
+++ b/codemp/qcommon/q_shared.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/qfiles.h
+++ b/codemp/qcommon/qfiles.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/sstring.h
+++ b/codemp/qcommon/sstring.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/stringed_ingame.cpp
+++ b/codemp/qcommon/stringed_ingame.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/stringed_ingame.h
+++ b/codemp/qcommon/stringed_ingame.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/stringed_interface.cpp
+++ b/codemp/qcommon/stringed_interface.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/stringed_interface.h
+++ b/codemp/qcommon/stringed_interface.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/tags.h
+++ b/codemp/qcommon/tags.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/timing.h
+++ b/codemp/qcommon/timing.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/qcommon/vm.cpp
+++ b/codemp/qcommon/vm.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/qcommon/z_memman_pc.cpp
+++ b/codemp/qcommon/z_memman_pc.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-common/mdx_format.h
+++ b/codemp/rd-common/mdx_format.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-common/tr_common.h
+++ b/codemp/rd-common/tr_common.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/rd-common/tr_font.cpp
+++ b/codemp/rd-common/tr_font.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-common/tr_font.h
+++ b/codemp/rd-common/tr_font.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-common/tr_image_jpg.cpp
+++ b/codemp/rd-common/tr_image_jpg.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/rd-common/tr_image_load.cpp
+++ b/codemp/rd-common/tr_image_load.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/rd-common/tr_image_png.cpp
+++ b/codemp/rd-common/tr_image_png.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/rd-common/tr_image_tga.cpp
+++ b/codemp/rd-common/tr_image_tga.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/rd-common/tr_noise.cpp
+++ b/codemp/rd-common/tr_noise.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/rd-common/tr_public.h
+++ b/codemp/rd-common/tr_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/rd-common/tr_types.h
+++ b/codemp/rd-common/tr_types.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/rd-dedicated/G2_API.cpp
+++ b/codemp/rd-dedicated/G2_API.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/G2_bolts.cpp
+++ b/codemp/rd-dedicated/G2_bolts.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/G2_bones.cpp
+++ b/codemp/rd-dedicated/G2_bones.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/G2_misc.cpp
+++ b/codemp/rd-dedicated/G2_misc.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/G2_surfaces.cpp
+++ b/codemp/rd-dedicated/G2_surfaces.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/tr_backend.cpp
+++ b/codemp/rd-dedicated/tr_backend.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/tr_ghoul2.cpp
+++ b/codemp/rd-dedicated/tr_ghoul2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/tr_init.cpp
+++ b/codemp/rd-dedicated/tr_init.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/tr_local.h
+++ b/codemp/rd-dedicated/tr_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/tr_main.cpp
+++ b/codemp/rd-dedicated/tr_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/tr_mesh.cpp
+++ b/codemp/rd-dedicated/tr_mesh.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/tr_model.cpp
+++ b/codemp/rd-dedicated/tr_model.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/tr_shader.cpp
+++ b/codemp/rd-dedicated/tr_shader.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-dedicated/tr_skin.cpp
+++ b/codemp/rd-dedicated/tr_skin.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/G2_API.cpp
+++ b/codemp/rd-vanilla/G2_API.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/G2_bolts.cpp
+++ b/codemp/rd-vanilla/G2_bolts.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/G2_bones.cpp
+++ b/codemp/rd-vanilla/G2_bones.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/G2_misc.cpp
+++ b/codemp/rd-vanilla/G2_misc.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/G2_surfaces.cpp
+++ b/codemp/rd-vanilla/G2_surfaces.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/qgl.h
+++ b/codemp/rd-vanilla/qgl.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_WorldEffects.cpp
+++ b/codemp/rd-vanilla/tr_WorldEffects.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_WorldEffects.h
+++ b/codemp/rd-vanilla/tr_WorldEffects.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_arb.cpp
+++ b/codemp/rd-vanilla/tr_arb.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_backend.cpp
+++ b/codemp/rd-vanilla/tr_backend.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_bsp.cpp
+++ b/codemp/rd-vanilla/tr_bsp.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_cmds.cpp
+++ b/codemp/rd-vanilla/tr_cmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_curve.cpp
+++ b/codemp/rd-vanilla/tr_curve.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_decals.cpp
+++ b/codemp/rd-vanilla/tr_decals.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_ghoul2.cpp
+++ b/codemp/rd-vanilla/tr_ghoul2.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_image.cpp
+++ b/codemp/rd-vanilla/tr_image.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_init.cpp
+++ b/codemp/rd-vanilla/tr_init.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_light.cpp
+++ b/codemp/rd-vanilla/tr_light.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_local.h
+++ b/codemp/rd-vanilla/tr_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_main.cpp
+++ b/codemp/rd-vanilla/tr_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_marks.cpp
+++ b/codemp/rd-vanilla/tr_marks.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_mesh.cpp
+++ b/codemp/rd-vanilla/tr_mesh.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_model.cpp
+++ b/codemp/rd-vanilla/tr_model.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_quicksprite.cpp
+++ b/codemp/rd-vanilla/tr_quicksprite.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_quicksprite.h
+++ b/codemp/rd-vanilla/tr_quicksprite.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_scene.cpp
+++ b/codemp/rd-vanilla/tr_scene.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_shade.cpp
+++ b/codemp/rd-vanilla/tr_shade.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_shade_calc.cpp
+++ b/codemp/rd-vanilla/tr_shade_calc.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_shader.cpp
+++ b/codemp/rd-vanilla/tr_shader.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_shadows.cpp
+++ b/codemp/rd-vanilla/tr_shadows.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_skin.cpp
+++ b/codemp/rd-vanilla/tr_skin.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_sky.cpp
+++ b/codemp/rd-vanilla/tr_sky.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_subs.cpp
+++ b/codemp/rd-vanilla/tr_subs.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_surface.cpp
+++ b/codemp/rd-vanilla/tr_surface.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_surfacesprites.cpp
+++ b/codemp/rd-vanilla/tr_surfacesprites.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/rd-vanilla/tr_world.cpp
+++ b/codemp/rd-vanilla/tr_world.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/server/NPCNav/navigator.cpp
+++ b/codemp/server/NPCNav/navigator.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/server/NPCNav/navigator.h
+++ b/codemp/server/NPCNav/navigator.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/server/sv_bot.cpp
+++ b/codemp/server/sv_bot.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/server/sv_ccmds.cpp
+++ b/codemp/server/sv_ccmds.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/server/sv_game.cpp
+++ b/codemp/server/sv_game.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/server/sv_net_chan.cpp
+++ b/codemp/server/sv_net_chan.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/server/sv_snapshot.cpp
+++ b/codemp/server/sv_snapshot.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/server/sv_world.cpp
+++ b/codemp/server/sv_world.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/keycodes.h
+++ b/codemp/ui/keycodes.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/menudef.h
+++ b/codemp/ui/menudef.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/ui_atoms.c
+++ b/codemp/ui/ui_atoms.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/ui_cvar.c
+++ b/codemp/ui/ui_cvar.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/ui_force.c
+++ b/codemp/ui/ui_force.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/ui_force.h
+++ b/codemp/ui/ui_force.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/ui_gameinfo.c
+++ b/codemp/ui/ui_gameinfo.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/ui_local.h
+++ b/codemp/ui/ui_local.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/ui/ui_public.h
+++ b/codemp/ui/ui_public.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/ui_saber.c
+++ b/codemp/ui/ui_saber.c
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/codemp/ui/ui_shared.c
+++ b/codemp/ui/ui_shared.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/ui/ui_shared.h
+++ b/codemp/ui/ui_shared.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/ui/ui_syscalls.c
+++ b/codemp/ui/ui_syscalls.c
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 

--- a/codemp/ui/ui_xcvar.h
+++ b/codemp/ui/ui_xcvar.h
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/shared/sys/snapvector.cpp
+++ b/shared/sys/snapvector.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2013 - 2015, OpenJK contributors
 
 This file is part of the OpenJK source code.

--- a/shared/sys/sys_event.cpp
+++ b/shared/sys/sys_event.cpp
@@ -1,8 +1,8 @@
 /*
 ===========================================================================
 Copyright (C) 1999 - 2005, Id Software, Inc.
-Copyright (C) 2002 - 2013, Raven Software, Inc.
-Copyright (C) 2002 - 2013, Activision, Inc.
+Copyright (C) 2000 - 2013, Raven Software, Inc.
+Copyright (C) 2001 - 2013, Activision, Inc.
 Copyright (C) 2005 - 2015, ioquake3 contributors
 Copyright (C) 2013 - 2015, OpenJK contributors
 


### PR DESCRIPTION
Some of the older copyright boilerplate removed by 59dfa47 said
things like

// Copyright 2001-2013 Raven Software
// Copyright 2000-2001 Raven Software
// Copyright 2001-2013 Activision

so we should preserve that. It seems safest to assume that this
applies to to everything.

Change automated by:

find * -type f -print0 | xargs -0 perl -p -i -e \
's/(Copyright \(C\) )2002( - 2013, Raven Software, Inc\.)/$1."2000".$2/eg'
find * -type f -print0 | xargs -0 perl -p -i -e \
's/(Copyright \(C\) )2002( - 2013, Activision, Inc\.)/$1."2001".$2/eg'

Refs #628