### PR TITLE
Offer opt-out for user tracking functionality (ja_guid)

### DIFF
--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -513,6 +513,8 @@ void 	Cvar_WriteVariables( fileHandle_t f );
 // writes lines containing "set variable value" for all variables
 // with the archive flag set to true.
 
+cvar_t *Cvar_Unset(cvar_t *cv);
+
 void	Cvar_Init( void );
 
 char	*Cvar_InfoString( int bit );


### PR DESCRIPTION
### What does this PR address?
Since fd47854, OpenJK sends along a unique ID (`ja_guid`) as part of userinfo to servers, which identifies a player across game sessions and system restarts. It does this by generating a random 2KiB key file (`jakey`) on first run, then sending a hash of that file and the server address when connecting to a server. This is equivalent to [persistent cookies](https://en.wikipedia.org/wiki/HTTP_cookie#Persistent_cookie) on the World Wide Web.

The `ja_guid` tracking can be useful to server owners as they can log and analyse player behaviour over many sessions, even if the player changes their name while playing or before connecting. It can also provide a weak form of correlation to mod authors for logging per-player info such as K/D ratios and combat stats without having to write an accounts system into the mod. _(Please don't implement an admin system using `ja_guid` as the authentication method though)_

### What does this PR do?
This pull request offers players and hosts the choice to opt-out of the default tracking enabled in OpenJK, so that they will not be tracked across game sessions unless they choose to. Players can already identify themselves using their in-game names, and the `ja_guid` method doesn't provide any confidence of authenticity regardless.

The new cvar `cl_enableGuid` is used to toggle tracking functionality. As it's a cvar, players can change the tracking setting at runtime or on the command line. The code comes with tracking enabled by default, as is currently the behaviour in OpenJK.

#### Remarks
For some third-party package distributions, it may be desirable to have a compile-time define for setting whether tracking should be enabled/disabled by default (or not even compiled into the binary at all). I can look into that if it's needed.

_`jakey` files that have already been generated will be left alone._

***

What are your thoughts? :ear: