### PR TITLE
Filesystem RAII

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -181,6 +181,13 @@ if(BuildSPEngine OR BuildJK2SPEngine)
 		)
 	source_group("common" FILES ${SPEngineCommonFiles})
 	set(SPEngineFiles ${SPEngineFiles} ${SPEngineCommonFiles})
+	
+	set(SPEngineSafeCommonFiles
+		"${SharedDir}/qcommon/safe/files.cpp"
+		"${SharedDir}/qcommon/safe/files.h"
+		)
+	source_group("common/safe" FILES ${SPEngineCommonSafeFiles})
+	set(SPEngineFiles ${SPEngineFiles} ${SPEngineCommonSafeFiles})
 
 
 	# Server files

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -511,15 +511,6 @@ void	FS_ForceFlush( fileHandle_t f );
 void	FS_FreeFile( void *buffer );
 // frees the memory returned by FS_ReadFile
 
-class FS_AutoFreeFile {
-private:
-	FS_AutoFreeFile();
-	void *buffer;
-public:
-	FS_AutoFreeFile(void *inbuf) : buffer(inbuf) { };
-	~FS_AutoFreeFile() { if (buffer) FS_FreeFile(buffer); };
-};
-
 void	FS_WriteFile( const char *qpath, const void *buffer, int size );
 // writes a complete file, creating any subdirectories needed
 

--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -247,6 +247,13 @@ if(BuildMPEngine OR BuildMPDed)
 	endif(WIN32)
 	source_group("common" FILES ${MPEngineAndDedCommonFiles})
 	set(MPEngineAndDedFiles ${MPEngineAndDedFiles} ${MPEngineAndDedCommonFiles})
+	
+	set(MPEngineAndDedCommonSafeFiles
+		"${SharedDir}/qcommon/safe/files.cpp"
+		"${SharedDir}/qcommon/safe/files.h"
+		)
+	source_group("common/safe" FILES ${MPEngineAndDedCommonSafeFiles})
+	set(MPEngineAndDedFiles ${MPEngineAndDedFiles} ${MPEngineAndDedCommonSafeFiles})
 
 	set(MPEngineAndDedG2Files
 		"${MPDir}/ghoul2/G2.h"

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -633,15 +633,6 @@ void	FS_ForceFlush( fileHandle_t f );
 void	FS_FreeFile( void *buffer );
 // frees the memory returned by FS_ReadFile
 
-class FS_AutoFreeFile {
-private:
-	FS_AutoFreeFile();
-	void *buffer;
-public:
-	FS_AutoFreeFile(void *inbuf) : buffer(inbuf) { };
-	~FS_AutoFreeFile() { if (buffer) FS_FreeFile(buffer); };
-};
-
 void	FS_WriteFile( const char *qpath, const void *buffer, int size );
 // writes a complete file, creating any subdirectories needed
 

--- a/shared/qcommon/safe/files.cpp
+++ b/shared/qcommon/safe/files.cpp
@@ -4,19 +4,67 @@
 
 namespace FS
 {
-	FileList::~FileList() noexcept
+	//    FileBuffer
+
+	FileBuffer::FileBuffer( void* buffer, const long size ) noexcept
+		: _buffer( buffer )
+		, _size( size )
 	{
-		if( _begin )
+		assert( buffer != nullptr || size == 0 );
+		assert( size >= 0 );
+	}
+
+	FileBuffer::~FileBuffer() noexcept
+	{
+		if( _buffer )
 		{
-			FS_FreeFileList( _begin );
+			FS_FreeFile( _buffer );
 		}
 	}
+
+	FileBuffer::FileBuffer( FileBuffer&& rhs ) noexcept
+		: _buffer( rhs._buffer )
+		, _size( rhs._size )
+	{
+		rhs._buffer = nullptr;
+		rhs._size = 0;
+	}
+
+	FileBuffer& FileBuffer::operator=( FileBuffer&& rhs ) noexcept
+	{
+		if( _buffer )
+		{
+			FS_FreeFile( _buffer );
+		}
+		_buffer = rhs._buffer;
+		rhs._buffer = nullptr;
+		_size = rhs._size;
+		rhs._size = 0;
+		return *this;
+	}
+
+	FileBuffer ReadFile( const char* path )
+	{
+		void* buffer;
+		const long size = FS_ReadFile( path, &buffer );
+		return size >= 0 ? FileBuffer{ buffer, size } : FileBuffer{};
+	}
+
+	//    FileList
 
 	FileList::FileList( char** files, int numFiles ) noexcept
 		: _begin( files )
 		, _end( files + numFiles )
 	{
 		assert( numFiles >= 0 );
+	}
+
+	FileList::~FileList() noexcept
+	{
+		if( _begin )
+		{
+			FS_FreeFileList( _begin );
+		}
 	}
 
 	FileList::FileList( FileList&& rhs ) noexcept

--- a/shared/qcommon/safe/files.cpp
+++ b/shared/qcommon/safe/files.cpp
@@ -1,0 +1,49 @@
+#include "files.h"
+
+#include "qcommon/qcommon.h"
+
+namespace FS
+{
+	FileList::~FileList() noexcept
+	{
+		if( _begin )
+		{
+			FS_FreeFileList( _begin );
+		}
+	}
+
+	FileList::FileList( char** files, int numFiles ) noexcept
+		: _begin( files )
+		, _end( files + numFiles )
+	{
+		assert( numFiles >= 0 );
+	}
+
+	FileList::FileList( FileList&& rhs ) noexcept
+		: _begin( rhs._begin )
+		, _end( rhs._end )
+	{
+		rhs._begin = nullptr;
+		rhs._end = nullptr;
+	}
+
+	FileList& FileList::operator=( FileList&& rhs ) noexcept
+	{
+		if( _begin != nullptr )
+		{
+			FS_FreeFileList( _begin );
+		}
+		_begin = rhs._begin;
+		rhs._begin = nullptr;
+		_end = rhs._end;
+		rhs._end = nullptr;
+		return *this;
+	}
+
+	FileList ListFiles( const char * directory, const char * extension )
+	{
+		int numFiles{};
+		auto files = FS_ListFiles( directory, extension, &numFiles );
+		return FileList{ files, numFiles };
+	}
+}

--- a/shared/qcommon/safe/files.h
+++ b/shared/qcommon/safe/files.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstddef>
+#include <cassert>
+
+namespace FS
+{
+	class FileList
+	{
+		friend FileList ListFiles( const char*, const char* );
+	public:
+		FileList() noexcept = default;
+		~FileList() noexcept;
+		// noncopyable
+		FileList( const FileList& ) = delete;
+		FileList& operator=( const FileList& ) = delete;
+		// movable
+		FileList( FileList&& rhs ) noexcept;
+		FileList& operator=( FileList&& rhs ) noexcept;
+
+		const char *const *begin() const noexcept
+		{
+			return _begin;
+		}
+		const char *const *end() const noexcept
+		{
+			return _end;
+		}
+		std::size_t size() const noexcept
+		{
+			return static_cast< std::size_t >( _end - _begin );
+		}
+
+	private:
+		// called by ListFiles(), which is a friend.
+		FileList( char** files, int numFiles ) noexcept;
+		
+	private:
+		// TODO: this should really be const; it's a matter of making FS_ListFiles' result const.
+		char** _begin = nullptr;
+		const char* const* _end = nullptr;
+	};
+
+	/**
+	@brief Returns a list of the files in a directory.
+
+	The returned files will not include any directories or `/`.
+
+	@note ERR_FATAL if called before file system initialization
+	@todo Which is it? Returns no directories at all, or returns them when looking for extension "/"?
+	@param directory should not have either a leading or trailing /
+	@param extension if "/", only subdirectories will be returned
+	*/
+	FileList ListFiles( const char* directory, const char* extension );
+}


### PR DESCRIPTION
C++11 RAII wrappers for `FS_FileList()` and `FS_ReadFile()`: `FS::FileList()` and `FS::ReadFile()` with foreach support. Removed `FS_AutoReadFile`, which allowed for misuse.

I think using C++'s namespaces for C++ features makes sense, hence the names.