### PR TITLE
Various fixes + partial 'equalization' between SP and MP

### DIFF
--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -1143,7 +1143,11 @@ void CL_InitRef( void ) {
 	RIT(SV_Trace);
 	RIT(S_RestartMusic);
 	RIT(Z_Free);
+#ifdef DEBUG_ZONE_ALLOCS
+	RIT(_D_Z_Malloc);
+#else
 	RIT(Z_Malloc);
+#endif
 	RIT(Z_MemSize);
 	RIT(Z_MorphMallocTag);
 

--- a/code/client/snd_dma.cpp
+++ b/code/client/snd_dma.cpp
@@ -5111,21 +5111,24 @@ static int SND_FreeSFXMem(sfx_t *sfx)
 
 		if (sfx->lipSyncData)
 		{
-			iBytesFreed +=	Z_Free(	sfx->lipSyncData);
+			iBytesFreed +=	Z_Size(	sfx->lipSyncData);
+							Z_Free(	sfx->lipSyncData);
 									sfx->lipSyncData = NULL;
 		}
 	}
 #endif
 
 	if (						sfx->pSoundData) {
-		iBytesFreed +=	Z_Free(	sfx->pSoundData );
+		iBytesFreed +=	Z_Size(	sfx->pSoundData);
+						Z_Free(	sfx->pSoundData );
 								sfx->pSoundData = NULL;
 	}
 
 	sfx->bInMemory = false;	
 
 	if (						sfx->pMP3StreamHeader) {
-		iBytesFreed +=	Z_Free(	sfx->pMP3StreamHeader );
+		iBytesFreed +=	Z_Size(	sfx->pMP3StreamHeader);
+						Z_Free(	sfx->pMP3StreamHeader );
 								sfx->pMP3StreamHeader = NULL;
 	}
 

--- a/code/game/CMakeLists.txt
+++ b/code/game/CMakeLists.txt
@@ -358,7 +358,7 @@ if(WIN32)
 	set(SPGameFiles ${SPGameFiles} ${SPGameWin32Files})
 endif(WIN32)
 
-add_library(${SPGame} SHARED ${SPGameFiles})
+add_library(${SPGame} MODULE ${SPGameFiles})
 
 # Hide symbols not explicitly marked public.
 set_property(TARGET ${SPGame} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
@@ -370,7 +370,7 @@ endif()
 
 if(WIN32)
 	install(TARGETS ${SPGame}
-		RUNTIME
+		LIBRARY
 		DESTINATION "${JKAInstallDir}/OpenJK"
 		COMPONENT ${JKASPClientComponent})
 else(WIN32)

--- a/code/game/NPC_move.cpp
+++ b/code/game/NPC_move.cpp
@@ -624,7 +624,7 @@ NPC_CheckCombatMove
 -------------------------
 */
 
-inline qboolean NPC_CheckCombatMove( void )
+QINLINE qboolean NPC_CheckCombatMove( void )
 {
 	//return NPCInfo->combatMove;
 	if ( ( NPCInfo->goalEntity && NPC->enemy && NPCInfo->goalEntity == NPC->enemy ) || ( NPCInfo->combatMove ) )
@@ -672,7 +672,7 @@ NPC_GetMoveInformation
 -------------------------
 */
 
-inline qboolean NPC_GetMoveInformation( vec3_t dir, float *distance )
+static QINLINE qboolean NPC_GetMoveInformation( vec3_t dir, float *distance )
 {
 	//NOTENOTE: Use path stacks!
 

--- a/code/game/g_public.h
+++ b/code/game/g_public.h
@@ -252,7 +252,7 @@ typedef struct {
 
 	// dynamic memory allocator for things that need to be freed
 	void		*(*Malloc)( int iSize, memtag_t eTag, qboolean bZeroIt);	// see qcommon/tags.h for choices
-	int			(*Free)( void *buf );
+	void		(*Free)( void *buf );
 	qboolean	(*bIsFromZone)( const void *buf, memtag_t eTag);	// see qcommon/tags.h for choices
 
 /*

--- a/code/qcommon/cm_patch.cpp
+++ b/code/qcommon/cm_patch.cpp
@@ -1023,7 +1023,7 @@ static void CM_PatchCollideFromGrid( cGrid_t *grid, patchCollide_t *pf ) {
 	int				noAdjust[4];
 
 	int numFacets;
-	facets = (facet_t*) Z_Malloc(MAX_FACETS*sizeof(facet_t), TAG_TEMP_WORKSPACE, qfalse, 4);
+	facets = (facet_t*) Z_Malloc(MAX_FACETS*sizeof(facet_t), TAG_TEMP_WORKSPACE, qfalse);
 
 	numPlanes = 0;
 	numFacets = 0;

--- a/code/qcommon/cm_public.h
+++ b/code/qcommon/cm_public.h
@@ -26,7 +26,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include "qfiles.h"
 
-qboolean CM_DeleteCachedMap(qboolean bGuaranteedOkToDelete);
+qboolean	CM_DeleteCachedMap(qboolean bGuaranteedOkToDelete);
 void		CM_LoadMap( const char *name, qboolean clientload, int *checksum, qboolean subBSP);
 void		CM_ClearMap( void );
 int			CM_TotalMapContents();

--- a/code/qcommon/common.cpp
+++ b/code/qcommon/common.cpp
@@ -1066,13 +1066,13 @@ static void Com_CatchError ( int code )
 Com_Init
 =================
 */
-extern void Com_InitZoneMemory();
 void Com_Init( char *commandLine ) {
 	char	*s;
 
 	Com_Printf( "%s %s %s\n", Q3_VERSION, PLATFORM_STRING, __DATE__ );
 
 	try {
+		Com_InitZoneMemory();
 		Cvar_Init ();
 
 		// prepare enough of the subsystems to handle
@@ -1082,8 +1082,7 @@ void Com_Init( char *commandLine ) {
 		//Swap_Init ();
 		Cbuf_Init ();
 
-		Com_InitZoneMemory();
-
+		Com_InitZoneMemoryVars();
 		Cmd_Init ();
 
 		// override anything from the config files with command line args

--- a/code/qcommon/files.cpp
+++ b/code/qcommon/files.cpp
@@ -29,11 +29,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
  *
  *****************************************************************************/
 
-#include "q_shared.h"
-#include "qcommon.h"
+#include "qcommon/qcommon.h"
 
 #ifndef FINAL_BUILD
-#include "../client/client.h"
+#include "client/client.h"
 #endif
 #include <minizip/unzip.h>
 
@@ -275,6 +274,10 @@ static fileHandleData_t	fsh[MAX_FILE_HANDLES];
 // last valid game folder used
 char lastValidBase[MAX_OSPATH];
 char lastValidGame[MAX_OSPATH];
+
+#ifdef FS_MISSING
+FILE*		missingFiles = NULL;
+#endif
 
 /* C99 defines __func__ */
 #if __STDC_VERSION__ < 199901L
@@ -1473,6 +1476,11 @@ long FS_FOpenFileRead( const char *filename, fileHandle_t *file, qboolean unique
 	while ( bFasterToReOpenUsingNewLocalFile );
 
 	Com_DPrintf ("Can't find %s\n", filename);
+#ifdef FS_MISSING
+	if (missingFiles) {
+		fprintf(missingFiles, "%s\n", filename);
+	}
+#endif
 	*file = 0;
 	return -1;
 }
@@ -2873,6 +2881,12 @@ void FS_Shutdown( void ) {
 	Cmd_RemoveCommand( "fdir" );
 	Cmd_RemoveCommand( "touchFile" );
 	Cmd_RemoveCommand( "which" );
+
+#ifdef FS_MISSING
+	if (closemfp) {
+		fclose(missingFiles);
+	}
+#endif
 }
 
 /*
@@ -2965,6 +2979,14 @@ void FS_Startup( const char *gameName ) {
 	fs_gamedirvar->modified = qfalse; // We just loaded, it's not modified
 
 	Com_Printf( "----------------------\n" );
+
+#ifdef FS_MISSING
+	if (missingFiles == NULL) {
+		char filename[MAX_OSPATH];
+		Com_sprintf(filename, sizeof(filename), "%s/%s", homePath, "missing.log");
+		missingFiles = fopen( filename, "ab" );
+	}
+#endif
 	Com_Printf( "%d files in pk3 files\n", fs_packFiles );
 }
 

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -667,10 +667,10 @@ temp file loading
 
 */
 
-int  Z_Validate( void );			// also used to insure all of these are paged in
+void  Z_Validate( void );			// also used to insure all of these are paged in
 int   Z_MemSize	( memtag_t eTag );
 void  Z_TagFree	( memtag_t eTag );
-int   Z_Free	( void *ptr );	//returns bytes freed
+void   Z_Free	( void *ptr );	//returns bytes freed
 int	  Z_Size	( void *pvAddress);
 void  Z_MorphMallocTag( void *pvAddress, memtag_t eDesiredTag );
 qboolean Z_IsFromZone(const void *pvAddress, memtag_t eTag);	//returns size if true

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -26,10 +26,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #ifndef __QCOMMON_H__
 #define __QCOMMON_H__
 
-#include "q_shared.h"
+#include "qcommon/q_shared.h"
 #include "stringed_ingame.h"
 #include "strippublic.h"
-#include "cm_public.h"
+#include "qcommon/cm_public.h"
 #include "sys/sys_public.h"
 
 

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -666,6 +666,7 @@ temp file loading
 --- high memory ---
 
 */
+
 int  Z_Validate( void );			// also used to insure all of these are paged in
 int   Z_MemSize	( memtag_t eTag );
 void  Z_TagFree	( memtag_t eTag );
@@ -676,22 +677,19 @@ qboolean Z_IsFromZone(const void *pvAddress, memtag_t eTag);	//returns size if t
 
 #ifdef DEBUG_ZONE_ALLOCS
 
-	void *_D_Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, const char *psFile, int iLine );
-	void *_D_S_Malloc ( int iSize, const char *psFile, int iLine );	
-	void  _D_Z_Label  ( const void *pvAddress, const char *pslabel );
+void *_D_Z_Malloc( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign, const char *psFile, int iLine );
+void *_D_S_Malloc( int iSize, const char *psFile, int iLine );
+void  _D_Z_Label( const void *pvAddress, const char *pslabel );
 
-	#define Z_Malloc(_iSize, _eTag, _bZeroit)	_D_Z_Malloc (_iSize, _eTag, _bZeroit, __FILE__, __LINE__)
-	#define S_Malloc(_iSize)					_D_S_Malloc	(_iSize, __FILE__, __LINE__)	// NOT 0 filled memory only for small allocations	
-	
-	#define Z_Label(_ptr, _label)				_D_Z_Label	(_ptr, _label)
+#define Z_Malloc(_iSize, _eTag, _bZeroit)	_D_Z_Malloc (_iSize, _eTag, _bZeroit, 4, __FILE__, __LINE__)
+#define S_Malloc(_iSize)			_D_S_Malloc	(_iSize, __FILE__, __LINE__)	// NOT 0 filled memory only for small allocations
+#define Z_Label(_ptr, _label)			_D_Z_Label	(_ptr, _label)
 
 #else
 
-	void *Z_Malloc  ( int iSize, memtag_t eTag, qboolean bZeroit = qfalse, int iAlign = 4);	// return memory NOT zero-filled by default
-	void *S_Malloc	( int iSize );									// NOT 0 filled memory only for small allocations
-
-	#define Z_Label(_ptr, _label)	/* */
-
+void *Z_Malloc( int iSize, memtag_t eTag, qboolean bZeroit = qfalse, int iAlign = 4);	// return memory NOT zero-filled by default
+void *S_Malloc( int iSize );									// NOT 0 filled memory only for small allocations
+#define Z_Label(_ptr, _label)
 #endif
 
 void Com_InitZoneMemory(void);

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -694,6 +694,8 @@ qboolean Z_IsFromZone(const void *pvAddress, memtag_t eTag);	//returns size if t
 
 #endif
 
+void Com_InitZoneMemory(void);
+void Com_InitZoneMemoryVars(void);
 
 void Hunk_Clear( void );
 void Hunk_ClearToMark( void );

--- a/code/qcommon/z_memman_pc.cpp
+++ b/code/qcommon/z_memman_pc.cpp
@@ -177,14 +177,14 @@ int Z_Validate(void)
 #pragma pack(1)
 typedef struct
 {
-	zoneHeader_t	Header;	
+	zoneHeader_t	Header;
 //	byte mem[0];
 	zoneTail_t		Tail;
 } StaticZeroMem_t;
 
 typedef struct
 {
-	zoneHeader_t	Header;	
+	zoneHeader_t	Header;
 	byte mem[2];
 	zoneTail_t		Tail;
 } StaticMem_t;
@@ -709,12 +709,11 @@ static void Z_Details_f(void)
 			float	fSize		= (float)(iThisSize) / 1024.0f / 1024.0f;
 			int		iSize		= fSize;
 			int		iRemainder 	= 100.0f * (fSize - floor(fSize));
-			Com_Printf("%20s %9d (%2d.%02dMB) in %6d blocks (%9d Bytes/block)\n", 
-					    psTagStrings[i], 
-							  iThisSize, 
-								iSize,iRemainder,
-								           iThisCount, iThisSize / iThisCount
-					   );
+			Com_Printf("%20s %9d (%2d.%02dMB) in %6d blocks (%9d Bytes/block)\n",
+				psTagStrings[i],
+				iThisSize,
+				iSize, iRemainder,
+				iThisCount, iThisSize / iThisCount);
 		}
 	}
 	Com_Printf("---------------------------------------------------------------------------\n");
@@ -910,7 +909,10 @@ void Com_InitZoneMemory( void )
 
 	memset(&TheZone, 0, sizeof(TheZone)); 
 	TheZone.Header.iMagic = ZONE_MAGIC;
+}
 
+void Com_InitZoneMemoryVars( void)
+{
 	com_validateZone = Cvar_Get("com_validateZone", "0", 0);
 
 	Cmd_AddCommand("zone_stats",	Z_Stats_f);
@@ -919,7 +921,6 @@ void Com_InitZoneMemory( void )
 #ifdef _DEBUG
 	Cmd_AddCommand("zone_memrecovertest", Z_MemRecoverTest_f);
 #endif
-
 
 #ifdef DEBUG_ZONE_ALLOCS
 	Cmd_AddCommand("zone_tagdebug",	Z_TagDebug_f);

--- a/code/qcommon/z_memman_pc.cpp
+++ b/code/qcommon/z_memman_pc.cpp
@@ -24,9 +24,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include "q_shared.h"
 #include "qcommon.h"
-#include "sstring.h"
 
 #ifdef DEBUG_ZONE_ALLOCS
+#include "sstring.h"
 int giZoneSnaphotNum=0;
 #define DEBUG_ZONE_ALLOC_OPTIONAL_LABEL_SIZE 256
 typedef sstring<DEBUG_ZONE_ALLOC_OPTIONAL_LABEL_SIZE> sDebugString_t;
@@ -81,7 +81,7 @@ static inline zoneTail_t *ZoneTailFromHeader(zoneHeader_t *pHeader)
 }
 
 #ifdef DETAILED_ZONE_DEBUG_CODE
-map <void*,int> mapAllocatedZones;
+std::map <void*,int> mapAllocatedZones;
 #endif
 
 
@@ -215,15 +215,40 @@ const static StaticMem_t gNumberString[] = {
 	{ DEF_STATIC('9') },
 };
 
-qboolean gbMemFreeupOccured = qfalse;
+#ifdef DEBUG_ZONE_ALLOCS
+// returns actual filename only, no path
+// (copes with either slash-scheme for names)
+//
+// (normally I'd call another function for this, but this is supposed to be engine-independent,
+//	 so a certain amount of re-invention of the wheel is to be expected...)
+//
+char *_D_Z_Filename_WithoutPath(const char *psFilename)
+{
+	static char sString[ MAX_QPATH ];
+
+	const char *psCopyPos = psFilename;
+
+	while (*psFilename)
+	{
+		if (*psFilename == PATH_SEP)
+			psCopyPos = psFilename+1;
+		psFilename++;
+	}
+
+	strcpy(sString,psCopyPos);
+
+	return sString;
+}
+#endif
 
 #include "../rd-common/tr_public.h"	// sorta hack sorta not
 extern refexport_t re;
 
+qboolean gbMemFreeupOccured = qfalse;
 #ifdef DEBUG_ZONE_ALLOCS
-void *_D_Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, const char *psFile, int iLine)
+void *_D_Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/, const char *psFile, int iLine)
 #else
-void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int unusedAlign)
+void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 #endif
 {	
 	gbMemFreeupOccured = qfalse;
@@ -335,11 +360,8 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int unusedAlign)
 		}
 	}
 
-
 #ifdef DEBUG_ZONE_ALLOCS
-	extern char *Filename_WithoutPath(const char *psFilename);
-
-	Q_strncpyz(pMemory->sSrcFileBaseName, Filename_WithoutPath(psFile), sizeof(pMemory->sSrcFileBaseName));
+	Q_strncpyz(pMemory->sSrcFileBaseName, _D_Z_Filename_WithoutPath(psFile), sizeof(pMemory->sSrcFileBaseName));
 	pMemory->iSrcFileLineNum	= iLine;	
 	pMemory->sOptionalLabel[0]	= '\0';
 	pMemory->iSnapshotNumber	= giZoneSnaphotNum;
@@ -523,7 +545,6 @@ int Z_Size(void *pvAddress)
 	return pMemory->iSize;
 }
 
-
 #ifdef DEBUG_ZONE_ALLOCS
 void _D_Z_Label(const void *pvAddress, const char *psLabel)
 {
@@ -543,8 +564,6 @@ void _D_Z_Label(const void *pvAddress, const char *psLabel)
 				pMemory->sOptionalLabel[ sizeof(pMemory->sOptionalLabel)-1 ] = '\0';
 }
 #endif
-
-
 
 // Frees a block of memory...
 //
@@ -632,11 +651,10 @@ void Z_TagFree(memtag_t eTag)
 //#endif
 }
 
-
 #ifdef DEBUG_ZONE_ALLOCS
 void *_D_S_Malloc ( int iSize, const char *psFile, int iLine)
 {
-	return _D_Z_Malloc( iSize, TAG_SMALL, qfalse, psFile, iLine );
+	return _D_Z_Malloc( iSize, TAG_SMALL, qfalse, 4, psFile, iLine );
 }
 #else
 void *S_Malloc( int iSize ) 
@@ -722,11 +740,11 @@ static void Z_Details_f(void)
 }
 
 #ifdef DEBUG_ZONE_ALLOCS
-#pragma warning (disable:4503)	// decorated name length xceeded, name was truncated
-typedef map <sDebugString_t,int> LabelRefCount_t;	// yet another place where Gil's tring class works and MS's doesn't
-typedef map <sDebugString_t,LabelRefCount_t>	TagBlockLabels_t;
-										TagBlockLabels_t AllTagBlockLabels;
-#pragma warning (disable:4503)	// decorated name length xceeded, name was truncated
+typedef std::map <sDebugString_t, int> LabelRefCount_t;	// yet another place where Gil's string class works and MS's doesn't
+typedef std::map <sDebugString_t, LabelRefCount_t>	TagBlockLabels_t;
+
+static TagBlockLabels_t AllTagBlockLabels;
+
 static void Z_Snapshot_f(void)
 {	
 	AllTagBlockLabels.clear();

--- a/code/qcommon/z_memman_pc.cpp
+++ b/code/qcommon/z_memman_pc.cpp
@@ -22,8 +22,8 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // Created 2/3/03 by Brian Osman - split Zone code from common.cpp
 
-#include "q_shared.h"
 #include "qcommon.h"
+#include "client/client.h"
 
 #ifdef DEBUG_ZONE_ALLOCS
 #include "sstring.h"
@@ -51,25 +51,22 @@ static const char *psTagStrings[TAG_COUNT+1]=	// +1 because TAG_COUNT will itsel
 #define ZONE_MAGIC			0x21436587
 
 // if you change ANYTHING in this structure, be sure to update the tables below using DEF_STATIC...
-//
 typedef struct zoneHeader_s
 {
-		int					iMagic;
+		int				iMagic;
 		memtag_t			eTag;
-		int					iSize;
-struct	zoneHeader_s		*pNext;
-struct	zoneHeader_s		*pPrev;
-
+		int				iSize;
+		struct zoneHeader_s		*pNext;
+		struct zoneHeader_s		*pPrev;
 #ifdef DEBUG_ZONE_ALLOCS
 		char				sSrcFileBaseName[MAX_QPATH];
-		int					iSrcFileLineNum;
+		int				iSrcFileLineNum;
 		char				sOptionalLabel[DEBUG_ZONE_ALLOC_OPTIONAL_LABEL_SIZE];
-		int					iSnapshotNumber;
+		int				iSnapshotNumber;
 #endif
-
 } zoneHeader_t;
 
-typedef struct 
+typedef struct
 {
 	int iMagic;
 
@@ -84,7 +81,6 @@ static inline zoneTail_t *ZoneTailFromHeader(zoneHeader_t *pHeader)
 std::map <void*,int> mapAllocatedZones;
 #endif
 
-
 typedef struct zoneStats_s
 {
 	size_t		iCurrent;
@@ -94,8 +90,8 @@ typedef struct zoneStats_s
 	// I'm keeping these updated on the fly, since it's quicker for cache-pool
 	//	purposes rather than recalculating each time...
 	//
-	int		iSizesPerTag [TAG_COUNT];	
-	int		iCountsPerTag[TAG_COUNT];	
+	int		iSizesPerTag [TAG_COUNT];
+	int		iCountsPerTag[TAG_COUNT];
 
 } zoneStats_t;
 
@@ -109,13 +105,10 @@ cvar_t	*com_validateZone;
 
 zone_t	TheZone = {};
 
-
-
-
 // Scans through the linked list of mallocs and makes sure no data has been overwritten
 
 int Z_Validate(void)
-{	
+{
 	int ret=0;
 	if(!com_validateZone || !com_validateZone->integer)
 	{
@@ -132,7 +125,7 @@ int Z_Validate(void)
 		{
 			Com_Error(ERR_FATAL, "Z_Validate(): Bad block allocation count!");
 			return ret;
-		}		   
+		}
 		#endif
 
 		if(pMemory->iMagic != ZONE_MAGIC)
@@ -142,10 +135,10 @@ int Z_Validate(void)
 		}
 
 		// this block of code is intended to make sure all of the data is paged in
-		if (pMemory->eTag != TAG_IMAGE_T 
-			&& pMemory->eTag != TAG_MODEL_MD3 
-			&& pMemory->eTag != TAG_MODEL_GLM 
-			&& pMemory->eTag != TAG_MODEL_GLA )	//don't bother with disk caches as they've already been hit or will be thrown out next 
+		if (pMemory->eTag != TAG_IMAGE_T
+			&& pMemory->eTag != TAG_MODEL_MD3
+			&& pMemory->eTag != TAG_MODEL_GLM
+			&& pMemory->eTag != TAG_MODEL_GLA )	//don't bother with disk caches as they've already been hit or will be thrown out next
 		{
 			unsigned char *memstart = (unsigned char *)pMemory;
 			int totalSize = pMemory->iSize;
@@ -163,26 +156,24 @@ int Z_Validate(void)
 			Com_Error(ERR_FATAL, "Z_Validate(): Corrupt zone tail!");
 			return ret;
 		}
-		
+
 		pMemory = pMemory->pNext;
 	}
 	return ret;
 }
-				
-
 
 // static mem blocks to reduce a lot of small zone overhead
 //
 #pragma pack(push)
 #pragma pack(1)
-typedef struct
+typedef struct StaticZeroMem_s
 {
 	zoneHeader_t	Header;
 //	byte mem[0];
 	zoneTail_t		Tail;
 } StaticZeroMem_t;
 
-typedef struct
+typedef struct StaticMem_s
 {
 	zoneHeader_t	Header;
 	byte mem[2];
@@ -241,9 +232,6 @@ char *_D_Z_Filename_WithoutPath(const char *psFilename)
 }
 #endif
 
-#include "../rd-common/tr_public.h"	// sorta hack sorta not
-extern refexport_t re;
-
 qboolean gbMemFreeupOccured = qfalse;
 #ifdef DEBUG_ZONE_ALLOCS
 void *_D_Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/, const char *psFile, int iLine)
@@ -260,9 +248,8 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 		return &pMemory[1];
 	}
 
-	// Add in tracking info and round to a longword...  (ignore longword aligning now we're not using contiguous blocks)
+	// Add in tracking info
 	//
-//	int iRealSize = (iSize + sizeof(zoneHeader_t) + sizeof(zoneTail_t) + 3) & 0xfffffffc;
 	int iRealSize = (iSize + sizeof(zoneHeader_t) + sizeof(zoneTail_t));
 
 	// Allocate a chunk...
@@ -309,7 +296,7 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 			}
 
 
-			// ditch any image_t's (and associated GL texture mem) not used on this level...
+			// ditch any image_t's (and associated GL texture memory) not used on this level...
 			//
 			if (re.RegisterImages_LevelLoadEnd())
 			{
@@ -326,23 +313,23 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 				continue;
 			}
 
-			// as a last panic measure, dump all the audio memory, but not if we're in the audio loader 
+			// as a last panic measure, dump all the audio memory, but not if we're in the audio loader
 			//	(which is annoying, but I'm not sure how to ensure we're not dumping any memory needed by the sound
 			//	currently being loaded if that was the case)...
 			//
 			// note that this keeps querying until it's freed up as many bytes as the requested size, but freeing
 			//	several small blocks might not mean that one larger one is satisfiable after freeup, however that'll
-			//	just make it go round again and try for freeing up another bunch of blocks until the total is satisfied 
-			//	again (though this will have freed twice the requested amount in that case), so it'll either work 
+			//	just make it go round again and try for freeing up another bunch of blocks until the total is satisfied
+			//	again (though this will have freed twice the requested amount in that case), so it'll either work
 			//	eventually or not free up enough and drop through to the final ERR_DROP. No worries...
 			//
-			extern qboolean gbInsideLoadSound;			
-			extern int SND_FreeOldestSound(void);	// I had to add a void-arg version of this because of link issues, sigh
+			extern qboolean gbInsideLoadSound;
+			extern int SND_FreeOldestSound();
 			if (!gbInsideLoadSound)
 			{
 				int iBytesFreed = SND_FreeOldestSound();
 				if (iBytesFreed)
-				{						
+				{
 					int iTheseBytesFreed = 0;
 					while ( (iTheseBytesFreed = SND_FreeOldestSound()) != 0)
 					{
@@ -374,7 +361,7 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 
 #ifdef DEBUG_ZONE_ALLOCS
 	Q_strncpyz(pMemory->sSrcFileBaseName, _D_Z_Filename_WithoutPath(psFile), sizeof(pMemory->sSrcFileBaseName));
-	pMemory->iSrcFileLineNum	= iLine;	
+	pMemory->iSrcFileLineNum	= iLine;
 	pMemory->sOptionalLabel[0]	= '\0';
 	pMemory->iSnapshotNumber	= giZoneSnaphotNum;
 #endif
@@ -382,7 +369,7 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 	// Link in
 	pMemory->iMagic	= ZONE_MAGIC;
 	pMemory->eTag	= eTag;
-	pMemory->iSize	= iSize;	
+	pMemory->iSize	= iSize;
 	pMemory->pNext  = TheZone.Header.pNext;
 	TheZone.Header.pNext = pMemory;
 	if (pMemory->pNext)
@@ -400,7 +387,7 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 	TheZone.Stats.iCurrent += iSize;
 	TheZone.Stats.iCount++;
 	TheZone.Stats.iSizesPerTag	[eTag] += iSize;
-	TheZone.Stats.iCountsPerTag	[eTag]++;	
+	TheZone.Stats.iCountsPerTag	[eTag]++;
 
 	if (TheZone.Stats.iCurrent > TheZone.Stats.iPeak)
 	{
@@ -410,7 +397,6 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 #ifdef DETAILED_ZONE_DEBUG_CODE
 	mapAllocatedZones[pMemory]++;
 #endif
-	
 	Z_Validate();	// check for corruption
 
 	void *pvReturnMem = &pMemory[1];
@@ -465,7 +451,6 @@ void Z_MorphMallocTag( void *pvAddress, memtag_t eDesiredTag )
 	TheZone.Stats.iCountsPerTag	[pMemory->eTag]++;
 }
 
-
 static int Zone_FreeBlock(zoneHeader_t *pMemory)
 {
 	const int iSize = pMemory->iSize;
@@ -490,13 +475,14 @@ static int Zone_FreeBlock(zoneHeader_t *pMemory)
 		{
 			pMemory->pNext->pPrev = pMemory->pPrev;
 		}
-		
+
+#ifdef _DEBUG
 		//debugging double frees
 		pMemory->iMagic = INT_ID('F','R','E','E');
+#endif
 		free (pMemory);
 
-		
-		#ifdef DETAILED_ZONE_DEBUG_CODE
+#ifdef DETAILED_ZONE_DEBUG_CODE
 		// this has already been checked for in execution order, but wtf?
 		int& iAllocCount = mapAllocatedZones[pMemory];
 		if (iAllocCount == 0)
@@ -504,8 +490,8 @@ static int Zone_FreeBlock(zoneHeader_t *pMemory)
 			Com_Error(ERR_FATAL, "Zone_FreeBlock(): Double-freeing block!");
 			return -1;
 		}
-		iAllocCount--;	
-		#endif
+		iAllocCount--;
+#endif
 	}
 	return iSize;
 }
@@ -515,10 +501,11 @@ static int Zone_FreeBlock(zoneHeader_t *pMemory)
 qboolean Z_IsFromZone(const void *pvAddress, memtag_t eTag)
 {
 	const zoneHeader_t *pMemory = ((const zoneHeader_t *)pvAddress) - 1;
-#if 1	//debugging double free
+#ifdef _DEBUG
+	//debugging double free
 	if (pMemory->iMagic == INT_ID('F','R','E','E'))
 	{
-		Com_Printf("Z_IsFromZone(%x): Ptr has been freed already!(%9s)\n",pvAddress,pvAddress);
+		Com_Printf("Z_IsFromZone(%x): Ptr has been freed already!(%9s)\n", pvAddress, pvAddress);
 		return qfalse;
 	}
 #endif
@@ -580,16 +567,20 @@ void _D_Z_Label(const void *pvAddress, const char *psLabel)
 //
 int Z_Free(void *pvAddress)
 {
+	if (pvAddress == NULL)
+	{
+		//Com_Error(ERR_FATAL, "Z_Free(): NULL arg");
+		return -1;
+	}
 	if (!TheZone.Stats.iCount)
 	{
-		//Com_Error(ERR_FATAL, "Z_Free(): Zone has been cleard already!");
-		Com_Printf("Z_Free(%x): Zone has been cleard already!\n",pvAddress);
+		Com_Printf("Z_Free(%x): Zone has been cleared already!\n",pvAddress);
 		return -1;
 	}
 
 	zoneHeader_t *pMemory = ((zoneHeader_t *)pvAddress) - 1;
 
-#if 1	//debugging double free
+#ifdef _DEBUG
 	if (pMemory->iMagic == INT_ID('F','R','E','E'))
 	{
 		Com_Error(ERR_FATAL, "Z_Free(%s): Block already-freed, or not allocated through Z_Malloc!",pvAddress);
@@ -608,10 +599,10 @@ int Z_Free(void *pvAddress)
 	//
 	int& iAllocCount = mapAllocatedZones[pMemory];
 	if (iAllocCount <= 0)
-	{			
+	{
 		Com_Error(ERR_FATAL, "Z_Free(): Block already-freed, or not allocated through Z_Malloc!");
 		return -1;
-	}		   
+	}
 	#endif
 
 	if (pMemory->iMagic != ZONE_MAGIC)
@@ -668,7 +659,7 @@ void *_D_S_Malloc ( int iSize, const char *psFile, int iLine)
 	return _D_Z_Malloc( iSize, TAG_SMALL, qfalse, 4, psFile, iLine );
 }
 #else
-void *S_Malloc( int iSize ) 
+void *S_Malloc( int iSize )
 {
 	return Z_Malloc( iSize, TAG_SMALL, qfalse);
 }
@@ -695,7 +686,7 @@ static void Z_MemRecoverTest_f(void)
 	}
 	size_t origLimit = Sys_LimitAvailableMemory(fgb * 1024 * 1024 * 1024);
 	size_t iTotalMalloc = 0;
-	gbMemFreeupOccured = 0;
+	gbMemFreeupOccured = qfalse;
 	while (1)
 	{
 		int iThisMalloc = 5 * (1024 * 1024);
@@ -723,22 +714,20 @@ static void Z_MemRecoverTest_f(void)
 static void Z_Stats_f(void)
 {
 	Com_Printf("\nThe zone is using %ld bytes (%.2fMB) in %d memory blocks\n",
-								  TheZone.Stats.iCurrent, 
-									        (float)TheZone.Stats.iCurrent / 1024.0f / 1024.0f, 
-													  TheZone.Stats.iCount
+								TheZone.Stats.iCurrent,
+								TheZone.Stats.iCurrent / 1024.0f / 1024.0f,
+								TheZone.Stats.iCount
 				);
 
 	Com_Printf("The zone peaked at %ld bytes (%.2fMB)\n",
-									TheZone.Stats.iPeak, 
-									         (float)TheZone.Stats.iPeak / 1024.0f / 1024.0f
+								TheZone.Stats.iPeak,
+								TheZone.Stats.iPeak / 1024.0f / 1024.0f
 				);
 }
 
 // Gives a detailed breakdown of the memory blocks in the zone
-//
 static void Z_Details_f(void)
 {
-
 	Com_Printf("---------------------------------------------------------------------------\n");
 	Com_Printf("%20s %9s\n","Zone Tag","Bytes");
 	Com_Printf("%20s %9s\n","--------","-----");
@@ -749,13 +738,13 @@ static void Z_Details_f(void)
 
 		if (iThisCount)
 		{
-			// can you believe that using %2.2f as a format specifier doesn't bloody work? 
+			// can you believe that using %2.2f as a format specifier doesn't bloody work?
 			//	It ignores the left-hand specifier. Sigh, now I've got to do shit like this...
 			//
 			float	fSize		= (float)(iThisSize) / 1024.0f / 1024.0f;
 			int		iSize		= fSize;
 			int		iRemainder 	= 100.0f * (fSize - floor(fSize));
-			Com_Printf("%20s %9d (%2d.%02dMB) in %6d blocks (%9d Bytes/block)\n",
+			Com_Printf("%20s %9d (%2d.%02dMB) in %6d blocks (%9d bytes/block)\n",
 				psTagStrings[i],
 				iThisSize,
 				iSize, iRemainder,
@@ -774,14 +763,14 @@ typedef std::map <sDebugString_t, LabelRefCount_t>	TagBlockLabels_t;
 static TagBlockLabels_t AllTagBlockLabels;
 
 static void Z_Snapshot_f(void)
-{	
+{
 	AllTagBlockLabels.clear();
 
 	zoneHeader_t *pMemory = TheZone.Header.pNext;
 	while (pMemory)
 	{
 		AllTagBlockLabels[psTagStrings[pMemory->eTag]][pMemory->sOptionalLabel]++;
-		pMemory = pMemory->pNext;		
+		pMemory = pMemory->pNext;
 	}
 
 	giZoneSnaphotNum++;
@@ -806,7 +795,7 @@ static void Z_TagDebug_f(void)
 
 			AllTagBlockLabels_Local = AllTagBlockLabels;	// horrible great STL copy
 
-			psTAGName = Cmd_Argv(2);			
+			psTAGName = Cmd_Argv(2);
 		}
 
 		if (psTAGName[0])
@@ -863,7 +852,7 @@ static void Z_TagDebug_f(void)
 			{
 				AllTagBlockLabels_Local[psTagStrings[pMemory->eTag]][pMemory->sOptionalLabel]--;
 			}
-			pMemory = pMemory->pNext;		
+			pMemory = pMemory->pNext;
 		}
 	}
 
@@ -890,9 +879,9 @@ static void Z_TagDebug_f(void)
 			}
 
 			Com_Printf(" %9d (%2d.%02dMB) File: \"%s\", Line: %d\n",
-						  pMemory->iSize,
- 							  iSize,iRemainder,
-												pMemory->sSrcFileBaseName,
+						pMemory->iSize,
+						iSize, iRemainder,
+						pMemory->sSrcFileBaseName,
 															pMemory->iSrcFileLineNum
 					   );
 			if (pMemory->sOptionalLabel[0])
@@ -901,7 +890,7 @@ static void Z_TagDebug_f(void)
 			}
 			iBlocksListed++;
 			iTotalSize += pMemory->iSize;
-			
+
 			if (bSnapShotTestActive)
 			{
 				// bump ref count so we only 1 warning per new string, not for every one sharing that label...
@@ -909,7 +898,7 @@ static void Z_TagDebug_f(void)
 				AllTagBlockLabels_Local[psTagStrings[pMemory->eTag]][pMemory->sOptionalLabel]++;
 			}
 		}
-		pMemory = pMemory->pNext;		
+		pMemory = pMemory->pNext;
 	}
 
 	Com_Printf("( %d blocks listed, %d bytes (%.2fMB) total )\n",iBlocksListed, iTotalSize, (float)iTotalSize / 1024.0f / 1024.0f);
@@ -919,6 +908,8 @@ static void Z_TagDebug_f(void)
 // Shuts down the zone memory system and frees up all memory
 void Com_ShutdownZoneMemory(void)
 {
+	Com_Printf("Shutting down zone memory .....\n");
+
 	Cmd_RemoveCommand("zone_stats");
 	Cmd_RemoveCommand("zone_details");
 
@@ -936,12 +927,12 @@ void Com_ShutdownZoneMemory(void)
 		Com_Printf("Automatically freeing %d blocks making up %ld bytes\n", TheZone.Stats.iCount, TheZone.Stats.iCurrent);
 		Z_TagFree(TAG_ALL);
 
-		//assert(!TheZone.Stats.iCount);	// These aren't really problematic per se, it's just warning us that we're freeing extra
-		//assert(!TheZone.Stats.iCurrent);  // memory that is in the zone manager (but not actively tracked..) so if anything, zone_*
-											// commands will just simply be wrong in displaying bytes, but in my tests, it's only off
-											// by like 10 bytes / 1 block, which isn't a real problem --eez
+		assert(!TheZone.Stats.iCount);		// These aren't really problematic per se, it's just warning us that we're freeing extra
+		assert(!TheZone.Stats.iCurrent);	// memory that is in the zone manager (but not actively tracked..) so if anything, zone_*
+							// commands will just simply be wrong in displaying bytes, but in my tests, it's only off
+							// by like 10 bytes / 1 block, which isn't a real problem --eez
 		if(TheZone.Stats.iCount < 0) {
-			Com_Printf(S_COLOR_YELLOW"WARNING: Freeing %d extra blocks (%d bytes) not tracked by the zone manager\n", 
+			Com_Printf(S_COLOR_YELLOW"WARNING: Freeing %d extra blocks (%d bytes) not tracked by the zone manager\n",
 				abs(TheZone.Stats.iCount), abs(TheZone.Stats.iCurrent));
 		}
 	}
@@ -949,20 +940,20 @@ void Com_ShutdownZoneMemory(void)
 
 // Initialises the zone memory system
 
-void Com_InitZoneMemory( void ) 
+void Com_InitZoneMemory( void )
 {
 	Com_Printf("Initialising zone memory .....\n");
 
-	memset(&TheZone, 0, sizeof(TheZone)); 
+	memset(&TheZone, 0, sizeof(TheZone));
 	TheZone.Header.iMagic = ZONE_MAGIC;
 }
 
-void Com_InitZoneMemoryVars( void)
+void Com_InitZoneMemoryVars( void )
 {
 	com_validateZone = Cvar_Get("com_validateZone", "0", 0);
 
-	Cmd_AddCommand("zone_stats",	Z_Stats_f);
-	Cmd_AddCommand("zone_details",	Z_Details_f);
+	Cmd_AddCommand("zone_stats", Z_Stats_f);
+	Cmd_AddCommand("zone_details", Z_Details_f);
 
 #ifdef _DEBUG
 	Cmd_AddCommand("zone_memrecovertest", Z_MemRecoverTest_f);
@@ -973,9 +964,6 @@ void Com_InitZoneMemoryVars( void)
 	Cmd_AddCommand("zone_snapshot",	Z_Snapshot_f);
 #endif
 }
-
-
-
 
 /*
 ========================
@@ -1014,14 +1002,13 @@ Touch all known used data to make sure it is paged in
 ===============
 */
 void Com_TouchMemory( void ) {
-	//int		start, end;
 	int		i, j;
-	int		sum;	
+	int		sum;
 	int		totalTouched;
 
 	Z_Validate();
 
-	//start = Sys_Milliseconds();
+//	start = Sys_Milliseconds();
 
 	sum = 0;
 	totalTouched=0;
@@ -1038,9 +1025,8 @@ void Com_TouchMemory( void ) {
 		pMemory = pMemory->pNext;
 	}
 
-	//end = Sys_Milliseconds();
+//	end = Sys_Milliseconds();
 
-	//Com_Printf( "Com_TouchMemory: %i bytes, %i msec\n", totalTouched, end - start );
+//	Com_Printf( "Com_TouchMemory: %i bytes, %i msec\n", totalTouched, end - start );
 }
-
 

--- a/code/qcommon/z_memman_pc.cpp
+++ b/code/qcommon/z_memman_pc.cpp
@@ -87,9 +87,9 @@ std::map <void*,int> mapAllocatedZones;
 
 typedef struct zoneStats_s
 {
-	int		iCount;
-	int		iCurrent;
-	int		iPeak;
+	size_t		iCurrent;
+	size_t		iCount;
+	size_t		iPeak;
 
 	// I'm keeping these updated on the fly, since it's quicker for cache-pool
 	//	purposes rather than recalculating each time...
@@ -250,7 +250,8 @@ void *_D_Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/, 
 #else
 void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 #endif
-{	
+{
+	int loopCount = 0;
 	gbMemFreeupOccured = qfalse;
 
 	if (iSize == 0)
@@ -269,6 +270,7 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 	zoneHeader_t *pMemory = NULL;
 	while (pMemory == NULL)
 	{
+		loopCount++;
 		if (gbMemFreeupOccured)
 		{
 			Sys_Sleep(1000);	// sleep for a second, so Windows has a chance to shuffle mem to de-swiss-cheese it
@@ -279,10 +281,14 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 		} else {
 			pMemory = (zoneHeader_t *) malloc ( iRealSize );
 		}
-		if (!pMemory)
+
+		if (pMemory)
+			break;
+
+		if (loopCount < 10)
 		{
 			// new bit, if we fail to malloc memory, try dumping some of the cached stuff that's non-vital and try again...
-			//
+			// Aditionally, limit the number of retrials.
 
 			// ditch the BSP cache...
 			//
@@ -348,16 +354,22 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /*iAlign*/)
 					continue;
 				}
 			}
+		}
 
-			// sigh, dunno what else to try, I guess we'll have to give up and report this as an out-of-mem error...
-			//
-			// findlabel:  "recovermem"
-
-			Com_Printf(S_COLOR_RED"Z_Malloc(): Failed to alloc %d bytes (TAG_%s) !!!!!\n", iSize, psTagStrings[eTag]);
-			Z_Details_f();
-			Com_Error(ERR_FATAL,"(Repeat): Z_Malloc(): Failed to alloc %d bytes (TAG_%s) !!!!!\n", iSize, psTagStrings[eTag]);
+		// If the tag is TAG_SPECIAL_MEM_TEST tag, that means we are in a test and we can safely return NULL.
+		if (eTag == TAG_SPECIAL_MEM_TEST)
+		{
 			return NULL;
 		}
+
+		// sigh, dunno what else to try, I guess we'll have to give up and report this as an out-of-mem error...
+		//
+		// findlabel:  "recovermem"
+
+		Com_Printf(S_COLOR_RED"Z_Malloc(): Failed to alloc %d bytes (TAG_%s) !!!!!\n", iSize, psTagStrings[eTag]);
+		Z_Details_f();
+		Com_Error(ERR_FATAL,"(Repeat): Z_Malloc(): Failed to alloc %d bytes (TAG_%s) !!!!!\n", iSize, psTagStrings[eTag]);
+		return NULL;
 	}
 
 #ifdef DEBUG_ZONE_ALLOCS
@@ -667,26 +679,43 @@ void *S_Malloc( int iSize )
 #ifdef _DEBUG
 static void Z_MemRecoverTest_f(void)
 {
-	// needs to be in _DEBUG only, not good for final game! 
-	//
-	if ( Cmd_Argc() != 2 ) {
-		Com_Printf( "Usage: zone_memrecovertest max2alloc\n" );
+	//default amount of available memory
+	float fgb = 4;
+	if (Cmd_Argc() > 2) {
+		Com_Printf("usage: %s [<maximum in GiB>]\n", Cmd_Argv(0));
 		return;
 	}
-
-	int iMaxAlloc = 1024*1024*atoi( Cmd_Argv(1) );
-	int iTotalMalloc = 0;
+	if (Cmd_Argc() == 2) {
+		errno = 0;
+		fgb = strtof(Cmd_Argv(1), 0);
+		if (errno)
+		{
+			fgb = 4;
+		}
+		fgb = fabs(fgb);
+	}
+	size_t origLimit = Sys_LimitAvailableMemory(fgb * 1024 * 1024 * 1024);
+	size_t iTotalMalloc = 0;
+	gbMemFreeupOccured = 0;
 	while (1)
 	{
-		const int iThisMalloc = 5* (1024 * 1024);
-		Z_Malloc(iThisMalloc, TAG_SPECIAL_MEM_TEST, qfalse);	// and lose, just to consume memory
+		int iThisMalloc = 5 * (1024 * 1024);
+		void *mem = Z_Malloc(iThisMalloc, TAG_SPECIAL_MEM_TEST, qfalse);	// and lose, just to consume memory
+		if (!mem)
+			break;
 		iTotalMalloc += iThisMalloc;
 
-		if (gbMemFreeupOccured || (iTotalMalloc >= iMaxAlloc) )
+		if (gbMemFreeupOccured)
 			break;
 	}
 
 	Z_TagFree(TAG_SPECIAL_MEM_TEST);
+
+	Com_Printf("Memory garbage collector did %srun.\n", gbMemFreeupOccured ? "" : "NOT ");
+
+	Com_Printf("Maximum allocated memory = %ld bytes\n", iTotalMalloc);
+
+	Sys_LimitAvailableMemory(origLimit);
 }
 #endif
 
@@ -694,13 +723,13 @@ static void Z_MemRecoverTest_f(void)
 
 static void Z_Stats_f(void)
 {
-	Com_Printf("\nThe zone is using %d bytes (%.2fMB) in %d memory blocks\n", 
+	Com_Printf("\nThe zone is using %ld bytes (%.2fMB) in %d memory blocks\n",
 								  TheZone.Stats.iCurrent, 
 									        (float)TheZone.Stats.iCurrent / 1024.0f / 1024.0f, 
 													  TheZone.Stats.iCount
 				);
 
-	Com_Printf("The zone peaked at %d bytes (%.2fMB)\n", 
+	Com_Printf("The zone peaked at %ld bytes (%.2fMB)\n",
 									TheZone.Stats.iPeak, 
 									         (float)TheZone.Stats.iPeak / 1024.0f / 1024.0f
 				);
@@ -905,7 +934,7 @@ void Com_ShutdownZoneMemory(void)
 
 	if(TheZone.Stats.iCount)
 	{
-		Com_Printf("Automatically freeing %d blocks making up %d bytes\n", TheZone.Stats.iCount, TheZone.Stats.iCurrent);
+		Com_Printf("Automatically freeing %d blocks making up %ld bytes\n", TheZone.Stats.iCount, TheZone.Stats.iCurrent);
 		Z_TagFree(TAG_ALL);
 
 		//assert(!TheZone.Stats.iCount);	// These aren't really problematic per se, it's just warning us that we're freeing extra

--- a/code/qcommon/z_memman_pc.cpp
+++ b/code/qcommon/z_memman_pc.cpp
@@ -573,7 +573,6 @@ void _D_Z_Label(const void *pvAddress, const char *psLabel)
 	}
 
 	Q_strncpyz(	pMemory->sOptionalLabel, psLabel, sizeof(pMemory->sOptionalLabel));
-				pMemory->sOptionalLabel[ sizeof(pMemory->sOptionalLabel)-1 ] = '\0';
 }
 #endif
 

--- a/code/rd-common/tr_image_jpg.cpp
+++ b/code/rd-common/tr_image_jpg.cpp
@@ -567,7 +567,7 @@ void RE_SaveJPG(const char * filename, int quality, int image_width, int image_h
 	size_t bufSize;
 
 	bufSize = image_width * image_height * 3;
-	out = (byte *)ri.Z_Malloc( bufSize, TAG_TEMP_WORKSPACE, qfalse, 4 );
+	out = (byte *) Z_Malloc( bufSize, TAG_TEMP_WORKSPACE, qfalse );
 
 	bufSize = RE_SaveJPGToBuffer(out, bufSize, quality, image_width, image_height, image_buffer, padding);
 	ri.FS_WriteFile(filename, out, bufSize);

--- a/code/rd-common/tr_image_png.cpp
+++ b/code/rd-common/tr_image_png.cpp
@@ -234,7 +234,7 @@ struct PNGFileReader
 		png_read_update_info (png_ptr, info_ptr);
 
 		// We always assume there are 4 channels. RGB channels are expanded to RGBA when read.
-		byte *tempData = (byte *)ri.Z_Malloc (width_ * height_ * 4, TAG_TEMP_PNG, qfalse, 4);
+		byte *tempData = (byte *) Z_Malloc (width_ * height_ * 4, TAG_TEMP_PNG, qfalse);
 		if ( !tempData )
 		{
 			ri.Printf (PRINT_ERROR, "Could not allocate enough memory to load the image.");
@@ -242,7 +242,7 @@ struct PNGFileReader
 		}
 
 		// Dynamic array of row pointers, with 'height' elements, initialized to NULL.
-		byte **row_pointers = (byte **)ri.Z_Malloc (sizeof (byte *) * height_, TAG_TEMP_PNG, qfalse, 4);
+		byte **row_pointers = (byte **) Z_Malloc (sizeof (byte *) * height_, TAG_TEMP_PNG, qfalse);
 		if ( !row_pointers )
 		{
 			ri.Printf (PRINT_ERROR, "Could not allocate enough memory to load the image.");

--- a/code/rd-common/tr_public.h
+++ b/code/rd-common/tr_public.h
@@ -40,7 +40,11 @@ typedef struct {
 	int					(*Milliseconds)						( void );
 
 	void				(*Hunk_ClearToMark)					( void );
+#ifdef DEBUG_ZONE_ALLOCS
+	void*				(*_D_Z_Malloc)						( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign, const char *psFile, int iLine );
+#else
 	void*				(*Z_Malloc)							( int iSize, memtag_t eTag, qboolean zeroIt, int iAlign );
+#endif
 	int					(*Z_Free)							( void *memory );
 	int					(*Z_MemSize)						( memtag_t eTag );
 	void				(*Z_MorphMallocTag)					( void *pvBuffer, memtag_t eDesiredTag );

--- a/code/rd-common/tr_public.h
+++ b/code/rd-common/tr_public.h
@@ -45,7 +45,7 @@ typedef struct {
 #else
 	void*				(*Z_Malloc)							( int iSize, memtag_t eTag, qboolean zeroIt, int iAlign );
 #endif
-	int					(*Z_Free)							( void *memory );
+	void				(*Z_Free)							( void *memory );
 	int					(*Z_MemSize)						( memtag_t eTag );
 	void				(*Z_MorphMallocTag)					( void *pvBuffer, memtag_t eDesiredTag );
 

--- a/code/rd-vanilla/CMakeLists.txt
+++ b/code/rd-vanilla/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BuildSPRdVanilla OR BuildJK2SPRdVanilla)
 	set(SPRDVanillaRendererIncludeDirectories ${SPRDVanillaRendererIncludeDirectories} ${OpenJKLibDir})
 	
 	function(add_sp_renderer_project ProjectName Label EngineName InstallDir Component)
-		add_library(${ProjectName} SHARED ${SPRDVanillaFiles})
+		add_library(${ProjectName} MODULE ${SPRDVanillaFiles})
 		if(NOT MSVC)
 			# remove "lib" prefix for .so/.dylib files
 			set_target_properties(${ProjectName} PROPERTIES PREFIX "")
@@ -148,7 +148,7 @@ if(BuildSPRdVanilla OR BuildJK2SPRdVanilla)
 
 		if(WIN32)
 			install(TARGETS ${ProjectName}
-				RUNTIME
+				LIBRARY
 				DESTINATION ${InstallDir}
 				COMPONENT ${Component})
 		else(WIN32)

--- a/code/rd-vanilla/tr_WorldEffects.cpp
+++ b/code/rd-vanilla/tr_WorldEffects.cpp
@@ -1117,7 +1117,7 @@ public:
 		mRotation.mMin		= -0.7f;
 		mRotation.mMax		=  0.7f;
 		mRotationChangeTimer.mMin = 500;
-		mRotationChangeTimer.mMin = 2000;
+		mRotationChangeTimer.mMax = 2000;
 
 		mMass.mMin			= 5.0f;
 		mMass.mMax			= 10.0f;

--- a/code/rd-vanilla/tr_ghoul2.cpp
+++ b/code/rd-vanilla/tr_ghoul2.cpp
@@ -241,8 +241,8 @@ public:
 
 		mNumBones = header->numBones;
 		mBones = new SBoneCalc[mNumBones];
-		mFinalBones = (CTransformBone*)Z_Malloc(sizeof(CTransformBone) * mNumBones, TAG_GHOUL2, qtrue, 16);
-		mSmoothBones = (CTransformBone*)Z_Malloc(sizeof(CTransformBone) * mNumBones, TAG_GHOUL2, qtrue, 16);
+		mFinalBones = (CTransformBone*) Z_Malloc(sizeof(CTransformBone) * mNumBones, TAG_GHOUL2, qtrue);
+		mSmoothBones = (CTransformBone*) Z_Malloc(sizeof(CTransformBone) * mNumBones, TAG_GHOUL2, qtrue);
 		mSkels = new mdxaSkel_t*[mNumBones];
 		mdxaSkelOffsets_t *offsets;
 		mdxaSkel_t		*skel;

--- a/code/rd-vanilla/tr_init.cpp
+++ b/code/rd-vanilla/tr_init.cpp
@@ -816,7 +816,7 @@ byte *RB_ReadPixels(int x, int y, int width, int height, size_t *offset, int *pa
 	padwidth = PAD(linelen, packAlign);
 
 	// Allocate a few more bytes so that we can choose an alignment we like
-	buffer = (byte *)ri.Z_Malloc(padwidth * height + *offset + packAlign - 1, TAG_TEMP_WORKSPACE, qfalse, 4);
+	buffer = (byte *) Z_Malloc(padwidth * height + *offset + packAlign - 1, TAG_TEMP_WORKSPACE, qfalse);
 
 	bufstart = (byte *)PADP((intptr_t) buffer + *offset, packAlign);
 	qglReadPixels(x, y, width, height, GL_RGB, GL_UNSIGNED_BYTE, bufstart);
@@ -964,7 +964,7 @@ static void R_LevelShot( void ) {
 	allsource = RB_ReadPixels(0, 0, glConfig.vidWidth, glConfig.vidHeight, &offset, &padlen);
 	source = allsource + offset;
 
-	buffer = (byte *)ri.Z_Malloc(LEVELSHOTSIZE * LEVELSHOTSIZE*3 + 18, TAG_TEMP_WORKSPACE, qfalse, 4);
+	buffer = (byte *) Z_Malloc(LEVELSHOTSIZE * LEVELSHOTSIZE*3 + 18, TAG_TEMP_WORKSPACE, qfalse);
 	Com_Memset (buffer, 0, 18);
 	buffer[2] = 2;		// uncompressed type
 	buffer[12] = LEVELSHOTSIZE & 255;

--- a/code/rd-vanilla/tr_init.cpp
+++ b/code/rd-vanilla/tr_init.cpp
@@ -305,6 +305,18 @@ static void GLW_InitTextureCompression( void )
 		Com_Printf ("...GL_EXT_texture_compression_s3tc available\n" );
 	}
 
+#ifndef _WIN32
+	// Disable texture compressino method if no preferred texture compression method is defined
+	// and we are using the MESA opengl library.
+	if ((r_ext_preferred_tc_method->integer == TC_NONE)
+		&& (Q_stristr(glConfig.renderer_string, "mesa")))
+	{
+		Com_Printf("...MESA video driver detected, disabling texture compression.\n" );
+		Com_Printf(".....Set r_ext_preferred_tc_method to disable override.\n" );
+		ri.Cvar_Set("r_ext_compress_textures", "0");
+	}
+#endif
+
 	if ( !r_ext_compressed_textures->value )
 	{
 		// Compressed textures are off
@@ -727,6 +739,7 @@ static void InitOpenGL( void )
 		// set default state
 		GL_SetDefaultState();
 		R_Splash();	//get something on screen asap
+
 	}
 	else
 	{

--- a/code/rd-vanilla/tr_local.h
+++ b/code/rd-vanilla/tr_local.h
@@ -1844,4 +1844,8 @@ Ghoul2 Insert End
 void RB_DrawSurfaceSprites( shaderStage_t *stage, shaderCommands_t *input);
 
 // tr_subs.cpp
+#ifdef DEBUG_ZONE_ALLOCS
+void *_D_Z_Malloc( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign, const char *psFile, int iLine );
+#else
 void *Z_Malloc( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign );
+#endif

--- a/code/rd-vanilla/tr_skin.cpp
+++ b/code/rd-vanilla/tr_skin.cpp
@@ -173,7 +173,7 @@ int RE_GetAnimationCFG(const char *psCFGFilename, char *psDest, int iDestSize)
 			return 0;
 		}
 
-		psText = (char *) ri.Z_Malloc( iLen+1, TAG_ANIMATION_CFG, qfalse, 4 );
+		psText = (char *) Z_Malloc( iLen+1, TAG_ANIMATION_CFG, qfalse );
 
 		ri.FS_Read( psText, iLen, f );
 		psText[iLen] = '\0';

--- a/code/rd-vanilla/tr_subs.cpp
+++ b/code/rd-vanilla/tr_subs.cpp
@@ -88,8 +88,8 @@ void *Z_Malloc( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign ) {
 }
 #endif
 
-int Z_Free( void *ptr ) {
-	return ri.Z_Free( ptr );
+void Z_Free( void *ptr ) {
+	ri.Z_Free( ptr );
 }
 
 int Z_MemSize( memtag_t eTag ) {

--- a/code/rd-vanilla/tr_subs.cpp
+++ b/code/rd-vanilla/tr_subs.cpp
@@ -77,9 +77,16 @@ void Com_DPrintf(const char *format, ...)
 //}
 
 // ZONE
+
+#ifdef DEBUG_ZONE_ALLOCS
+void *_D_Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int iAlign, const char *psFile, int iLine ) {
+	return ri._D_Z_Malloc( iSize, eTag, bZeroit, iAlign, psFile, iLine );
+}
+#else
 void *Z_Malloc( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign ) {
 	return ri.Z_Malloc( iSize, eTag, bZeroit, iAlign );
 }
+#endif
 
 int Z_Free( void *ptr ) {
 	return ri.Z_Free( ptr );

--- a/codeJK2/game/CMakeLists.txt
+++ b/codeJK2/game/CMakeLists.txt
@@ -266,7 +266,7 @@ if(WIN32)
 	set(JK2SPGameFiles ${JK2SPGameFiles} ${JK2SPGameWin32Files})
 endif(WIN32)
 
-add_library(${JK2SPGame} SHARED ${JK2SPGameFiles})
+add_library(${JK2SPGame} MODULE ${JK2SPGameFiles})
 
 if(NOT MSVC)
 	# remove "lib" prefix for .so/.dylib files

--- a/codemp/cgame/CMakeLists.txt
+++ b/codemp/cgame/CMakeLists.txt
@@ -129,7 +129,7 @@ set(MPCGameGFiles
 source_group("ghoul2" FILES ${MPCGameG2Files})
 set(MPCGameFiles ${MPCGameFiles} ${MPCGameG2Files})
 
-add_library(${MPCGame} SHARED ${MPCGameFiles})
+add_library(${MPCGame} MODULE ${MPCGameFiles})
 
 if(NOT MSVC)
 	# remove "lib" prefix for .so/.dylib files
@@ -147,14 +147,14 @@ if(MakeApplicationBundles AND BuildMPEngine)
 		COMPONENT ${JKAMPCoreComponent})
 elseif(WIN32)
 	install(TARGETS ${MPCGame}
-		RUNTIME
+		LIBRARY
 		DESTINATION "${JKAInstallDir}/OpenJK"
 		COMPONENT ${JKAMPCoreComponent})
 	if (WIN64)
 		# Don't do this on 32-bit Windows to avoid overwriting
 		# vanilla JKA's DLLs
 		install(TARGETS ${MPCGame}
-			RUNTIME
+			LIBRARY
 			DESTINATION "${JKAInstallDir}/base"
 			COMPONENT ${JKAMPCoreComponent})
 	endif()

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -2378,7 +2378,12 @@ void CL_InitRef( void ) {
 	ri.Hunk_FreeTempMemory = Hunk_FreeTempMemory;
 	ri.Hunk_Alloc = Hunk_Alloc;
 	ri.Hunk_MemoryRemaining = Hunk_MemoryRemaining;
+#ifdef DEBUG_ZONE_ALLOCS
+#undef Z_Malloc
+	ri._D_Z_Malloc = _D_Z_Malloc;
+#else
 	ri.Z_Malloc = Z_Malloc;
+#endif
 	ri.Z_Free = Z_Free;
 	ri.Z_MemSize = Z_MemSize;
 	ri.Z_MorphMallocTag = Z_MorphMallocTag;

--- a/codemp/game/CMakeLists.txt
+++ b/codemp/game/CMakeLists.txt
@@ -197,7 +197,7 @@ set(MPGameUiFiles
 source_group("ui" FILES ${MPGameUiFiles})
 set(MPGameFiles ${MPGameFiles} ${MPGameUiFiles})
 
-add_library(${MPGame} SHARED ${MPGameFiles})
+add_library(${MPGame} MODULE ${MPGameFiles})
 
 if(NOT MSVC)
 	# remove "lib" prefix for .so/.dylib files
@@ -215,14 +215,14 @@ if(MakeApplicationBundles AND BuildMPEngine)
 		COMPONENT ${JKAMPCoreComponent})
 elseif(WIN32)
 	install(TARGETS ${MPGame}
-		RUNTIME
+		LIBRARY
 		DESTINATION "${JKAInstallDir}/OpenJK"
 		COMPONENT ${JKAMPCoreComponent})
 	if (WIN64)
 		# Don't do this on 32-bit Windows to avoid overwriting
 		# vanilla JKA's DLLs
 		install(TARGETS ${MPGame}
-			RUNTIME
+			LIBRARY
 			DESTINATION "${JKAInstallDir}/base"
 			COMPONENT ${JKAMPCoreComponent})
 	endif()

--- a/codemp/game/NPC_move.c
+++ b/codemp/game/NPC_move.c
@@ -95,7 +95,7 @@ NPC_CheckCombatMove
 -------------------------
 */
 
-QINLINE qboolean NPC_CheckCombatMove( void )
+static QINLINE qboolean NPC_CheckCombatMove( void )
 {
 	//return NPCInfo->combatMove;
 	if ( ( NPCS.NPCInfo->goalEntity && NPCS.NPC->enemy && NPCS.NPCInfo->goalEntity == NPCS.NPC->enemy ) || ( NPCS.NPCInfo->combatMove ) )
@@ -143,7 +143,7 @@ NPC_GetMoveInformation
 -------------------------
 */
 
-QINLINE qboolean NPC_GetMoveInformation( vec3_t dir, float *distance )
+static QINLINE qboolean NPC_GetMoveInformation( vec3_t dir, float *distance )
 {
 	//NOTENOTE: Use path stacks!
 

--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -259,7 +259,7 @@ qboolean BG_KnockDownable(playerState_t *ps)
 }
 
 //hacky assumption check, assume any client non-humanoid is a rocket trooper
-qboolean QINLINE PM_IsRocketTrooper(void)
+static qboolean QINLINE PM_IsRocketTrooper(void)
 {
 	/*
 	if (pm->ps->clientNum < MAX_CLIENTS &&

--- a/codemp/game/w_saber.c
+++ b/codemp/game/w_saber.c
@@ -5238,7 +5238,7 @@ blockStuff:
 	return didHit;
 }
 
-QINLINE int VectorCompare2( const vec3_t v1, const vec3_t v2 ) {
+static QINLINE int VectorCompare2( const vec3_t v1, const vec3_t v2 ) {
 	if ( v1[0] > v2[0]+0.0001f || v1[0] < v2[0]-0.0001f
 		|| v1[1] > v2[1]+0.0001f || v1[1] < v2[1]-0.0001f
 		|| v1[2] > v2[2]+0.0001f || v1[2] < v2[2]-0.0001f ) {

--- a/codemp/qcommon/cm_load.cpp
+++ b/codemp/qcommon/cm_load.cpp
@@ -688,7 +688,7 @@ static void CM_LoadMap_Actual( const char *name, qboolean clientload, int *check
 	const int iBSPLen = FS_FOpenFileRead( name, &h, qfalse );
 	if (h)
 	{
-		newBuff = Z_Malloc( iBSPLen, TAG_BSP_DISKIMAGE );
+		newBuff = Z_Malloc( iBSPLen, TAG_BSP_DISKIMAGE, qfalse );
 		FS_Read( newBuff, iBSPLen, h);
 		FS_FCloseFile( h );
 

--- a/codemp/qcommon/cm_public.h
+++ b/codemp/qcommon/cm_public.h
@@ -26,6 +26,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "qcommon/q_shared.h"
 #include "qfiles.h"
 
+qboolean	CM_DeleteCachedMap(qboolean bGuaranteedOkToDelete);
 void		CM_LoadMap( const char *name, qboolean clientload, int *checksum);
 
 void		CM_ClearMap( void );

--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -23,7 +23,6 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
 /*****************************************************************************
-
  * name:		files.cpp
  *
  * desc:		file code
@@ -39,15 +38,15 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #endif
 #include <minizip/unzip.h>
 
-#if defined(_WIN32)
-#include <windows.h>
-#endif
-
 // for rmdir
 #if defined (_MSC_VER)
 	#include <direct.h>
 #else
 	#include <unistd.h>
+#endif
+
+#if defined(_WIN32)
+#include <windows.h>
 #endif
 
 /*
@@ -1992,7 +1991,7 @@ long FS_ReadFile( const char *qpath, void **buffer ) {
 	buf[len]='\0';	// because we're not calling Z_Malloc with optional trailing 'bZeroIt' bool
 	*buffer = buf;
 
-//	Z_Label(buf, qpath);
+	Z_Label(buf, qpath);
 
 	FS_Read (buf, len, h);
 
@@ -3465,7 +3464,9 @@ void FS_Startup( const char *gameName ) {
 
 #ifdef FS_MISSING
 	if (missingFiles == NULL) {
-		missingFiles = fopen( "\\missing.txt", "ab" );
+		char filename[MAX_OSPATH];
+		Com_sprintf(filename, sizeof(filename), "%s/%s", homePath, "missing.log");
+		missingFiles = fopen( filename, "ab" );
 	}
 #endif
 	Com_Printf( "%d files in pk3 files\n", fs_packFiles );

--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -287,12 +287,10 @@ static int		fs_numServerReferencedPaks;
 static int		fs_serverReferencedPaks[MAX_SEARCH_PATHS];			// checksums
 static char	*fs_serverReferencedPakNames[MAX_SEARCH_PATHS];		// pk3 names
 
-#if defined(_WIN32)
 // temporary files - store them in a circular buffer. We're pretty
 // much guaranteed to not need more than 8 temp files at a time.
 static int		fs_temporaryFileWriteIdx = 0;
 static char		fs_temporaryFileNames[8][MAX_OSPATH];
-#endif
 
 // last valid game folder used
 char lastValidBase[MAX_OSPATH];
@@ -644,12 +642,13 @@ void FS_CopyFile( char *fromOSPath, char *toOSPath ) {
 ===========
 FS_Remove
 
+Return true on success
 ===========
 */
-void FS_Remove( const char *osPath ) {
+bool FS_Remove( const char *osPath ) {
 	FS_CheckFilenameIsMutable( osPath, __func__ );
 
-	remove( osPath );
+	return remove( osPath ) == 0;
 }
 
 /*
@@ -3239,26 +3238,20 @@ void FS_Shutdown( qboolean closemfp ) {
 	searchpath_t	*p, *next;
 	int	i;
 
-#if defined(_WIN32)
 	// Delete temporary files
 	fs_temporaryFileWriteIdx = 0;
 	for ( size_t i = 0; i < ARRAY_LEN(fs_temporaryFileNames); i++ )
 	{
 		if (fs_temporaryFileNames[i][0] != '\0')
 		{
-			if ( !DeleteFile(fs_temporaryFileNames[i]) )
+			if ( !FS_Remove(fs_temporaryFileNames[i]) )
 			{
-				DWORD error = GetLastError();
-				Com_DPrintf("FS_Shutdown: failed to delete '%s'. "
-							"Win32 error code: 0x08x",
-							fs_temporaryFileNames[i],
-							error);
+				Com_DPrintf("FS_Shutdown: failed to delete '%s'",
+							fs_temporaryFileNames[i]);
 			}
-
 			fs_temporaryFileNames[i][0] = '\0';
 		}
 	}
-#endif
 
 	for(i = 0; i < MAX_FILE_HANDLES; i++) {
 		if (fsh[i].fileSize) {
@@ -3837,9 +3830,7 @@ void FS_InitFilesystem( void ) {
 	Q_strncpyz(lastValidBase, fs_basepath->string, sizeof(lastValidBase));
 	Q_strncpyz(lastValidGame, fs_gamedirvar->string, sizeof(lastValidGame));
 
-#if defined(_WIN32)
 	Com_Memset(fs_temporaryFileNames, 0, sizeof(fs_temporaryFileNames));
-#endif
 
   // bk001208 - SafeMode see below, FIXME?
 }
@@ -4129,99 +4120,51 @@ bool FS_LoadMachOBundle( const char *name )
 
 qboolean FS_WriteToTemporaryFile( const void *data, size_t dataLength, char **tempFilePath )
 {
-#if defined(_WIN32)
-	DWORD error;
-	TCHAR tempPath[MAX_PATH];
-	DWORD tempPathResult = GetTempPath(MAX_PATH, tempPath);
-	if ( tempPathResult )
+	const char *tempFileName = Sys_TemporaryFilePath();
+	if (!tempFileName)
 	{
-		TCHAR tempFileName[MAX_PATH];
-		UINT tempFileNameResult = GetTempFileName(tempPath, "OJK", 0, tempFileName);
-		if ( tempFileNameResult )
-		{
-			HANDLE file = CreateFile(
-				tempFileName, GENERIC_WRITE, 0, NULL,
-				CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, 0);
-			if ( file != INVALID_HANDLE_VALUE )
-			{
-				DWORD bytesWritten = 0;
-				if (WriteFile(file, data, dataLength, &bytesWritten, NULL))
-				{
-					int deletesRemaining = ARRAY_LEN(fs_temporaryFileNames);
-
-					CloseHandle(file);
-
-					while ( deletesRemaining > 0 &&
-							fs_temporaryFileNames[fs_temporaryFileWriteIdx][0] != '\0' )
-					{
-						// Delete old temporary file as we need to
-						if ( DeleteFile(fs_temporaryFileNames[fs_temporaryFileWriteIdx]) )
-						{
-							break;
-						}
-
-						error = GetLastError();
-						Com_DPrintf("FS_WriteToTemporaryFile failed for '%s'. "
-									"Win32 error code: 0x%08x\n",
-									fs_temporaryFileNames[fs_temporaryFileWriteIdx],
-									error);
-
-						// Failed to delete, possibly because DLL was still in use. This can
-						// happen when running a listen server and you continually restart
-						// the map. The game DLL is reloaded, but cgame and ui DLLs are not.
-						fs_temporaryFileWriteIdx =
-							(fs_temporaryFileWriteIdx + 1) % ARRAY_LEN(fs_temporaryFileNames);
-						deletesRemaining--;
-					}
-
-					// If this happened, then all slots are used and we some how have 8 DLLs
-					// loaded at once?!
-					assert(deletesRemaining > 0);
-
-					Q_strncpyz(fs_temporaryFileNames[fs_temporaryFileWriteIdx],
-								tempFileName, sizeof(fs_temporaryFileNames[0]));
-					fs_temporaryFileWriteIdx =
-						(fs_temporaryFileWriteIdx + 1) % ARRAY_LEN(fs_temporaryFileNames);
-
-					if ( tempFilePath )
-					{
-						size_t fileNameLen = strlen(tempFileName);
-						*tempFilePath = (char *)Z_Malloc(fileNameLen + 1, TAG_FILESYS);
-						Q_strncpyz(*tempFilePath, tempFileName, fileNameLen + 1);
-					}
-					
-					return qtrue;
-				}
-				else
-				{
-					error = GetLastError();
-					Com_DPrintf("FS_WriteToTemporaryFile failed to write '%s'. "
-								"Win32 error code: 0x%08x\n",
-								tempFileName, error);
-				}
-			}
-			else
-			{
-				error = GetLastError();
-				Com_DPrintf("FS_WriteToTemporaryFile failed to create '%s'. "
-							"Win32 error code: 0x%08x\n",
-							tempFileName, error);
-			}
-		}
-		else
-		{
-			error = GetLastError();
-			Com_DPrintf("FS_WriteToTemporaryFile failed to generate temporary file name. "
-						"Win32 error code: 0x%08x\n", error);
-		}
+		return qfalse;
 	}
-	else
+
+	if ( !Sys_WriteDataToPath(tempFileName, data, dataLength) )
 	{
-		error = GetLastError();
-		Com_DPrintf("FS_WriteToTemporaryFile failed to get temporary file folder. "
-						"Win32 error code: 0x%08x\n", error);
+		return qfalse;
 	}
-#endif
 
-	return qfalse;
+	int deletesRemaining = ARRAY_LEN(fs_temporaryFileNames);
+
+	while ( deletesRemaining > 0 &&
+			fs_temporaryFileNames[fs_temporaryFileWriteIdx][0] != '\0' )
+	{
+		// Delete old temporary file as we need to
+		if (FS_Remove(fs_temporaryFileNames[fs_temporaryFileWriteIdx]))
+		{
+			break;
+		}
+
+		// WIN32: Failed to delete, possibly because DLL was still in use. This can
+		// happen when running a listen server and you continually restart
+		// the map. The game DLL is reloaded, but cgame and ui DLLs are not.
+		fs_temporaryFileWriteIdx =
+			(fs_temporaryFileWriteIdx + 1) % ARRAY_LEN(fs_temporaryFileNames);
+		deletesRemaining--;
+	}
+
+	// If this happened, then all slots are used and we somehow have 8 DLLs
+	// loaded at once?!
+	assert(deletesRemaining > 0);
+
+	Q_strncpyz(fs_temporaryFileNames[fs_temporaryFileWriteIdx],
+				tempFileName, sizeof(fs_temporaryFileNames[0]));
+	fs_temporaryFileWriteIdx =
+		(fs_temporaryFileWriteIdx + 1) % ARRAY_LEN(fs_temporaryFileNames);
+
+	if ( tempFilePath )
+	{
+		size_t fileNameLen = strlen(tempFileName);
+		*tempFilePath = (char *)Z_Malloc(fileNameLen + 1, TAG_FILESYS);
+		Q_strncpyz(*tempFilePath, tempFileName, fileNameLen + 1);
+	}
+
+	return qtrue;
 }

--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -2413,7 +2413,7 @@ char **FS_ListFilteredFiles( const char *path, const char *extension, char *filt
 		return NULL;
 	}
 
-	listCopy = (char **)Z_Malloc( ( nfiles + 1 ) * sizeof( *listCopy ), TAG_FILESYS );
+	listCopy = (char **)Z_Malloc( ( nfiles + 1 ) * sizeof( *listCopy ), TAG_FILESYS, qfalse );
 	for ( i = 0 ; i < nfiles ; i++ ) {
 		listCopy[i] = list[i];
 	}

--- a/codemp/qcommon/q_platform.h
+++ b/codemp/qcommon/q_platform.h
@@ -123,11 +123,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 		#define OS_STRING "kFreeBSD"
 	#endif
 
-	#ifdef __clang__
-		#define QINLINE static inline
-	#else
-		#define QINLINE inline
-	#endif
+	#define QINLINE inline
 
 	#define PATH_SEP '/'
 

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -27,6 +27,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 // qcommon.h -- definitions common between client and server, but not game.or ref modules
 
 #include "qcommon/q_shared.h"
+#include "qcommon/cm_public.h"
 #include "sys/sys_public.h"
 
 // some zone mem debugging stuff

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -29,6 +29,17 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "qcommon/q_shared.h"
 #include "sys/sys_public.h"
 
+// some zone mem debugging stuff
+#ifndef FINAL_BUILD
+	#ifdef _DEBUG
+	//
+	// both of these should be REM'd unless you specifically need them...
+	//
+	//#define DEBUG_ZONE_ALLOCS			// adds __FILE__ and __LINE__ info to zone blocks, to see who's leaking
+	//#define DETAILED_ZONE_DEBUG_CODE	// this slows things down a LOT, and is only for tracking nasty double-freeing Z_Malloc bugs
+	#endif
+#endif
+
 //============================================================================
 
 //
@@ -837,46 +848,36 @@ temp file loading
 
 */
 
-#if defined(_DEBUG) && !defined(BSPC)
-	#define DEBUG_ZONE_ALLOCS
-#endif
-
-/*
 #ifdef DEBUG_ZONE_ALLOCS
-	#define Z_TagMalloc(size, tag)			Z_TagMallocDebug(size, tag, #size, __FILE__, __LINE__)
-	#define Z_Malloc(size)					Z_MallocDebug(size, #size, __FILE__, __LINE__)
-	#define S_Malloc(size)					S_MallocDebug(size, #size, __FILE__, __LINE__)
-	void *Z_TagMallocDebug( int size, int tag, char *label, char *file, int line );	// NOT 0 filled memory
-	void *Z_MallocDebug( int size, char *label, char *file, int line );			// returns 0 filled memory
-	void *S_MallocDebug( int size, char *label, char *file, int line );			// returns 0 filled memory
+
+void *_D_Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign, const char *psFile, int iLine );
+void *_D_S_Malloc ( int iSize, const char *psFile, int iLine );
+void  _D_Z_Label  ( const void *pvAddress, const char *pslabel );
+
+#define Z_Malloc(_iSize, _eTag, _bZeroit, ...)	_D_Z_Malloc (_iSize, _eTag, _bZeroit, 4, __FILE__, __LINE__)
+#define S_Malloc(_iSize)						_D_S_Malloc	(_iSize, __FILE__, __LINE__)	// NOT 0 filled memory only for small allocations
+
+#define Z_Label(_ptr, _label)					_D_Z_Label	(_ptr, _label)
+
 #else
-	void *Z_TagMalloc( int size, int tag );	// NOT 0 filled memory
-	void *Z_Malloc( int size );			// returns 0 filled memory
-	void *S_Malloc( int size );			// NOT 0 filled memory only for small allocations
-#endif
-void Z_Free( void *ptr );
-void Z_FreeTags( int tag );
-int Z_AvailableMemory( void );
-void Z_LogHeap( void );
-*/
 
-// later on I'll re-implement __FILE__, __LINE__ etc, but for now...
-//
-#ifdef DEBUG_ZONE_ALLOCS
 void *Z_Malloc  ( int iSize, memtag_t eTag, qboolean bZeroit = qfalse, int iAlign = 4);	// return memory NOT zero-filled by default
 void *S_Malloc	( int iSize );					// NOT 0 filled memory only for small allocations
-#else
-void *Z_Malloc  ( int iSize, memtag_t eTag, qboolean bZeroit = qfalse, int iAlign = 4);	// return memory NOT zero-filled by default
-void *S_Malloc	( int iSize );					// NOT 0 filled memory only for small allocations
+
+#define Z_Label(_ptr, _label)
 #endif
-void  Z_MorphMallocTag( void *pvBuffer, memtag_t eDesiredTag );
+
 void  Z_Validate( void );
 int   Z_MemSize	( memtag_t eTag );
 void  Z_TagFree	( memtag_t eTag );
 void  Z_Free	( void *ptr );
 int	  Z_Size	( void *pvAddress);
+void  Z_MorphMallocTag( void *pvBuffer, memtag_t eDesiredTag );
+qboolean Z_IsFromZone(const void *pvAddress, memtag_t eTag);	//returns size if true
+
 void Com_InitZoneMemory(void);
 void Com_InitZoneMemoryVars(void);
+
 void Com_InitHunkMemory(void);
 void Com_ShutdownZoneMemory(void);
 void Com_ShutdownHunkMemory(void);

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -590,7 +590,7 @@ char	**FS_ListFiles( const char *directory, const char *extension, int *numfiles
 void	FS_FreeFileList( char **fileList );
 //rwwRMG - changed to fileList to not conflict with list type
 
-void FS_Remove( const char *osPath );
+bool FS_Remove( const char *osPath );
 void FS_HomeRemove( const char *homePath );
 
 void FS_Rmdir( const char *osPath, qboolean recursive );
@@ -713,7 +713,6 @@ qboolean FS_ComparePaks( char *neededpaks, int len, qboolean dlstring );
 void FS_Rename( const char *from, const char *to );
 
 qboolean FS_WriteToTemporaryFile( const void *data, size_t dataLength, char **tempFileName );
-
 
 /*
 ==============================================================

--- a/codemp/qcommon/z_memman_pc.cpp
+++ b/codemp/qcommon/z_memman_pc.cpp
@@ -87,9 +87,9 @@ std::map <void*,int> mapAllocatedZones;
 
 typedef struct zoneStats_s
 {
-	int		iCount;
-	int		iCurrent;
-	int		iPeak;
+	size_t		iCount;
+	size_t		iCurrent;
+	size_t		iPeak;
 
 	// I'm keeping these updated on the fly, since it's quicker for cache-pool
 	//	purposes rather than recalculating each time...
@@ -225,6 +225,7 @@ void *_D_Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, int /* iAlign = 
 void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /* iAlign = 4 */)
 #endif
 {
+	int loopCount = 0;
 	gbMemFreeupOccured = qfalse;
 
 	if (iSize == 0)
@@ -242,6 +243,7 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /* iAlign = 4 */)
 	zoneHeader_t *pMemory = NULL;
 	while (pMemory == NULL)
 	{
+		loopCount++;
 		if (gbMemFreeupOccured)
 		{
 			Sys_Sleep(1000);	// sleep for a second, so Windows has a chance to shuffle mem to de-swiss-cheese it
@@ -252,10 +254,14 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /* iAlign = 4 */)
 		} else {
 			pMemory = (zoneHeader_t *) malloc ( iRealSize );
 		}
-		if (!pMemory)
+
+		if (pMemory)
+			break;
+
+		if (loopCount < 10)
 		{
 			// new bit, if we fail to malloc memory, try dumping some of the cached stuff that's non-vital and try again...
-			//
+			// Aditionally, limit the number of retrials.
 
 			// ditch the BSP cache...
 			//
@@ -288,11 +294,13 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /* iAlign = 4 */)
 
 			// ditch the model-binaries cache...  (must be getting desperate here!)
 			//
+#ifndef DEDICATED
 			if ( re->RegisterModels_LevelLoadEnd(qtrue) )
 			{
 				gbMemFreeupOccured = qtrue;
 				continue;
 			}
+#endif
 
 			// as a last panic measure, dump all the audio memory, but not if we're in the audio loader
 			//	(which is annoying, but I'm not sure how to ensure we're not dumping any memory needed by the sound
@@ -322,16 +330,22 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /* iAlign = 4 */)
 					continue;
 				}
 			}
+		}
 
-			// sigh, dunno what else to try, I guess we'll have to give up and report this as an out-of-mem error...
-			//
-			// findlabel:  "recovermem"
-
-			Com_Printf(S_COLOR_RED"Z_Malloc(): Failed to alloc %d bytes (TAG_%s) !!!!!\n", iSize, psTagStrings[eTag]);
-			Z_Details_f();
-			Com_Error(ERR_FATAL,"(Repeat): Z_Malloc(): Failed to alloc %d bytes (TAG_%s) !!!!!\n", iSize, psTagStrings[eTag]);
+		// If the tag is TAG_SPECIAL_MEM_TEST tag, that means we are in a test and we can safely return NULL.
+		if (eTag == TAG_SPECIAL_MEM_TEST)
+		{
 			return NULL;
 		}
+
+		// sigh, dunno what else to try, I guess we'll have to give up and report this as an out-of-mem error...
+		//
+		// findlabel:  "recovermem"
+
+		Com_Printf(S_COLOR_RED"Z_Malloc(): Failed to alloc %d bytes (TAG_%s) !!!!!\n", iSize, psTagStrings[eTag]);
+		Z_Details_f();
+		Com_Error(ERR_FATAL,"(Repeat): Z_Malloc(): Failed to alloc %d bytes (TAG_%s) !!!!!\n", iSize, psTagStrings[eTag]);
+		return NULL;
 	}
 
 #ifdef DEBUG_ZONE_ALLOCS
@@ -597,16 +611,33 @@ void *S_Malloc( int iSize )
 
 
 #ifdef _DEBUG
+
 static void Z_MemRecoverTest_f(void)
 {
-	// needs to be in _DEBUG only, not good for final game!
-	// fixme: findmeste: Remove this sometime
-	//
-	int iTotalMalloc = 0;
+	//default amount of available memory
+	float fgb = 4;
+	if (Cmd_Argc() > 2) {
+		Com_Printf("usage: %s [<maximum in GiB>]\n", Cmd_Argv(0));
+		return;
+	}
+	if (Cmd_Argc() == 2) {
+		errno = 0;
+		fgb = strtof(Cmd_Argv(1), 0);
+		if (errno)
+		{
+			fgb = 4;
+		}
+		fgb = fabs(fgb);
+	}
+	size_t origLimit = Sys_LimitAvailableMemory(fgb * 1024 * 1024 * 1024);
+	size_t iTotalMalloc = 0;
+	gbMemFreeupOccured = qfalse;
 	while (1)
 	{
-		int iThisMalloc = 5* (1024 * 1024);
-		Z_Malloc(iThisMalloc, TAG_SPECIAL_MEM_TEST, qfalse);	// and lose, just to consume memory
+		int iThisMalloc = 5 * (1024 * 1024);
+		void *mem = Z_Malloc(iThisMalloc, TAG_SPECIAL_MEM_TEST, qfalse);	// and lose, just to consume memory
+		if (!mem)
+			break;
 		iTotalMalloc += iThisMalloc;
 
 		if (gbMemFreeupOccured)
@@ -614,6 +645,12 @@ static void Z_MemRecoverTest_f(void)
 	}
 
 	Z_TagFree(TAG_SPECIAL_MEM_TEST);
+
+	Com_Printf("Memory garbage collector did %srun.\n", gbMemFreeupOccured ? "" : "NOT ");
+
+	Com_Printf("Maximum allocated memory = %ld bytes\n", iTotalMalloc);
+
+	Sys_LimitAvailableMemory(origLimit);
 }
 #endif
 
@@ -623,13 +660,13 @@ static void Z_MemRecoverTest_f(void)
 
 static void Z_Stats_f(void)
 {
-	Com_Printf("\nThe zone is using %d bytes (%.2fMB) in %d memory blocks\n",
+	Com_Printf("\nThe zone is using %ld bytes (%.2fMB) in %d memory blocks\n",
 								  TheZone.Stats.iCurrent,
 									        (float)TheZone.Stats.iCurrent / 1024.0f / 1024.0f,
 													  TheZone.Stats.iCount
 				);
 
-	Com_Printf("The zone peaked at %d bytes (%.2fMB)\n",
+	Com_Printf("The zone peaked at %ld bytes (%.2fMB)\n",
 									TheZone.Stats.iPeak,
 									         (float)TheZone.Stats.iPeak / 1024.0f / 1024.0f
 				);
@@ -835,7 +872,7 @@ void Com_ShutdownZoneMemory(void)
 
 	if(TheZone.Stats.iCount)
 	{
-		Com_Printf("Automatically freeing %d blocks making up %d bytes\n", TheZone.Stats.iCount, TheZone.Stats.iCurrent);
+		Com_Printf("Automatically freeing %d blocks making up %ld bytes\n", TheZone.Stats.iCount, TheZone.Stats.iCurrent);
 		Z_TagFree(TAG_ALL);
 
 		assert(!TheZone.Stats.iCount);
@@ -891,6 +928,9 @@ char *CopyString( const char *in ) {
 
 	out = (char *) S_Malloc (strlen(in)+1);
 	strcpy (out, in);
+
+	Z_Label(out,in);
+
 	return out;
 }
 

--- a/codemp/qcommon/z_memman_pc.cpp
+++ b/codemp/qcommon/z_memman_pc.cpp
@@ -24,15 +24,22 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include "client/client.h" // hi i'm bad
 
+#ifdef DEBUG_ZONE_ALLOCS
+#include "sstring.h"
+int giZoneSnaphotNum=0;
+#define DEBUG_ZONE_ALLOC_OPTIONAL_LABEL_SIZE 256
+typedef sstring<DEBUG_ZONE_ALLOC_OPTIONAL_LABEL_SIZE> sDebugString_t;
+#endif
+
 ////////////////////////////////////////////////
 //
 #ifdef TAGDEF	// itu?
 #undef TAGDEF
 #endif
 #define TAGDEF(blah) #blah
-const static char *psTagStrings[TAG_COUNT+1]=	// +1 because TAG_COUNT will itself become a string here. Oh well.
+static const char *psTagStrings[TAG_COUNT+1]=	// +1 because TAG_COUNT will itself become a string here. Oh well.
 {
-	#include "qcommon/tags.h"
+	#include "tags.h"
 };
 //
 ////////////////////////////////////////////////
@@ -46,13 +53,20 @@ void CIN_CloseAllVideos();
 
 #define ZONE_MAGIC			0x21436587
 
+// if you change ANYTHING in this structure, be sure to update the tables below using DEF_STATIC...
 typedef struct zoneHeader_s
 {
-		int					iMagic;
-		memtag_t			eTag;
-		int					iSize;
-struct	zoneHeader_s		*pNext;
-struct	zoneHeader_s		*pPrev;
+		int						iMagic;
+		memtag_t				eTag;
+		int						iSize;
+		struct zoneHeader_s		*pNext;
+		struct zoneHeader_s		*pPrev;
+#ifdef DEBUG_ZONE_ALLOCS
+		char				sSrcFileBaseName[MAX_QPATH];
+		int				iSrcFileLineNum;
+		char				sOptionalLabel[DEBUG_ZONE_ALLOC_OPTIONAL_LABEL_SIZE];
+		int				iSnapshotNumber;
+#endif
 } zoneHeader_t;
 
 typedef struct
@@ -67,7 +81,7 @@ static inline zoneTail_t *ZoneTailFromHeader(zoneHeader_t *pHeader)
 }
 
 #ifdef DETAILED_ZONE_DEBUG_CODE
-map <void*,int> mapAllocatedZones;
+std::map <void*,int> mapAllocatedZones;
 #endif
 
 
@@ -155,23 +169,61 @@ typedef struct StaticMem_s {
 
 StaticZeroMem_t gZeroMalloc  =
 	{ {ZONE_MAGIC, TAG_STATIC,0,NULL,NULL},{ZONE_MAGIC}};
-StaticMem_t gEmptyString =
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'\0','\0'},{ZONE_MAGIC}};
-StaticMem_t gNumberString[] = {
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'0','\0'},{ZONE_MAGIC}},
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'1','\0'},{ZONE_MAGIC}},
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'2','\0'},{ZONE_MAGIC}},
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'3','\0'},{ZONE_MAGIC}},
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'4','\0'},{ZONE_MAGIC}},
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'5','\0'},{ZONE_MAGIC}},
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'6','\0'},{ZONE_MAGIC}},
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'7','\0'},{ZONE_MAGIC}},
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'8','\0'},{ZONE_MAGIC}},
-	{ {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL},{'9','\0'},{ZONE_MAGIC}},
+
+#ifdef DEBUG_ZONE_ALLOCS
+#define DEF_STATIC(_char) {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL, "<static>",0,"",0},{_char,'\0'},{ZONE_MAGIC}
+#else
+#define DEF_STATIC(_char) {ZONE_MAGIC, TAG_STATIC,2,NULL,NULL			        },{_char,'\0'},{ZONE_MAGIC}
+#endif
+
+const static StaticMem_t gEmptyString =
+	{ DEF_STATIC('\0') };
+
+const static StaticMem_t gNumberString[] = {
+	{ DEF_STATIC('0') },
+	{ DEF_STATIC('1') },
+	{ DEF_STATIC('2') },
+	{ DEF_STATIC('3') },
+	{ DEF_STATIC('4') },
+	{ DEF_STATIC('5') },
+	{ DEF_STATIC('6') },
+	{ DEF_STATIC('7') },
+	{ DEF_STATIC('8') },
+	{ DEF_STATIC('9') },
 };
 
+#ifdef DEBUG_ZONE_ALLOCS
+// returns actual filename only, no path
+// (copes with either slash-scheme for names)
+//
+// (normally I'd call another function for this, but this is supposed to be engine-independent,
+//	 so a certain amount of re-invention of the wheel is to be expected...)
+//
+char *_D_Z_Filename_WithoutPath(const char *psFilename)
+{
+	static char sString[ MAX_QPATH ];
+
+	const char *psCopyPos = psFilename;
+
+	while (*psFilename)
+	{
+		if (*psFilename == PATH_SEP)
+			psCopyPos = psFilename+1;
+		psFilename++;
+	}
+
+	strcpy(sString,psCopyPos);
+
+	return sString;
+}
+#endif
+
 qboolean gbMemFreeupOccured = qfalse;
-void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit /* = qfalse */, int iUnusedAlign /* = 4 */)
+#ifdef DEBUG_ZONE_ALLOCS
+void *_D_Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, int /* iAlign = 4 */, const char *psFile, int iLine)
+#else
+void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit, int /* iAlign = 4 */)
+#endif
 {
 	gbMemFreeupOccured = qfalse;
 
@@ -282,6 +334,13 @@ void *Z_Malloc(int iSize, memtag_t eTag, qboolean bZeroit /* = qfalse */, int iU
 		}
 	}
 
+#ifdef DEBUG_ZONE_ALLOCS
+	Q_strncpyz(pMemory->sSrcFileBaseName, _D_Z_Filename_WithoutPath(psFile), sizeof(pMemory->sSrcFileBaseName));
+	pMemory->iSrcFileLineNum	= iLine;	
+	pMemory->sOptionalLabel[0]	= '\0';
+	pMemory->iSnapshotNumber	= giZoneSnaphotNum;
+#endif
+
 	// Link in
 	pMemory->iMagic	= ZONE_MAGIC;
 	pMemory->eTag	= eTag;
@@ -391,8 +450,8 @@ static void Zone_FreeBlock(zoneHeader_t *pMemory)
 		{
 			pMemory->pNext->pPrev = pMemory->pPrev;
 		}
-		free (pMemory);
 
+		free (pMemory);
 
 		#ifdef DETAILED_ZONE_DEBUG_CODE
 		// this has already been checked for in execution order, but wtf?
@@ -427,6 +486,24 @@ int Z_Size(void *pvAddress)
 	return pMemory->iSize;
 }
 
+#ifdef DEBUG_ZONE_ALLOCS
+void _D_Z_Label(const void *pvAddress, const char *psLabel)
+{
+	zoneHeader_t *pMemory = ((zoneHeader_t *)pvAddress) - 1;
+
+	if (pMemory->eTag == TAG_STATIC)
+	{
+		return;
+	}
+
+	if (pMemory->iMagic != ZONE_MAGIC)
+	{
+		Com_Error(ERR_FATAL, "_D_Z_Label(): Not a valid zone header!");
+	}
+
+	Q_strncpyz(	pMemory->sOptionalLabel, psLabel, sizeof(pMemory->sOptionalLabel));
+}
+#endif
 
 // Frees a block of memory...
 //
@@ -506,9 +583,17 @@ void Z_TagFree(memtag_t eTag)
 }
 
 
-void *S_Malloc( int iSize ) {
-	return Z_Malloc( iSize, TAG_SMALL );
+#ifdef DEBUG_ZONE_ALLOCS
+void *_D_S_Malloc ( int iSize, const char *psFile, int iLine)
+{
+	return _D_Z_Malloc( iSize, TAG_SMALL, qfalse, 4, psFile, iLine );
 }
+#else
+void *S_Malloc( int iSize )
+{
+	return Z_Malloc( iSize, TAG_SMALL, qfalse, 4);
+}
+#endif
 
 
 #ifdef _DEBUG
@@ -582,6 +667,154 @@ static void Z_Details_f(void)
 
 	Z_Stats_f();
 }
+#ifdef DEBUG_ZONE_ALLOCS
+typedef std::map <sDebugString_t, int> LabelRefCount_t;	// yet another place where Gil's string class works and MS's doesn't
+typedef std::map <sDebugString_t, LabelRefCount_t>	TagBlockLabels_t;
+
+static TagBlockLabels_t AllTagBlockLabels;
+
+static void Z_Snapshot_f(void)
+{
+	AllTagBlockLabels.clear();
+
+	zoneHeader_t *pMemory = TheZone.Header.pNext;
+	while (pMemory)
+	{
+		AllTagBlockLabels[psTagStrings[pMemory->eTag]][pMemory->sOptionalLabel]++;
+		pMemory = pMemory->pNext;
+	}
+
+	giZoneSnaphotNum++;
+	Com_Printf("Ok.    ( Current snapshot num is now %d )\n",giZoneSnaphotNum);
+}
+
+static void Z_TagDebug_f(void)
+{
+	TagBlockLabels_t AllTagBlockLabels_Local;
+	qboolean bSnapShotTestActive = qfalse;
+
+	memtag_t eTag = TAG_ALL;
+
+	const char *psTAGName = Cmd_Argv(1);
+	if (psTAGName[0])
+	{
+		// check optional arg...
+		//
+		if (!Q_stricmp(psTAGName,"#snap"))
+		{
+			bSnapShotTestActive = qtrue;
+
+			AllTagBlockLabels_Local = AllTagBlockLabels;	// horrible great STL copy
+
+			psTAGName = Cmd_Argv(2);
+		}
+
+		if (psTAGName[0])
+		{
+			// skip over "tag_" if user supplied it...
+			//
+			if (!Q_stricmpn(psTAGName,"TAG_",4))
+			{
+				psTAGName += 4;
+			}
+
+			// see if the user specified a valid tag...
+			//
+			for (int i=0; i<TAG_COUNT; i++)
+			{
+				if (!Q_stricmp(psTAGName,psTagStrings[i]))
+				{
+					eTag = (memtag_t) i;
+					break;
+				}
+			}
+		}
+	}
+	else
+	{
+		Com_Printf("Usage: 'zone_tagdebug [#snap] <tag>', e.g. TAG_GHOUL2, TAG_ALL (careful!)\n");
+		return;
+	}
+
+	Com_Printf("Dumping debug data for tag \"%s\"...%s\n\n",psTagStrings[eTag], bSnapShotTestActive?"( since snapshot only )":"");
+
+	Com_Printf("%8s"," ");	// to compensate for code further down:   Com_Printf("(%5d) ",iBlocksListed);
+	if (eTag == TAG_ALL)
+	{
+		Com_Printf("%20s ","Zone Tag");
+	}
+	Com_Printf("%9s\n","Bytes");
+	Com_Printf("%8s"," ");
+	if (eTag == TAG_ALL)
+	{
+		Com_Printf("%20s ","--------");
+	}
+	Com_Printf("%9s\n","-----");
+
+
+	if (bSnapShotTestActive)
+	{
+		// dec ref counts in last snapshot for all current blocks (which will make new stuff go negative)
+		//
+		zoneHeader_t *pMemory = TheZone.Header.pNext;
+		while (pMemory)
+		{
+			if (pMemory->eTag == eTag || eTag == TAG_ALL)
+			{
+				AllTagBlockLabels_Local[psTagStrings[pMemory->eTag]][pMemory->sOptionalLabel]--;
+			}
+			pMemory = pMemory->pNext;
+		}
+	}
+
+	// now dump them out...
+	//
+	int iBlocksListed = 0;
+	int iTotalSize = 0;
+	zoneHeader_t *pMemory = TheZone.Header.pNext;
+	while (pMemory)
+	{
+		if (	(pMemory->eTag == eTag	|| eTag == TAG_ALL)
+			&&  (!bSnapShotTestActive	|| (pMemory->iSnapshotNumber == giZoneSnaphotNum && AllTagBlockLabels_Local[psTagStrings[pMemory->eTag]][pMemory->sOptionalLabel] <0) )
+			)
+		{
+			float	fSize		= (float)(pMemory->iSize) / 1024.0f / 1024.0f;
+			int		iSize		= fSize;
+			int		iRemainder 	= 100.0f * (fSize - floor(fSize));
+
+			Com_Printf("(%5d) ",iBlocksListed);
+
+			if (eTag == TAG_ALL)
+			{
+				Com_Printf("%20s",psTagStrings[pMemory->eTag]);
+			}
+
+			Com_Printf(" %9d (%2d.%02dMB) File: \"%s\", Line: %d\n",
+						  pMemory->iSize,
+							  iSize,iRemainder,
+												pMemory->sSrcFileBaseName,
+															pMemory->iSrcFileLineNum
+					   );
+			if (pMemory->sOptionalLabel[0])
+			{
+				Com_Printf("( Label: \"%s\" )\n",pMemory->sOptionalLabel);
+			}
+			iBlocksListed++;
+			iTotalSize += pMemory->iSize;
+
+			if (bSnapShotTestActive)
+			{
+				// bump ref count so we only 1 warning per new string, not for every one sharing that label...
+				//
+				AllTagBlockLabels_Local[psTagStrings[pMemory->eTag]][pMemory->sOptionalLabel]++;
+			}
+		}
+		pMemory = pMemory->pNext;
+	}
+
+	Com_Printf("( %d blocks listed, %d bytes (%.2fMB) total )\n",iBlocksListed, iTotalSize, (float)iTotalSize / 1024.0f / 1024.0f);
+}
+#endif
 
 // Shuts down the zone memory system and frees up all memory
 void Com_ShutdownZoneMemory(void)
@@ -590,6 +823,15 @@ void Com_ShutdownZoneMemory(void)
 
 	Cmd_RemoveCommand("zone_stats");
 	Cmd_RemoveCommand("zone_details");
+
+#ifdef _DEBUG
+	Cmd_RemoveCommand("zone_memrecovertest");
+#endif
+
+#ifdef DEBUG_ZONE_ALLOCS
+	Cmd_RemoveCommand("zone_tagdebug");
+	Cmd_RemoveCommand("zone_snapshot");
+#endif
 
 	if(TheZone.Stats.iCount)
 	{
@@ -610,17 +852,18 @@ void Com_InitZoneMemory( void )
 }
 
 void Com_InitZoneMemoryVars( void ) {
-	//#ifdef _DEBUG
-//	com_validateZone = Cvar_Get("com_validateZone", "1", 0);
-//#else
 	com_validateZone = Cvar_Get("com_validateZone", "0", 0);
-//#endif
 
 	Cmd_AddCommand("zone_stats", Z_Stats_f);
 	Cmd_AddCommand("zone_details", Z_Details_f);
 
 #ifdef _DEBUG
 	Cmd_AddCommand("zone_memrecovertest", Z_MemRecoverTest_f);
+#endif
+
+#ifdef DEBUG_ZONE_ALLOCS
+	Cmd_AddCommand("zone_tagdebug",	Z_TagDebug_f);
+	Cmd_AddCommand("zone_snapshot",	Z_Snapshot_f);
 #endif
 }
 

--- a/codemp/rd-common/tr_public.h
+++ b/codemp/rd-common/tr_public.h
@@ -258,7 +258,11 @@ typedef struct refimport_s {
 	void			(*Hunk_FreeTempMemory)				( void *buf );
 	void *			(*Hunk_Alloc)						( int size, ha_pref preference );
 	int				(*Hunk_MemoryRemaining)				( void );
+#ifdef DEBUG_ZONE_ALLOCS
+	void *			(*_D_Z_Malloc)						( int iSize, memtag_t eTag, qboolean bZeroit /*= qfalse*/, int iAlign /*= 4*/, const char *psFile, int iLine); // return memory NOT zero-filled by default
+#else
 	void *			(*Z_Malloc)							( int iSize, memtag_t eTag, qboolean bZeroit /*= qfalse*/, int iAlign /*= 4*/); // return memory NOT zero-filled by default
+#endif
 	void			(*Z_Free)							( void *ptr );
 	int				(*Z_MemSize)						( memtag_t eTag );
 	void			(*Z_MorphMallocTag)					( void *pvBuffer, memtag_t eDesiredTag );

--- a/codemp/rd-vanilla/CMakeLists.txt
+++ b/codemp/rd-vanilla/CMakeLists.txt
@@ -124,7 +124,7 @@ set(MPVanillaRendererIncludeDirectories ${MPVanillaRendererIncludeDirectories} $
 set(MPVanillaRendererLibraries ${MPVanillaRendererLibraries} ${OPENGL_LIBRARIES})
 
 set(MPVanillaRendererIncludeDirectories ${MPVanillaRendererIncludeDirectories} ${OpenJKLibDir})
-add_library(${MPVanillaRenderer} SHARED ${MPVanillaRendererFiles})
+add_library(${MPVanillaRenderer} MODULE ${MPVanillaRendererFiles})
 
 if(NOT MSVC)
 	# remove "lib" prefix for .so/.dylib files
@@ -133,7 +133,7 @@ endif()
 
 if(WIN32)
 	install(TARGETS ${MPVanillaRenderer}
-		RUNTIME
+		LIBRARY
 		DESTINATION ${JKAInstallDir}
 		COMPONENT ${JKAMPClientComponent})
 else(WIN32)

--- a/codemp/rd-vanilla/G2_API.cpp
+++ b/codemp/rd-vanilla/G2_API.cpp
@@ -676,7 +676,7 @@ void RestoreGhoul2InfoArray()
 void SaveGhoul2InfoArray()
 {
 	size_t size = singleton->GetSerializedSize();
-	void *data = Z_Malloc (size, TAG_GHOUL2);
+	void *data = Z_Malloc (size, TAG_GHOUL2, qfalse);
 #ifdef _DEBUG
 	size_t written =
 #endif

--- a/codemp/rd-vanilla/tr_WorldEffects.cpp
+++ b/codemp/rd-vanilla/tr_WorldEffects.cpp
@@ -898,7 +898,7 @@ public:
 		mRotation.mMin		= -0.7f;
 		mRotation.mMax		=  0.7f;
 		mRotationChangeTimer.mMin = 500;
-		mRotationChangeTimer.mMin = 2000;
+		mRotationChangeTimer.mMax = 2000;
 
 		mMass.mMin			= 5.0f;
 		mMass.mMax			= 10.0f;

--- a/codemp/rd-vanilla/tr_init.cpp
+++ b/codemp/rd-vanilla/tr_init.cpp
@@ -343,6 +343,18 @@ static void GLW_InitTextureCompression( void )
 		Com_Printf ("...GL_EXT_texture_compression_s3tc available\n" );
 	}
 
+#ifndef _WIN32
+	// Disable texture compressino method if no preferred texture compression method is defined
+	// and we are using the MESA opengl library.
+	if ((r_ext_preferred_tc_method->integer == TC_NONE)
+		&& (Q_stristr(glConfig.renderer_string, "mesa")))
+	{
+		Com_Printf("...MESA video driver detected, disabling texture compression.\n" );
+		Com_Printf(".....Set r_ext_preferred_tc_method to disable override.\n" );
+		ri->Cvar_Set("r_ext_compress_textures", "0");
+	}
+#endif
+
 	if ( !r_ext_compressed_textures->value )
 	{
 		// Compressed textures are off

--- a/codemp/rd-vanilla/tr_subs.cpp
+++ b/codemp/rd-vanilla/tr_subs.cpp
@@ -78,9 +78,15 @@ int Hunk_MemoryRemaining( void ) {
 }
 
 // ZONE
-void *Z_Malloc( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign ) {
+#ifdef DEBUG_ZONE_ALLOCS
+void *_D_Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign, const char *psFile, int iLine) {
+	return ri->_D_Z_Malloc( iSize, eTag, bZeroit, iAlign, psFile, iLine );
+}
+#else
+void *Z_Malloc ( int iSize, memtag_t eTag, qboolean bZeroit, int iAlign) {
 	return ri->Z_Malloc( iSize, eTag, bZeroit, iAlign );
 }
+#endif
 
 void Z_Free( void *ptr ) {
 	ri->Z_Free( ptr );

--- a/codemp/server/sv_ccmds.cpp
+++ b/codemp/server/sv_ccmds.cpp
@@ -607,7 +607,7 @@ static void SV_RehashBans_f( void )
 			return;
 		}
 
-		curpos = textbuf = (char *)Z_Malloc( filelen, TAG_TEMP_WORKSPACE );
+		curpos = textbuf = (char *)Z_Malloc( filelen, TAG_TEMP_WORKSPACE, qfalse );
 
 		filelen = FS_Read( textbuf, filelen, readfrom );
 		FS_FCloseFile( readfrom );
@@ -1742,7 +1742,7 @@ static int QDECL SV_DemoFolderTimeComparator( const void *arg1, const void *arg2
 
 // returns number of folders found.  pass NULL result pointer for just a count.
 static int SV_FindLeafFolders( const char *baseFolder, char *result, int maxResults, int maxFolderLength ) {
-	char *fileList = (char *)Z_Malloc( MAX_OSPATH * maxResults, TAG_FILESYS ); // too big for stack since this is recursive
+	char *fileList = (char *)Z_Malloc( MAX_OSPATH * maxResults, TAG_FILESYS, qfalse ); // too big for stack since this is recursive
 	char fullFolder[MAX_OSPATH];
 	int resultCount = 0;
 	char *fileName;

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -841,7 +841,11 @@ static void SV_InitRef( void ) {
 	ri.Hunk_FreeTempMemory = Hunk_FreeTempMemory;
 	ri.Hunk_Alloc = Hunk_Alloc;
 	ri.Hunk_MemoryRemaining = Hunk_MemoryRemaining;
+#ifdef DEBUG_ZONE_ALLOCS
+	ri._D_Z_Malloc = _D_Z_Malloc;
+#else
 	ri.Z_Malloc = Z_Malloc;
+#endif
 	ri.Z_Free = Z_Free;
 	ri.Z_MemSize = Z_MemSize;
 	ri.Z_MorphMallocTag = Z_MorphMallocTag;

--- a/codemp/ui/CMakeLists.txt
+++ b/codemp/ui/CMakeLists.txt
@@ -82,7 +82,7 @@ set(MPUIRendererFiles
 source_group("rd-common" FILES ${MPUIRendererFiles})
 set(MPUIFiles ${MPUIFiles} ${MPUIRendererFiles})
 
-add_library(${MPUI} SHARED ${MPUIFiles})
+add_library(${MPUI} MODULE ${MPUIFiles})
 
 if(NOT MSVC)
 	# remove "lib" prefix for .so/.dylib files
@@ -100,14 +100,14 @@ if(MakeApplicationBundles AND BuildMPEngine)
 		COMPONENT ${JKAMPCoreComponent})
 elseif(WIN32)
 	install(TARGETS ${MPUI}
-		RUNTIME
+		LIBRARY
 		DESTINATION "${JKAInstallDir}/OpenJK"
 		COMPONENT ${JKAMPCoreComponent})
 	if (WIN64)
 		# Don't do this on 32-bit Windows to avoid overwriting
 		# vanilla JKA's DLLs
 		install(TARGETS ${MPUI}
-			RUNTIME
+			LIBRARY
 			DESTINATION "${JKAInstallDir}/base"
 			COMPONENT ${JKAMPCoreComponent})
 	endif()

--- a/shared/sys/sys_main.cpp
+++ b/shared/sys/sys_main.cpp
@@ -108,7 +108,7 @@ char *Sys_GetClipboardData( void ) {
 	char *cbText = SDL_GetClipboardText();
 	size_t len = strlen( cbText ) + 1;
 
-	char *buf = (char *)Z_Malloc( len, TAG_CLIPBOARD );
+	char *buf = (char *) Z_Malloc( len, TAG_CLIPBOARD, qfalse );
 	Q_strncpyz( buf, cbText, len );
 
 	SDL_free( cbText );

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -153,6 +153,10 @@ qboolean Sys_LowPhysicalMemory();
 
 void Sys_SetProcessorAffinity( void );
 
+const char *Sys_TemporaryFilePath();
+
+bool Sys_WriteDataToPath(const char *path, const void *data, size_t length);
+
 #ifdef _DEBUG
 
 size_t Sys_LimitAvailableMemory(size_t limit);

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -153,6 +153,12 @@ qboolean Sys_LowPhysicalMemory();
 
 void Sys_SetProcessorAffinity( void );
 
+#ifdef _DEBUG
+
+size_t Sys_LimitAvailableMemory(size_t limit);
+
+#endif
+
 typedef enum graphicsApi_e
 {
 	GRAPHICS_API_GENERIC,

--- a/shared/sys/sys_unix.cpp
+++ b/shared/sys/sys_unix.cpp
@@ -528,6 +528,37 @@ void Sys_SetProcessorAffinity( void ) {
 #endif
 }
 
+#ifdef _DEBUG
+
+#include <sys/resource.h>
+/*
+=================
+Sys_LimitAvailableMemory
+
+Limit the maximum size of the process's virtual memory (in bytes).
+Returns the original limit.
+=================
+*/
+size_t Sys_LimitAvailableMemory(size_t limit)
+{
+	struct rlimit rlim;
+	size_t available;
+
+	if (getrlimit(RLIMIT_AS, &rlim))
+	{
+		return 0;
+	}
+	available = rlim.rlim_cur;
+	rlim.rlim_cur = limit;
+	if (setrlimit(RLIMIT_AS, &rlim))
+	{
+		return 0;
+	}
+	return available;
+}
+
+#endif
+
 UnpackDLLResult Sys_UnpackDLL(const char *name)
 {
 	return UnpackDLLResult();

--- a/shared/sys/sys_unix.cpp
+++ b/shared/sys/sys_unix.cpp
@@ -583,16 +583,16 @@ void Sys_AnsiColorPrint( const char *msg )
 	int         length = 0;
 	static int  q3ToAnsi[Q_COLOR_BITS+1] =
 	{
-		30, // COLOR_BLACK
-		31, // COLOR_RED
-		32, // COLOR_GREEN
-		33, // COLOR_YELLOW
-		34, // COLOR_BLUE
-		36, // COLOR_CYAN
-		35, // COLOR_MAGENTA
-		0,  // COLOR_WHITE
-		33, // COLOR_ORANGE // FIXME
-		30, // COLOR_GREY
+		16,  // COLOR_BLACK
+		196, // COLOR_RED
+		46,  // COLOR_GREEN
+		226, // COLOR_YELLOW
+		21,  // COLOR_BLUE
+		51,  // COLOR_CYAN
+		200, // COLOR_MAGENTA
+		231, // COLOR_WHITE
+		208, // COLOR_ORANGE
+		244, // COLOR_GREY
 	};
 
 	while ( *msg )
@@ -616,7 +616,7 @@ void Sys_AnsiColorPrint( const char *msg )
 			else
 			{
 				// Print the color code
-				Com_sprintf( buffer, sizeof( buffer ), "\033[%dm",
+				Com_sprintf( buffer, sizeof( buffer ), "\033[38;5;%dm",
 					q3ToAnsi[ColorIndex( *(msg + 1) )] );
 				fputs( buffer, stderr );
 				msg += 2;

--- a/shared/sys/sys_win32.cpp
+++ b/shared/sys/sys_win32.cpp
@@ -218,6 +218,23 @@ void Sys_SetProcessorAffinity( void ) {
 		Com_DPrintf( "Setting affinity mask failed (%s)\n", GetErrorString( GetLastError() ) );
 }
 
+#ifdef _DEBUG
+
+/*
+=================
+Sys_LimitAvailableMemory
+
+Limit the maximum size of the process's virtual memory (in bytes).
+=================
+*/
+size_t Sys_LimitAvailableMemory(size_t /*limit*/)
+{
+	//FIXME: Use Windows Job Objects
+	return 0;
+}
+
+#endif
+
 /*
 ==================
 Sys_LowPhysicalMemory()


### PR DESCRIPTION
Changes in this PR:
- t1_rail did not work in SP
- Fixed small memory leak due to wrong initialization of ZoneMemory
- Made debugging DEBUG_ZONE_ALLOC working again
- Repaired the memory garbage collector test (on Linux)
- Minimized the differences between SP and MP for the zone memory manager
- In OpenJK, all libraries are loaded at request, not linked at startup. Enforce that using CMAKE MODULE instead of LIBRARY)
- MP did not work on LInux (now it does again)
- MESA does not handle texture compression well, thus disable it (it can be overridden)
- Orange on linux tty works again