### PR TITLE
[MP] Install game, cgame, ui DLLs on non-Mac again

### DIFF
--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -706,13 +706,15 @@ foreach(GameLib ${GameLibsBuilt})
 		${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}/${GameLib}${CMAKE_SHARED_LIBRARY_SUFFIX})
 endforeach(GameLib)
 
-include(InstallZIP)
-add_zip_command(openjk.pk3
-	FILES ${GameLibFullPaths}
-	DEPENDS "${GameLibsBuilt}")
-add_custom_target(Assets
-	ALL
-	DEPENDS openjk.pk3)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openjk.pk3
-	DESTINATION "OpenJK"
-	COMPONENT ${JKAMPCoreComponent})
+if(WIN32)
+	include(InstallZIP)
+	add_zip_command(openjk.pk3
+		FILES ${GameLibFullPaths}
+		DEPENDS "${GameLibsBuilt}")
+	add_custom_target(Assets
+		ALL
+		DEPENDS openjk.pk3)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/openjk.pk3
+		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
+endif()

--- a/codemp/cgame/CMakeLists.txt
+++ b/codemp/cgame/CMakeLists.txt
@@ -134,10 +134,22 @@ elseif(WIN32)
 		RUNTIME
 		DESTINATION "OpenJK"
 		COMPONENT ${JKAMPCoreComponent})
+	if (WIN64)
+		# Don't do this on 32-bit Windows to avoid overwriting
+		# vanilla JKA's DLLs
+		install(TARGETS ${MPCGame}
+			RUNTIME
+			DESTINATION "base"
+			COMPONENT ${JKAMPCoreComponent})
+	endif()
 else()
 	install(TARGETS ${MPCGame}
 		LIBRARY
 		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
+	install(TARGETS ${MPCGame}
+		LIBRARY
+		DESTINATION "base"
 		COMPONENT ${JKAMPCoreComponent})
 endif()
 

--- a/codemp/cgame/CMakeLists.txt
+++ b/codemp/cgame/CMakeLists.txt
@@ -129,6 +129,16 @@ if(MakeApplicationBundles AND BuildMPEngine)
 		LIBRARY
 		DESTINATION "${MPEngine}.app/Contents/MacOS/base"
 		COMPONENT ${JKAMPCoreComponent})
+elseif(WIN32)
+	install(TARGETS ${MPCGame}
+		RUNTIME
+		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
+else()
+	install(TARGETS ${MPCGame}
+		LIBRARY
+		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
 endif()
 
 set_target_properties(${MPCGame} PROPERTIES COMPILE_DEFINITIONS_RELWITHDEBINFO "${MPCGameDefines};${ReleaseDefines}")

--- a/codemp/game/CMakeLists.txt
+++ b/codemp/game/CMakeLists.txt
@@ -202,10 +202,22 @@ elseif(WIN32)
 		RUNTIME
 		DESTINATION "OpenJK"
 		COMPONENT ${JKAMPCoreComponent})
+	if (WIN64)
+		# Don't do this on 32-bit Windows to avoid overwriting
+		# vanilla JKA's DLLs
+		install(TARGETS ${MPGame}
+			RUNTIME
+			DESTINATION "base"
+			COMPONENT ${JKAMPCoreComponent})
+	endif()
 else()
 	install(TARGETS ${MPGame}
 		LIBRARY
 		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
+	install(TARGETS ${MPGame}
+		LIBRARY
+		DESTINATION "base"
 		COMPONENT ${JKAMPCoreComponent})
 endif()
 

--- a/codemp/game/CMakeLists.txt
+++ b/codemp/game/CMakeLists.txt
@@ -197,6 +197,16 @@ if(MakeApplicationBundles AND BuildMPEngine)
 		LIBRARY
 		DESTINATION "${MPEngine}.app/Contents/MacOS/base"
 		COMPONENT ${JKAMPCoreComponent})
+elseif(WIN32)
+	install(TARGETS ${MPGame}
+		RUNTIME
+		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
+else()
+	install(TARGETS ${MPGame}
+		LIBRARY
+		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
 endif()
 
 set_target_properties(${MPGame} PROPERTIES COMPILE_DEFINITIONS_RELWITHDEBINFO "${MPGameDefines};${ReleaseDefines}")

--- a/codemp/ui/CMakeLists.txt
+++ b/codemp/ui/CMakeLists.txt
@@ -82,6 +82,16 @@ if(MakeApplicationBundles AND BuildMPEngine)
 		LIBRARY
 		DESTINATION "${MPEngine}.app/Contents/MacOS/base"
 		COMPONENT ${JKAMPCoreComponent})
+elseif(WIN32)
+	install(TARGETS ${MPUI}
+		RUNTIME
+		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
+else()
+	install(TARGETS ${MPUI}
+		LIBRARY
+		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
 endif()
 
 set_target_properties(${MPUI} PROPERTIES COMPILE_DEFINITIONS_RELWITHDEBINFO "${MPUIDefines};${ReleaseDefines}")

--- a/codemp/ui/CMakeLists.txt
+++ b/codemp/ui/CMakeLists.txt
@@ -87,10 +87,22 @@ elseif(WIN32)
 		RUNTIME
 		DESTINATION "OpenJK"
 		COMPONENT ${JKAMPCoreComponent})
+	if (WIN64)
+		# Don't do this on 32-bit Windows to avoid overwriting
+		# vanilla JKA's DLLs
+		install(TARGETS ${MPUI}
+			RUNTIME
+			DESTINATION "base"
+			COMPONENT ${JKAMPCoreComponent})
+	endif()
 else()
 	install(TARGETS ${MPUI}
 		LIBRARY
 		DESTINATION "OpenJK"
+		COMPONENT ${JKAMPCoreComponent})
+	install(TARGETS ${MPUI}
+		LIBRARY
+		DESTINATION "base"
 		COMPONENT ${JKAMPCoreComponent})
 endif()
 


### PR DESCRIPTION
See #643.

This puts it back the way it was before d4cc979: alternatively we could omit the DLLs on Windows, and/or install to both `base/` and `OpenJK/` (for some reason before d4cc979 this was still done for Mac bundles, but not Windows or Linux).