### PR TITLE
add Travis-CI continuous integration glue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ compiler: gcc
 env:
   - ""
   - flavour=Debug
-  - host=i686-linux-gnu
+  #- host=i686-linux-gnu
   - host=i686-w64-mingw32
   - host=x86_64-w64-mingw32
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+sudo: true
+
+install:
+  - ./tools/travis-install.sh "${host:-native}" "${flavour:-Release}" $opts
+
+script:
+  - ./tools/travis-build.sh "${host:-native}" "${flavour:-Release}" $opts
+
+compiler: gcc
+env:
+  - ""
+  - flavour=Debug
+  - host=i686-linux-gnu
+  - host=i686-w64-mingw32
+  - host=x86_64-w64-mingw32
+
+# One extra build with clang, its warnings are often better
+matrix:
+  include:
+    - compiler: clang
+      env: ""

--- a/tools/travis-build.sh
+++ b/tools/travis-build.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+set -e
+set -x
+
+host="$1"
+flavour="$2"
+shift 2
+
+mkdir deps build
+
+case "${host}" in
+	(*-w64-mingw32)
+		export CC=${host}-gcc
+		export CXX=${host}-g++
+		set -- \
+			-D CMAKE_TOOLCHAIN_FILE=$(pwd)/CMakeModules/Toolchains/${host}.cmake \
+			"$@"
+		;;
+
+	(i?86-linux-gnu)
+		set -- \
+			-D CMAKE_TOOLCHAIN_FILE=$(pwd)/CMakeModules/Toolchains/linux-i686.cmake \
+			"$@"
+		;;
+
+	(native)
+		;;
+
+	(*)
+		set +x
+		echo "Error: don't know how to cross-compile for ${host} host"
+		exit 1
+		;;
+esac
+
+set -- -D CMAKE_BUILD_TYPE="$flavour" "$@"
+
+# Build JK2, so that the CI build is testing everything
+( cd build && cmake \
+	-D BuildJK2SPEngine=ON \
+	-D BuildJK2SPGame=ON \
+	-D BuildJK2SPRdVanilla=ON \
+	-D CMAKE_INSTALL_PREFIX=/prefix \
+	-D CMAKE_VERBOSE_MAKEFILE=ON \
+	"$@" .. )
+make -C build
+make -C build install DESTDIR=$(pwd)/build/DESTDIR
+( cd $(pwd)/build/DESTDIR && find . -ls )

--- a/tools/travis-install.sh
+++ b/tools/travis-install.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -e
+set -x
+
+host="$1"
+flavour="$2"
+shift 2
+
+# We need cmake from Ubuntu 14.04 (trusty), the version in 12.04 is too old.
+# We also need SDL2, which is broken in 14.04 but OK in trusty-updates;
+# and dpkg from 14.04 fixes installation of libglib2.0-dev:i386.
+echo "deb http://archive.ubuntu.com/ubuntu trusty main universe" | sudo tee -a /etc/apt/sources.list
+echo "deb http://archive.ubuntu.com/ubuntu trusty-updates main universe" | sudo tee -a /etc/apt/sources.list
+sudo apt-get update -qq
+sudo apt-get -q -y install cmake dpkg
+
+case "${host}" in
+	(native)
+		# upgrade some relevant libraries to vaguely modern versions
+		sudo apt-get -q -y install libsdl2-dev libjpeg-turbo8-dev zlib1g-dev libpng12-dev
+		;;
+
+	(i686-w64-mingw32)
+		sudo apt-get -q -y install g++-mingw-w64-i686
+		;;
+
+	(x86_64-w64-mingw32)
+		sudo apt-get -q -y install g++-mingw-w64-x86-64
+		;;
+
+	(i?86-linux-gnu)
+		# Install x86 libraries; remove anything that gets in the 
+		# way, and also Java because that would be upgraded and is
+		# quite large.
+		sudo apt-get -q -y install \
+			oracle-java7-installer- oracle-java8-installer- \
+			libglib2.0-dev- libglu1-mesa-dev- \
+			libgl1-mesa-dev:i386 libpulse-dev:i386 libglu1-mesa-dev:i386 \
+			libsdl2-dev:i386 libjpeg-turbo8-dev:i386 zlib1g-dev:i386 libc6-dev:i386 \
+			libpng12-dev:i386 \
+			g++-multilib g++ gcc cpp g++-4.8 gcc-4.8 g++-4.8-multilib
+		;;
+esac


### PR DESCRIPTION
This branch adds the metadata and scripts to build OpenJK for x86_64 Linux (with gcc and clang) and x86 and x86_64 Windows (with the mingw-w64 gcc toolchain), using [Travis-CI](https://travis-ci.org/). x86 Linux is supported but currently disabled, since it takes a few minutes of package installations to get Travis-CI's 3 year old Ubuntu setup into a state where it can produce 32-bit OpenJK binaries, so this build would lag behind the others.

See https://travis-ci.org/smcv/OpenJK for what the build results look like.

It is based on, and requires, my mingw branch (#688) for the mingw-w64 builds. I could disable those and only build for Linux if people really want that, but testing builds for both Windows and Linux seems better. At the moment, any branch in my clone https://github.com/smcv/OpenJK that contains a `/.travis.yml` (meaning just this one right now), and any pull request submitted to my clone (currently none), should get autobuilt by Travis-CI.

If one of the owners of the main OpenJK repository merges my branch, then links their github account to Travis-CI and enables Travis-CI integration for the main repository, the same things will happen. Apart from enabling Travis-CI for `smcv/OpenJK`, the only special setting I made through the web interface was "only build branches that contain .travis.yml" - the rest of the necessary information is in .travis.yml in the branch.

If you don't want Travis-CI hooked up to `JACoders/OpenJK`, it might be useful to merge something like this anyway, so contributors can easily enable it for their cloned repositories (and get a test-build attempted for Windows if they develop on Linux, or vice versa).