### PR TITLE
Fixed incorrectly treating vmMain as vararg

### DIFF
--- a/codemp/client/cl_cgameapi.cpp
+++ b/codemp/client/cl_cgameapi.cpp
@@ -215,7 +215,7 @@ qboolean CGVM_NoUseableForce( void ) {
 
 void CGVM_GetOrigin( int entID, vec3_t out ) {
 	if ( cgvm->isLegacy ) {
-		VM_Call( cgvm, CG_GET_ORIGIN, entID, out );
+		VM_Call( cgvm, CG_GET_ORIGIN, entID, reinterpret_cast< intptr_t >( out ) );
 		return;
 	}
 	VMSwap v( cgvm );
@@ -225,7 +225,7 @@ void CGVM_GetOrigin( int entID, vec3_t out ) {
 
 void CGVM_GetAngles( int entID, vec3_t out ) {
 	if ( cgvm->isLegacy ) {
-		VM_Call( cgvm, CG_GET_ANGLES, entID, out );
+		VM_Call( cgvm, CG_GET_ANGLES, entID, reinterpret_cast< intptr_t >( out ) );
 		return;
 	}
 	VMSwap v( cgvm );
@@ -253,7 +253,7 @@ trajectory_t *CGVM_GetAngleTrajectory( int entID ) {
 
 void CGVM_ROFF_NotetrackCallback( int entID, const char *notetrack ) {
 	if ( cgvm->isLegacy ) {
-		VM_Call( cgvm, CG_ROFF_NOTETRACK_CALLBACK, entID, notetrack );
+		VM_Call( cgvm, CG_ROFF_NOTETRACK_CALLBACK, entID, reinterpret_cast< intptr_t >( notetrack ) );
 		return;
 	}
 	VMSwap v( cgvm );

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -281,7 +281,7 @@ typedef struct vm_s {
 
 	// legacy stuff
 	struct {
-		intptr_t	(QDECL *main)( int callNum, ... );		// module vmMain
+		VMMainProc* main; // module vmMain
 		intptr_t	(QDECL *syscall)( intptr_t *parms );	// engine syscall handler
 	} legacy;
 } vm_t;
@@ -326,7 +326,7 @@ vm_t			*VM_Create( vmSlots_t vmSlot );
 void			 VM_Free( vm_t *vm );
 void			 VM_Clear(void);
 vm_t			*VM_Restart( vm_t *vm );
-intptr_t QDECL	 VM_Call( vm_t *vm, int callNum, ... );
+intptr_t QDECL	 VM_Call( vm_t *vm, int callNum, intptr_t arg0 = 0, intptr_t arg1 = 0, intptr_t arg2 = 0, intptr_t arg3 = 0, intptr_t arg4 = 0, intptr_t arg5 = 0, intptr_t arg6 = 0, intptr_t arg7 = 0, intptr_t arg8 = 0, intptr_t arg9 = 0, intptr_t arg10 = 0, intptr_t arg11 = 0 );
 void			 VM_Shifted_Alloc( void **ptr, int size );
 void			 VM_Shifted_Free( void **ptr );
 void			*VM_ArgPtr( intptr_t intValue );

--- a/codemp/qcommon/vm.cpp
+++ b/codemp/qcommon/vm.cpp
@@ -281,7 +281,7 @@ float _vmf( intptr_t x ) {
 	return fi.f;
 }
 
-intptr_t QDECL VM_Call( vm_t *vm, int callnum, ... ) {
+intptr_t QDECL VM_Call( vm_t *vm, int callnum, intptr_t arg0, intptr_t arg1, intptr_t arg2, intptr_t arg3, intptr_t arg4, intptr_t arg5, intptr_t arg6, intptr_t arg7, intptr_t arg8, intptr_t arg9, intptr_t arg10, intptr_t arg11 ) {
 	intptr_t args[16] = { 0 };
 
 	if ( !vm || !vm->name[0] ) {
@@ -291,13 +291,6 @@ intptr_t QDECL VM_Call( vm_t *vm, int callnum, ... ) {
 
 	VMSwap v( vm );
 
-	//rcg010207 -  see dissertation at top of VM_DllSyscall() in this file.
-	va_list ap;
-	va_start( ap, callnum );
-	for ( size_t i = 0; i < ARRAY_LEN( args ); i++ )
-		args[i] = va_arg( ap, intptr_t );
-	va_end( ap );
-
-	return vm->legacy.main( callnum, args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8],
-		args[9], args[10], args[11], args[12], args[13], args[14], args[15] );
+	return vm->legacy.main( callnum, arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8,
+		arg9, arg10, arg11 );
 }

--- a/codemp/server/sv_gameapi.cpp
+++ b/codemp/server/sv_gameapi.cpp
@@ -109,7 +109,7 @@ void GVM_ClientCommand( int clientNum ) {
 
 void GVM_ClientThink( int clientNum, usercmd_t *ucmd ) {
 	if ( gvm->isLegacy ) {
-		VM_Call( gvm, GAME_CLIENT_THINK, clientNum, ucmd );
+		VM_Call( gvm, GAME_CLIENT_THINK, clientNum, reinterpret_cast< intptr_t >( ucmd ) );
 		return;
 	}
 	VMSwap v( gvm );
@@ -145,7 +145,7 @@ int GVM_BotAIStartFrame( int time ) {
 
 void GVM_ROFF_NotetrackCallback( int entID, const char *notetrack ) {
 	if ( gvm->isLegacy ) {
-		VM_Call( gvm, GAME_ROFF_NOTETRACK_CALLBACK, entID, notetrack );
+		VM_Call( gvm, GAME_ROFF_NOTETRACK_CALLBACK, entID, reinterpret_cast< intptr_t >( notetrack ) );
 		return;
 	}
 	VMSwap v( gvm );
@@ -321,7 +321,7 @@ int GVM_ICARUS_GetSetIDForString( void ) {
 
 qboolean GVM_NAV_ClearPathToPoint( int entID, vec3_t pmins, vec3_t pmaxs, vec3_t point, int clipmask, int okToHitEnt ) {
 	if ( gvm->isLegacy )
-		return (qboolean)VM_Call( gvm, GAME_NAV_CLEARPATHTOPOINT, entID, pmins, pmaxs, point, clipmask, okToHitEnt );
+		return (qboolean)VM_Call( gvm, GAME_NAV_CLEARPATHTOPOINT, entID, reinterpret_cast< intptr_t >( pmins ), reinterpret_cast< intptr_t >( pmaxs ), reinterpret_cast< intptr_t >( point ), clipmask, okToHitEnt );
 	VMSwap v( gvm );
 
 	return ge->NAV_ClearPathToPoint( entID, pmins, pmaxs, point, clipmask, okToHitEnt );
@@ -329,7 +329,7 @@ qboolean GVM_NAV_ClearPathToPoint( int entID, vec3_t pmins, vec3_t pmaxs, vec3_t
 
 qboolean GVM_NPC_ClearLOS2( int entID, const vec3_t end ) {
 	if ( gvm->isLegacy )
-		return (qboolean)VM_Call( gvm, GAME_NAV_CLEARLOS, entID, end );
+		return (qboolean)VM_Call( gvm, GAME_NAV_CLEARLOS, entID, reinterpret_cast< intptr_t >( end ) );
 	VMSwap v( gvm );
 
 	return ge->NPC_ClearLOS2( entID, end );
@@ -337,7 +337,7 @@ qboolean GVM_NPC_ClearLOS2( int entID, const vec3_t end ) {
 
 int GVM_NAVNEW_ClearPathBetweenPoints( vec3_t start, vec3_t end, vec3_t mins, vec3_t maxs, int ignore, int clipmask ) {
 	if ( gvm->isLegacy )
-		return VM_Call( gvm, GAME_NAV_CLEARPATHBETWEENPOINTS, start, end, mins, maxs, ignore, clipmask );
+		return VM_Call( gvm, GAME_NAV_CLEARPATHBETWEENPOINTS, reinterpret_cast< intptr_t >( start ), reinterpret_cast< intptr_t >( end ), reinterpret_cast< intptr_t >( mins ), reinterpret_cast< intptr_t >( maxs ), ignore, clipmask );
 	VMSwap v( gvm );
 
 	return ge->NAVNEW_ClearPathBetweenPoints( start, end, mins, maxs, ignore, clipmask );

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -90,7 +90,7 @@ void	Sys_Init (void);
 
 // general development dll loading for virtual machine testing
 typedef void *GetGameAPIProc( void  *);
-typedef intptr_t QDECL VMMainProc( int, ... );
+typedef intptr_t QDECL VMMainProc( int, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t, intptr_t );
 typedef intptr_t QDECL SystemCallProc( intptr_t, ... );
 typedef void * QDECL GetModuleAPIProc( int, ... );
 


### PR DESCRIPTION
As mentioned in #719, `vmMain` is not a vararg function and should not be treated as one.

This is the easier fix of the issues mentioned in #719, there's still the matter of handling syscalls correctly.