### PR TITLE
Shared: fixed binding keys a-z in the menu

### DIFF
--- a/shared/sdl/sdl_input.cpp
+++ b/shared/sdl/sdl_input.cpp
@@ -262,7 +262,11 @@ static fakeAscii_t IN_TranslateSDLToJKKey( SDL_Keysym *keysym, qboolean down ) {
 	if( keysym->sym >= SDLK_SPACE && keysym->sym < SDLK_DELETE )
 	{
 		// These happen to match the ASCII chars
-		key = (fakeAscii_t)keysym->sym;
+		if (keysym->sym >= SDLK_a && keysym->sym <= SDLK_z) {
+			key = (fakeAscii_t)('A' + (keysym->sym - SDLK_a));
+		} else {
+			key = (fakeAscii_t)keysym->sym;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
menu code expects uppercase keycodes