### PR TITLE
fix fallout from removal of ibize_platform.h

### DIFF
--- a/code/game/g_savegame.cpp
+++ b/code/game/g_savegame.cpp
@@ -499,7 +499,7 @@ static void EnumerateField(const save_field_t *pField, const byte *pbBase)
 	}
 }
 
-static void EnumerateFields(const save_field_t *pFields, const byte *pbData, unsigned int ulChid, int iLen)
+static void EnumerateFields(const save_field_t *pFields, const byte *pbData, unsigned int ulChid, size_t iLen)
 {
 	strList = new std::list<sstring_t>;
 

--- a/codeJK2/cgame/cg_weapons.cpp
+++ b/codeJK2/cgame/cg_weapons.cpp
@@ -215,11 +215,11 @@ void CG_RegisterWeapon( int weaponNum ) {
 	// give ourselves the functions if we can
 	if (weaponData[weaponNum].func)
 	{
-		weaponInfo->missileTrailFunc = (void (__cdecl *)(struct centity_s *,const struct weaponInfo_s *))weaponData[weaponNum].func;
+		weaponInfo->missileTrailFunc = (void (QDECL *)(struct centity_s *,const struct weaponInfo_s *))weaponData[weaponNum].func;
 	}
 	if (weaponData[weaponNum].altfunc)
 	{
-		weaponInfo->alt_missileTrailFunc = (void (__cdecl *)(struct centity_s *,const struct weaponInfo_s *))weaponData[weaponNum].altfunc;
+		weaponInfo->alt_missileTrailFunc = (void (QDECL *)(struct centity_s *,const struct weaponInfo_s *))weaponData[weaponNum].altfunc;
 	}
 
 	switch ( weaponNum )	//extra client only stuff

--- a/codeJK2/game/g_savegame.cpp
+++ b/codeJK2/game/g_savegame.cpp
@@ -441,7 +441,7 @@ void EnumerateField(const field_t *pField, byte *pbBase)
 	}
 }
 
-static void EnumerateFields(const field_t *pFields, byte *pbData, unsigned int ulChid, int iLen)
+static void EnumerateFields(const field_t *pFields, byte *pbData, unsigned int ulChid, size_t iLen)
 {
 	strList = new list<sstring_t>;
 

--- a/codeJK2/icarus/blockstream.h
+++ b/codeJK2/icarus/blockstream.h
@@ -32,6 +32,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef _MSC_VER
 	#pragma warning (push, 3)	//go back down to 3 for the stl include

--- a/codeJK2/icarus/tokenizer.h
+++ b/codeJK2/icarus/tokenizer.h
@@ -26,6 +26,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define __TOKENIZER_H
 
 #include <string>
+#include <string.h>
 #include <vector>
 #include <map>
 


### PR DESCRIPTION
After commit 03235915 removed the inclusion of ibize_platform.h, I get compiler errors in codeJK2 on Linux (gcc).

One of the commits here should also fix #651.