### PR TITLE
Add support for using a system copy of minizip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.8)
 # For checks in subdirectories
 set(InOpenJK TRUE)
 
+include(FindPkgConfig)
+
 # Project name
 set(ProjectName "OpenJK" CACHE STRING "Project Name")
 project(${ProjectName})
@@ -30,6 +32,8 @@ if(WIN32)
 	option(UseInternalOpenAL "Whether to use the included OpenAL instead of a locally installed one" ON)
 	option(UseInternalZlib "Whether to use the included zlib instead of a locally installed one" ON)
 endif()
+
+option(UseInternalMinizip "Whether to use the included minizip instead of a locally installed one" ON)
 
 if(WIN32)
 	option(UseInternalPNG "Whether to use the included libpng instead of a locally installed one" ON)
@@ -260,6 +264,10 @@ endif()
 
 if(UseInternalZlib)
 	set(SharedDefines ${SharedDefines} "USE_INTERNAL_ZLIB")
+endif()
+
+if(UseInternalMinizip)
+	set(SharedDefines ${SharedDefines} "USE_INTERNAL_MINIZIP")
 endif()
 
 set(OpenJKLibDir "${CMAKE_SOURCE_DIR}/lib")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -162,15 +162,20 @@ if(BuildSPEngine OR BuildJK2SPEngine)
 	source_group("common" FILES ${SPEngineCommonFiles})
 	set(SPEngineFiles ${SPEngineFiles} ${SPEngineCommonFiles})
 
-	set(SPEngineMinizipFiles
-		"${OpenJKLibDir}/minizip/ioapi.c"
-		"${OpenJKLibDir}/minizip/ioapi.h"
-		"${OpenJKLibDir}/minizip/unzip.cpp"
-		"${OpenJKLibDir}/minizip/unzip.h"
-		)
-	source_group("minizip" FILES ${SPEngineMinizipFiles})
-	set(SPEngineFiles ${SPEngineFiles} ${SPEngineMinizipFiles})
-
+	if(UseInternalMinizip)
+		set(SPEngineMinizipFiles
+			"${OpenJKLibDir}/minizip/ioapi.c"
+			"${OpenJKLibDir}/minizip/ioapi.h"
+			"${OpenJKLibDir}/minizip/unzip.cpp"
+			"${OpenJKLibDir}/minizip/unzip.h"
+			)
+		source_group("minizip" FILES ${SPEngineMinizipFiles})
+		set(SPEngineFiles ${SPEngineFiles} ${SPEngineMinizipFiles})
+	else(UseInternalMinizip)
+		pkg_check_modules(MINIZIP REQUIRED minizip)
+		set(SPEngineIncludeDirectories ${SPEngineIncludeDirectories} ${MINIZIP_INCLUDE_DIRS})
+		set(SPEngineLibraries ${SPEngineLibraries} ${MINIZIP_LIBRARIES})
+	endif(UseInternalMinizip)
 
 	# Server files
 	set(SPEngineServerFiles

--- a/code/qcommon/files.cpp
+++ b/code/qcommon/files.cpp
@@ -35,7 +35,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #ifndef FINAL_BUILD
 #include "../client/client.h"
 #endif
+
+#ifdef USE_INTERNAL_MINIZIP
 #include "minizip/unzip.h"
+#else
+#include <unzip.h>
+#endif
 
 // for rmdir
 #if defined (_MSC_VER)

--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -328,6 +328,21 @@ if(BuildMPEngine OR BuildMPDed)
 	source_group("minizip" FILES ${MPEngineAndDedMinizipFiles})
 	set(MPEngineAndDedFiles ${MPEngineAndDedFiles} ${MPEngineAndDedMinizipFiles})
 
+	if(UseInternalMinizip)
+		set(MPEngineAndDedMinizipFiles
+			"${OpenJKLibDir}/minizip/ioapi.c"
+			"${OpenJKLibDir}/minizip/ioapi.h"
+			"${OpenJKLibDir}/minizip/unzip.cpp"
+			"${OpenJKLibDir}/minizip/unzip.h"
+			)
+		source_group("minizip" FILES ${MPEngineAndDedMinizipFiles})
+		set(MPEngineAndDedFiles ${MPEngineAndDedFiles} ${MPEngineAndDedMinizipFiles})
+	else(UseInternalMinizip)
+		pkg_check_modules(MINIZIP REQUIRED minizip)
+		set(MPEngineAndDedIncludeDirectories ${MPEngineAndDedIncludeDirectories} ${MINIZIP_INCLUDE_DIRS})
+		set(MPEngineAndDedLibraries ${MPEngineAndDedLibraries} ${MINIZIP_LIBRARIES})
+	endif(UseInternalMinizip)
+
 	set(MPEngineAndDedSysFiles
 		"${SharedDir}/sys/snapvector.cpp"
 		)

--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -37,7 +37,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "client/client.h"
 #endif
 #endif
+
+#ifdef USE_INTERNAL_MINIZIP
 #include "minizip/unzip.h"
+#else
+#include <unzip.h>
+#endif
 
 #if defined(_WIN32)
 #include <Windows.h>


### PR DESCRIPTION
Linux distributions prefer to use a shared system copy of each library
rather than having projects bundle it, so that any security fixes
or other bugfixes only need to happen once. minizip is in at least
Debian, Ubuntu and Fedora (they need it for Chromium).

I'm using pkg-config to find it, on the assumption that the bundled
internal copy will continue to be used on Windows.