### PR TITLE
Fix buffer overflow in {SP,MP} ui_main.{c,cpp}.

### DIFF
--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -29,8 +29,9 @@ USER INTERFACE MAIN
 =======================================================================
 */
 
-// leave this at the top of all UI_xxxx files for PCH reasons...
-//
+#include <algorithm>
+#include <vector>
+
 #include "../server/exe_headers.h"
 
 #include "ui_local.h"
@@ -2396,11 +2397,13 @@ static void UI_BuildPlayerModel_List( qboolean inGameLoad )
 
 		if (f)
 		{
-			char buffer[2048];
-			playerSpeciesInfo_t *species;
-			ui.FS_Read(&buffer, filelen, f);
+			playerSpeciesInfo_t *species = NULL;
+
+			std::vector<char> buffer(filelen + 1);
+			ui.FS_Read(&buffer[0], filelen, f);
 			ui.FS_FCloseFile(f);
-			buffer[filelen] = 0;	//ensure trailing NULL
+
+			buffer[filelen] = 0;
 
 			//record this species
 			if (uiInfo.playerSpeciesCount >= uiInfo.playerSpeciesMax)
@@ -2412,7 +2415,7 @@ static void UI_BuildPlayerModel_List( qboolean inGameLoad )
 			memset(species, 0, sizeof(playerSpeciesInfo_t));
 			Q_strncpyz( species->Name, dirptr, MAX_QPATH, qtrue );
 
-			if (!UI_ParseColorData(buffer,*species))
+			if (!UI_ParseColorData(buffer.data(),*species))
 			{
 				ui.Printf( "UI_BuildPlayerModel_List: Errors parsing '%s'\n", fpath );
 			}

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -33,6 +33,8 @@ USER INTERFACE MAIN
 // use this to get a demo build without an explicit demo build, i.e. to get the demo ui files to build
 //#define PRE_RELEASE_TADEMO
 
+#include <stdlib.h>
+
 #include "ghoul2/G2.h"
 #include "ui_local.h"
 #include "qcommon/qfiles.h"
@@ -9674,15 +9676,22 @@ static void UI_BuildPlayerModel_List( qboolean inGameLoad )
 
 		if (f)
 		{
-			char buffer[2048];
 			playerSpeciesInfo_t *species;
-			char	skinname[64];
-			int		numfiles;
-			int		iSkinParts=0;
+			char                 skinname[64];
+			int                  numfiles;
+			int                  iSkinParts=0;
+			char                *buffer = NULL;
 
-			trap->FS_Read(&buffer, filelen, f);
+			buffer = malloc(filelen + 1);
+			if(!buffer)
+			{
+				Com_Error(ERR_FATAL, "Could not allocate buffer to read %s", fpath);
+			}
+
+			trap->FS_Read(buffer, filelen, f);
 			trap->FS_Close(f);
-			buffer[filelen] = 0;	//ensure trailing NULL
+
+			buffer[filelen] = 0;
 
 			//record this species
 			if (uiInfo.playerSpeciesCount >= uiInfo.playerSpeciesMax)
@@ -9706,6 +9715,8 @@ static void UI_BuildPlayerModel_List( qboolean inGameLoad )
 			species->SkinHead = (skinName_t *)malloc(species->SkinHeadMax * sizeof(skinName_t));
 			species->SkinTorso = (skinName_t *)malloc(species->SkinTorsoMax * sizeof(skinName_t));
 			species->SkinLeg = (skinName_t *)malloc(species->SkinLegMax * sizeof(skinName_t));
+
+			free(buffer);
 
 			numfiles = trap->FS_GetFileList( va("models/players/%s",dirptr), ".skin", filelist, 2048 );
 			fileptr  = filelist;


### PR DESCRIPTION
playerchoices.txt was being read into a fixed-size buffer without a
length check.  Now, we use a dynamic buffer as the destination.