### PR TITLE
Avoid hard-coding a list of Linux architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,10 @@ if (APPLE)
 	set(SharedDefines "MACOS_X")
 endif()
 
+if (NOT WIN32 AND NOT APPLE)
+	set(SharedDefines "ARCH_STRING=\"${Architecture}\"")
+endif()
+
 # Compiler settings
 if(MSVC)
 

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -131,36 +131,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 	#define PATH_SEP '/'
 
+	#if !defined(ARCH_STRING)
+		#error ARCH_STRING should be defined by the build system
+	#endif
 
-	#if defined(__i386__)
-		#define ARCH_STRING "i386"
-	#elif defined(__x86_64__)
+	#if defined(__x86_64__)
 		#define idx64
-		#define ARCH_STRING "x86_64"
-	#elif defined(__powerpc64__)
-		#define ARCH_STRING "ppc64"
-	#elif defined(__powerpc__)
-		#define ARCH_STRING "ppc"
-	#elif defined(__s390__)
-		#define ARCH_STRING "s390"
-	#elif defined(__s390x__)
-		#define ARCH_STRING "s390x"
-	#elif defined(__ia64__)
-		#define ARCH_STRING "ia64"
-	#elif defined(__alpha__)
-		#define ARCH_STRING "alpha"
-	#elif defined(__sparc__)
-		#define ARCH_STRING "sparc"
-	#elif defined(__arm__)
-		#define ARCH_STRING "arm"
-	#elif defined(__cris__)
-		#define ARCH_STRING "cris"
-	#elif defined(__hppa__)
-		#define ARCH_STRING "hppa"
-	#elif defined(__mips__)
-		#define ARCH_STRING "mips"
-	#elif defined(__sh__)
-		#define ARCH_STRING "sh"
 	#endif
 
 	#if __FLOAT_WORD_ORDER == __BIG_ENDIAN
@@ -191,16 +167,15 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 	
 	#define QINLINE inline
 	#define PATH_SEP '/'
-	
-	#if defined(__i386__)
-		#define ARCH_STRING "i386"
-	#elif defined(__amd64__)
-		#define idx64
-		#define ARCH_STRING "amd64"
-	#elif defined(__axp__)
-		#define ARCH_STRING "alpha"
+
+	#if !defined(ARCH_STRING)
+		#error ARCH_STRING should be defined by the build system
 	#endif
-	
+
+	#if defined(__amd64__)
+		#define idx64
+	#endif
+
 	#if BYTE_ORDER == BIG_ENDIAN
 		#define Q3_BIG_ENDIAN
 	#else

--- a/codeJK2/game/CMakeLists.txt
+++ b/codeJK2/game/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT InOpenJK)
 	message(FATAL_ERROR "Use the top-level cmake script!")
 endif(NOT InOpenJK)
 
-set(JK2SPGameDefines ${JK2SPGameDefines} "JK2_MODE")
+set(JK2SPGameDefines ${SharedDefines} "JK2_MODE")
 
 set(JK2SPGameIncludeDirectories "${JK2SPDir}/game")
 if(WIN32)

--- a/codemp/qcommon/q_platform.h
+++ b/codemp/qcommon/q_platform.h
@@ -131,36 +131,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 	#define PATH_SEP '/'
 
+	#if !defined(ARCH_STRING)
+		#error ARCH_STRING should be defined by the build system
+	#endif
 
-	#if defined(__i386__)
-		#define ARCH_STRING "i386"
-	#elif defined(__x86_64__)
+	#if defined(__x86_64__)
 		#define idx64
-		#define ARCH_STRING "x86_64"
-	#elif defined(__powerpc64__)
-		#define ARCH_STRING "ppc64"
-	#elif defined(__powerpc__)
-		#define ARCH_STRING "ppc"
-	#elif defined(__s390__)
-		#define ARCH_STRING "s390"
-	#elif defined(__s390x__)
-		#define ARCH_STRING "s390x"
-	#elif defined(__ia64__)
-		#define ARCH_STRING "ia64"
-	#elif defined(__alpha__)
-		#define ARCH_STRING "alpha"
-	#elif defined(__sparc__)
-		#define ARCH_STRING "sparc"
-	#elif defined(__arm__)
-		#define ARCH_STRING "arm"
-	#elif defined(__cris__)
-		#define ARCH_STRING "cris"
-	#elif defined(__hppa__)
-		#define ARCH_STRING "hppa"
-	#elif defined(__mips__)
-		#define ARCH_STRING "mips"
-	#elif defined(__sh__)
-		#define ARCH_STRING "sh"
 	#endif
 
 	#if __FLOAT_WORD_ORDER == __BIG_ENDIAN
@@ -192,13 +168,12 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 	#define QINLINE inline
 	#define PATH_SEP '/'
 
-	#if defined(__i386__)
-		#define ARCH_STRING "i386"
-	#elif defined(__amd64__)
+	#if !defined(ARCH_STRING)
+		#error ARCH_STRING should be defined by the build system
+	#endif
+
+	#if defined(__amd64__)
 		#define idx64
-		#define ARCH_STRING "amd64"
-	#elif defined(__axp__)
-		#define ARCH_STRING "alpha"
 	#endif
 
 	#if BYTE_ORDER == BIG_ENDIAN


### PR DESCRIPTION
Until recently, ioquake3 and its derivatives required trivial code changes every time Linux developers get interested in running it on a new CPU, most recently ioquake/ioq3#128 for ARM64 (aka aarch64). For the vast majority of CPUs, the only change is to add ARCH_STRING detection, which must be kept in sync with the architecture from the build system. I fixed this for ioquake3 in ioquake/ioq3#129, and for iortcw in iortcw/iortcw#2; this branch is an OpenJK version of the same change.

The approach I've taken is to use the ${Architecture} from the CMake build system to define ARCH_STRING in ${SharedDefines} on all platforms except Windows and OS X, making it unnecessary to change anything to support new CPUs in most cases. Code changes should now only be needed if the new CPU is relevant to Windows or OS X, or if there is genuinely something weird and assumption-breaking about it. In practice, Unix OSs on unusual CPUs tend to fit into the same category as either x86 and ARM (ILP32 little-endian), x86_64 and ARM64 (LP64 little-endian), PowerPC (ILP32 big-endian) or PowerPC64 (LP64 big-endian), all of which are already supported.

This branch also fixes a minor bug in the JK2 module which would otherwise have broken this feature, and might have broken other configurations such as Win64 and OS X: ${SharedDefines} was not used in the JK2 code, which seems to have been a mistake rather than an intentional difference.

If Windows and OS X developers want to make those platforms treat the ARCH_STRING the same way I've done for Linux, that would also be a simplification; I haven't done so because I can't currently test on those platforms, and I don't want to break them. However, there's less need for that than on Linux anyway, because Windows and OS X are only portable among a limited number of CPU families.