### PR TITLE
Update NPC_stats.cpp

### DIFF
--- a/code/game/NPC_stats.cpp
+++ b/code/game/NPC_stats.cpp
@@ -40,7 +40,7 @@ extern vec3_t playerMins;
 extern vec3_t playerMaxs;
 extern stringID_table_t WPTable[];
 
-#define		MAX_MODELS_PER_LEVEL	40
+#define		MAX_MODELS_PER_LEVEL	60
 
 hstring		modelsAlreadyDone[MAX_MODELS_PER_LEVEL];
 
@@ -214,7 +214,7 @@ qboolean G_ParseLiteral( const char **data, const char *string )
 //
 // NPC parameters file : ext_data/NPCs/*.npc*
 //
-#define MAX_NPC_DATA_SIZE 0x40000
+#define MAX_NPC_DATA_SIZE 0x80000
 char	NPCParms[MAX_NPC_DATA_SIZE];
 
 /*


### PR DESCRIPTION
I've raised the npc memory to 0x80000 and the models per level to 60.  If this creates a problem with slowing the game, we can always go a little lower.  But, I doubt it should, unless limits are actually hit in game.  I'm new to coding, excuse me.  I'm just really hoping we can raise the npc limit for the game a little more, due to a mod I have been working on since before the source code was released.