### PR TITLE
move travis-ci from Ubuntu 12.04 to 14.04, and fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
-sudo: true
+sudo: required
+dist: trusty
 
 install:
   - ./tools/travis-install.sh "${host:-native}" "${flavour:-Release}" $opts
@@ -11,7 +12,7 @@ compiler: gcc
 env:
   - ""
   - flavour=Debug
-  #- host=i686-linux-gnu
+  - host=i686-linux-gnu
   - host=i686-w64-mingw32
   - host=x86_64-w64-mingw32
 

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -109,6 +109,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include <errno.h>
 #include <stddef.h>
 
+#ifdef __cplusplus
+#include <cmath>
+#endif
+
 //Ignore __attribute__ on non-gcc platforms
 #if !defined(__GNUC__) && !defined(__attribute__)
 	#define __attribute__(x)
@@ -777,8 +781,10 @@ inline vec_t VectorNormalize2( const vec3_t v, vec3_t out) {
 int Q_log2(int val);
 
 inline qboolean Q_isnan ( float f ) {
-#ifdef _WIN32
+#ifdef _MSC_VER
 	return _isnan (f);
+#elif defined(__cplusplus)
+        return std::isnan (f);
 #else
 	return isnan (f);
 #endif

--- a/codeJK2/game/Q3_Interface.cpp
+++ b/codeJK2/game/Q3_Interface.cpp
@@ -8613,7 +8613,7 @@ static int Q3_GetString( int entID, int type, const char *name, char **value )
 	case SET_ANIM_BOTH:
 		*value = (char *) Q3_GetAnimBoth( ent );
 
-		if ( VALIDSTRING( value ) == false )
+		if ( VALIDSTRING( *value ) == false )
 			return false;
 
 		break;

--- a/codemp/qcommon/q_math.c
+++ b/codemp/qcommon/q_math.c
@@ -1168,7 +1168,7 @@ float Q_powf ( float x, int y )
 
 qboolean Q_isnan (float f)
 {
-#ifdef _WIN32
+#ifdef _MSC_VER
 	return (qboolean)(_isnan (f) != 0);
 #else
 	return (qboolean)(isnan (f) != 0);

--- a/tools/travis-build.sh
+++ b/tools/travis-build.sh
@@ -42,7 +42,6 @@ set -- -D CMAKE_BUILD_TYPE="$flavour" "$@"
 	-D BuildJK2SPGame=ON \
 	-D BuildJK2SPRdVanilla=ON \
 	-D CMAKE_INSTALL_PREFIX=/prefix \
-	-D CMAKE_VERBOSE_MAKEFILE=ON \
 	"$@" .. )
 make -C build
 make -C build install DESTDIR=$(pwd)/build/DESTDIR

--- a/tools/travis-install.sh
+++ b/tools/travis-install.sh
@@ -7,11 +7,18 @@ host="$1"
 flavour="$2"
 shift 2
 
-# We need cmake from Ubuntu 14.04 (trusty), the version in 12.04 is too old.
-# We also need SDL2, which is broken in 14.04 but OK in trusty-updates;
-# and dpkg from 14.04 fixes installation of libglib2.0-dev:i386.
-echo "deb http://archive.ubuntu.com/ubuntu trusty main universe" | sudo tee -a /etc/apt/sources.list
-echo "deb http://archive.ubuntu.com/ubuntu trusty-updates main universe" | sudo tee -a /etc/apt/sources.list
+# travis-ci's Ubuntu 14.04 image provides an apt source for Chrome,
+# which breaks i386 multiarch. Disable it: we don't need it for any of
+# these builds anyway.
+: | sudo tee /etc/apt/sources.list.d/google-chrome.list
+
+# do this before apt-get update
+case "${host}" in
+	(i?86-linux-gnu)
+		sudo dpkg --add-architecture i386
+		;;
+esac
+
 sudo apt-get update -qq
 sudo apt-get -q -y install cmake dpkg
 
@@ -39,6 +46,7 @@ case "${host}" in
 			libgl1-mesa-dev:i386 libpulse-dev:i386 libglu1-mesa-dev:i386 \
 			libsdl2-dev:i386 libjpeg-turbo8-dev:i386 zlib1g-dev:i386 libc6-dev:i386 \
 			libpng12-dev:i386 \
-			g++-multilib g++ gcc cpp g++-4.8 gcc-4.8 g++-4.8-multilib
+			g++-multilib g++-4.8-multilib gcc-4.8-multilib \
+			g++ g++-4.8 gcc gcc-4.8 cpp cpp-4.8
 		;;
 esac


### PR DESCRIPTION
The master branch [fails to build on travis-ci](https://travis-ci.org/smcv/OpenJK/builds/87619402) because Ubuntu 12.04's compiler does not support `-std=c++11` (#738). This branch switches to travis-ci's new Ubuntu 14.04 infrastructure, and fixes some compiler errors on that platform, resulting in [a successful build again](https://travis-ci.org/smcv/OpenJK/builds/87619298).

See individual commit mesages for more details.