### PR TITLE
Stop setting CMake policy CMP0043 to OLD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,6 @@
 #============================================================================
 
 cmake_minimum_required(VERSION 2.8.8)
-
-# Set CMake policies
-if(POLICY CMP0043)
-	cmake_policy(SET CMP0043 OLD) # Don't ignore COMPILE_DEFINITION_<build>
-endif()
-
 # For checks in subdirectories
 set(InOpenJK TRUE)
 


### PR DESCRIPTION
This partially reverts commit 9a34abf46d3b82729440e46f0e171ae5033dc28a.
We no longer use COMPILE_DEFINITION_* since #687 was merged, so it
is no longer necessary to do this.

---

Just some minor cleanup after #687.