### PR TITLE
[SP] generic parser 2 cleanup

### DIFF
--- a/code/cgame/FxScheduler.cpp
+++ b/code/cgame/FxScheduler.cpp
@@ -443,7 +443,7 @@ int CFxScheduler::RegisterEffect( const char *file, bool bHasCorrectPath /*= fal
 	char			*data;
 	char			temp[MAX_QPATH];
 	const char		*pfile;
-	char			*bufParse = 0;
+	const char		*bufParse = 0;
 
 	if (bHasCorrectPath)
 	{

--- a/code/cgame/FxScheduler.cpp
+++ b/code/cgame/FxScheduler.cpp
@@ -39,6 +39,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 	#include "../qcommon/q_shared.h"
 #endif
 
+#include "qcommon/safe/string.h"
 #include <cmath>
 
 
@@ -395,7 +396,7 @@ void CFxScheduler::Clean(bool bRemoveTemplates /*= true*/, int idToPreserve /*= 
 // Return:
 //	int handle to the effect
 //------------------------------------------------------
-int CFxScheduler::RegisterEffect( const char *file, bool bHasCorrectPath /*= false*/ )
+int CFxScheduler::RegisterEffect( const char *path, bool bHasCorrectPath /*= false*/ )
 {
 	// Dealing with file names:
 	// File names can come from two places - the editor, in which case we should use the given
@@ -403,93 +404,69 @@ int CFxScheduler::RegisterEffect( const char *file, bool bHasCorrectPath /*= fal
 	// In either case we create a stripped file name to use for naming effects.
 	//
 
-	char sfile[MAX_QPATH];
+	// FIXME: this could maybe be a cstring_view, if mEffectIDs were to use a transparent comparator, but those were only added in C++14, which we don't support yet (sigh)
+	char filenameNoExt[MAX_QPATH];
 
 	// Get an extension stripped version of the file
 	if (bHasCorrectPath)
 	{
-		const char *last = file, *p = file;
-
+		// FIXME: this is basically COM_SkipPath, except it also accepts '\\' instead of '/'
+		const char *last = path, *p = path;
 		while (*p != '\0')
 		{
 			if ((*p == '/') || (*p == '\\'))
 			{
 				last = p + 1;
 			}
-
 			p++;
 		}
 
-		COM_StripExtension( last, sfile, sizeof(sfile) );
+		COM_StripExtension( last, filenameNoExt, sizeof( filenameNoExt ) );
 	}
 	else
 	{
-		COM_StripExtension( file, sfile, sizeof(sfile) );
+		COM_StripExtension( path, filenameNoExt, sizeof( filenameNoExt ) );
 	}
 
 	// see if the specified file is already registered.  If it is, just return the id of that file
 	TEffectID::iterator itr;
 
-	itr = mEffectIDs.find( sfile );
+	itr = mEffectIDs.find( filenameNoExt );
 
 	if ( itr != mEffectIDs.end() )
 	{
 		return (*itr).second;
 	}
 
-	CGenericParser2	parser;
-	int				len = 0;
-	fileHandle_t	fh;
-	char			*data;
-	char			temp[MAX_QPATH];
+	char			correctFilenameBuffer[MAX_QPATH];
 	const char		*pfile;
-	const char		*bufParse = 0;
-
 	if (bHasCorrectPath)
 	{
-		pfile = file;
+		pfile = path;
 	}
 	else
 	{
 		// Add on our extension and prepend the file with the default path
-		Com_sprintf( temp, sizeof(temp), "%s/%s.efx", FX_FILE_PATH, sfile );
-		pfile = temp;
+		Com_sprintf( correctFilenameBuffer, sizeof( correctFilenameBuffer ), "%s/%s.efx", FX_FILE_PATH, filenameNoExt );
+		pfile = correctFilenameBuffer;
 	}
-
-	len = theFxHelper.OpenFile( pfile, &fh, FS_READ );
-
-	if ( len < 0 )
-	{
-		theFxHelper.Print( "RegisterEffect: failed to load: %s\n", pfile );
-		return 0;
-	}
-
-	if (len == 0)
-	{
-		theFxHelper.Print( "RegisterEffect: INVALID file: %s\n", pfile );
-		theFxHelper.CloseFile( fh );
-		return 0;
-	}
-
-	// Allocate enough space to hold the file
-	// This should be flagged temp, but it seems ok as is.
-	data = new char[len+1];
-
-	// Get the goods and ensure Null termination
-	theFxHelper.ReadFile( data, len, fh );
-	data[len] = '\0';
-	bufParse = data;
 
 	// Let the generic parser process the whole file
-	parser.Parse( &bufParse );
-
-	theFxHelper.CloseFile( fh );
-
-	// Delete our temp copy of the file
-	delete [] data;
-
+	CGenericParser2	parser;
+	if( !parser.Parse( pfile ) )
+	{
+		if( !parser.ValidFile() )
+		{
+			theFxHelper.Print( "RegisterEffect: INVALID file: %s\n", pfile );
+		}
+		return false;
+		if( parser.ValidFile() )
+		{
+			return false;
+		}
+	}
 	// Lets convert the effect file into something that we can work with
-	return ParseEffect( sfile, parser.GetBaseParseGroup() );
+	return ParseEffect( filenameNoExt, parser.GetBaseParseGroup() );
 }
 
 
@@ -507,34 +484,10 @@ int CFxScheduler::RegisterEffect( const char *file, bool bHasCorrectPath /*= fal
 //	int handle of the effect
 //------------------------------------------------------
 
-struct primitiveType_s { const char *name; EPrimType type; } primitiveTypes[] = {
-	{ "particle", Particle },
-	{ "line", Line },
-	{ "tail", Tail },
-	{ "sound", Sound },
-	{ "cylinder", Cylinder },
-	{ "electricity", Electricity },
-	{ "emitter", Emitter },
-	{ "decal", Decal },
-	{ "orientedparticle", OrientedParticle },
-	{ "fxrunner", FxRunner },
-	{ "light", Light },
-	{ "cameraShake", CameraShake },
-	{ "flash", ScreenFlash },
-};
-static const size_t numPrimitiveTypes = ARRAY_LEN( primitiveTypes );
-
-int CFxScheduler::ParseEffect( const char *file, CGPGroup *base )
+int CFxScheduler::ParseEffect( const char *file, const CGPGroup& base )
 {
-	CGPGroup			*primitiveGroup;
-	CPrimitiveTemplate	*prim;
-	const char			*grpName;
-	SEffectTemplate		*effect = 0;
-	EPrimType			type;
-	int					handle;
-	CGPValue			*pair;
-
-	effect = GetNewEffectTemplate( &handle, file );
+	int handle;
+	SEffectTemplate* effect = GetNewEffectTemplate( &handle, file );
 
 	if ( !handle || !effect )
 	{
@@ -542,45 +495,42 @@ int CFxScheduler::ParseEffect( const char *file, CGPGroup *base )
 		return 0;
 	}
 
-	if ((pair = base->GetPairs())!=0)
+	for( auto& property : base.GetProperties() )
 	{
-		grpName = pair->GetName();
-		if ( !Q_stricmp( grpName, "repeatDelay" ))
+		if( Q::stricmp( property.GetName(), CSTRING_VIEW( "repeatDelay" ) ) == Q::Ordering::EQ )
 		{
-			effect->mRepeatDelay = atoi(pair->GetTopValue());
-		}
-		else
-		{//unknown
-
+			effect->mRepeatDelay = Q::svtoi( property.GetTopValue() );
 		}
 	}
 
-	primitiveGroup = base->GetSubGroups();
-
-	while ( primitiveGroup )
+	for( const auto& primitiveGroup : base.GetSubGroups() )
 	{
-		grpName = primitiveGroup->GetName();
-
-		type = None;
-		for ( size_t i=0; i<numPrimitiveTypes; i++ ) {
-			if ( !Q_stricmp( grpName, primitiveTypes[i].name ) ) {
-				type = primitiveTypes[i].type;
-				break;
-			}
-		}
-
-		if ( type != None )
+		static std::map< gsl::cstring_view, EPrimType, Q::CStringViewILess > primitiveTypes{
+			{ CSTRING_VIEW( "particle" ), Particle },
+			{ CSTRING_VIEW( "line" ), Line },
+			{ CSTRING_VIEW( "tail" ), Tail },
+			{ CSTRING_VIEW( "sound" ), Sound },
+			{ CSTRING_VIEW( "cylinder" ), Cylinder },
+			{ CSTRING_VIEW( "electricity" ), Electricity },
+			{ CSTRING_VIEW( "emitter" ), Emitter },
+			{ CSTRING_VIEW( "decal" ), Decal },
+			{ CSTRING_VIEW( "orientedparticle" ), OrientedParticle },
+			{ CSTRING_VIEW( "fxrunner" ), FxRunner },
+			{ CSTRING_VIEW( "light" ), Light },
+			{ CSTRING_VIEW( "cameraShake" ), CameraShake },
+			{ CSTRING_VIEW( "flash" ), ScreenFlash }
+		};
+		auto pos = primitiveTypes.find( primitiveGroup.GetName() );
+		if( pos != primitiveTypes.end() )
 		{
-			prim = new CPrimitiveTemplate;
+			CPrimitiveTemplate *prim = new CPrimitiveTemplate;
 
-			prim->mType = type;
+			prim->mType = pos->second;
 			prim->ParsePrimitive( primitiveGroup );
 
 			// Add our primitive template to the effect list
 			AddPrimitiveToEffect( effect, prim );
 		}
-
-		primitiveGroup = (CGPGroup *)primitiveGroup->GetNext();
 	}
 
 	return handle;
@@ -654,7 +604,7 @@ SEffectTemplate *CFxScheduler::GetNewEffectTemplate( int *id, const char *file )
 
 	theFxHelper.Print( "FxScheduler:  Error--reached max effects\n" );
 	*id = 0;
-	return 0;
+	return nullptr;
 }
 
 //------------------------------------------------------

--- a/code/cgame/FxScheduler.h
+++ b/code/cgame/FxScheduler.h
@@ -28,6 +28,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "../qcommon/sstring.h"
 typedef sstring_t fxString_t;
 
+#include "../game/genericparser2.h"
+#include "qcommon/safe/string.h"
+
 #ifndef FX_SCHEDULER_H_INC
 #define FX_SCHEDULER_H_INC
 
@@ -270,88 +273,95 @@ public:
 
 	CFxRange		mElasticity;
 
+private:
 
 	// Lower level parsing utilities
-	bool ParseVector( const char *val, vec3_t min, vec3_t max );
-	bool ParseFloat( const char *val, float *min, float *max );
-	bool ParseGroupFlags( const char *val, int *flags );
+	bool ParseVector( const gsl::cstring_view& val, vec3_t min, vec3_t max );
+	bool ParseFloat( const gsl::cstring_view& val, float& min, float& max );
+	bool ParseGroupFlags( const gsl::cstring_view& val, int& flags );
 
 	// Base key processing
 	// Note that these all have their own parse functions in case it becomes important to do certain kinds
 	//	of validation specific to that type.
-	bool ParseMin( const char *val );
-	bool ParseMax( const char *val );
-	bool ParseDelay( const char *val );
-	bool ParseCount( const char *val );
-	bool ParseLife( const char *val );
-	bool ParseElasticity( const char *val );
-	bool ParseFlags( const char *val );
-	bool ParseSpawnFlags( const char *val );
+	bool ParseMin( const gsl::cstring_view& val );
+	bool ParseMax( const gsl::cstring_view& val );
+	bool ParseDelay( const gsl::cstring_view& val );
+	bool ParseCount( const gsl::cstring_view& val );
+	bool ParseLife( const gsl::cstring_view& val );
+	bool ParseElasticity( const gsl::cstring_view& val );
+	bool ParseFlags( const gsl::cstring_view& val );
+	bool ParseSpawnFlags( const gsl::cstring_view& val );
 
-	bool ParseOrigin1( const char *val );
-	bool ParseOrigin2( const char *val );
-	bool ParseRadius( const char *val );
-	bool ParseHeight( const char *val );
-	bool ParseWindModifier( const char *val );
-	bool ParseRotation( const char *val );
-	bool ParseRotationDelta( const char *val );
-	bool ParseAngle( const char *val );
-	bool ParseAngleDelta( const char *val );
-	bool ParseVelocity( const char *val );
-	bool ParseAcceleration( const char *val );
-	bool ParseGravity( const char *val );
-	bool ParseDensity( const char *val );
-	bool ParseVariance( const char *val );
+	bool ParseOrigin1( const gsl::cstring_view& val );
+	bool ParseOrigin2( const gsl::cstring_view& val );
+	bool ParseRadius( const gsl::cstring_view& val );
+	bool ParseHeight( const gsl::cstring_view& val );
+	bool ParseWindModifier( const gsl::cstring_view& val );
+	bool ParseRotation( const gsl::cstring_view& val );
+	bool ParseRotationDelta( const gsl::cstring_view& val );
+	bool ParseAngle( const gsl::cstring_view& val );
+	bool ParseAngleDelta( const gsl::cstring_view& val );
+	bool ParseVelocity( const gsl::cstring_view& val );
+	bool ParseAcceleration( const gsl::cstring_view& val );
+	bool ParseGravity( const gsl::cstring_view& val );
+	bool ParseDensity( const gsl::cstring_view& val );
+	bool ParseVariance( const gsl::cstring_view& val );
 
+	/// Case insensitive map from cstring_view to Value
+	template< typename Value >
+	using StringViewIMap = std::map< gsl::cstring_view, Value, Q::CStringViewILess >;
+	using ParseMethod = bool ( CPrimitiveTemplate::* )( const gsl::cstring_view& );
 	// Group type processing
-	bool ParseRGB( CGPGroup *grp );
-	bool ParseAlpha( CGPGroup *grp );
-	bool ParseSize( CGPGroup *grp );
-	bool ParseSize2( CGPGroup *grp );
-	bool ParseLength( CGPGroup *grp );
+	bool ParseGroup( const CGPGroup& grp, const StringViewIMap< ParseMethod >& parseMethods, gsl::czstring name );
+	bool ParseRGB( const CGPGroup& grp );
+	bool ParseAlpha( const CGPGroup& grp );
+	bool ParseSize( const CGPGroup& grp );
+	bool ParseSize2( const CGPGroup& grp );
+	bool ParseLength( const CGPGroup& grp );
 
-	bool ParseModels( CGPValue *grp );
-	bool ParseShaders( CGPValue *grp );
-	bool ParseSounds( CGPValue *grp );
+	bool ParseModels( const CGPProperty& grp );
+	bool ParseShaders( const CGPProperty& grp );
+	bool ParseSounds( const CGPProperty& grp );
 
-	bool ParseImpactFxStrings( CGPValue *grp );
-	bool ParseDeathFxStrings( CGPValue *grp );
-	bool ParseEmitterFxStrings( CGPValue *grp );
-	bool ParsePlayFxStrings( CGPValue *grp );
+	bool ParseImpactFxStrings( const CGPProperty& grp );
+	bool ParseDeathFxStrings( const CGPProperty& grp );
+	bool ParseEmitterFxStrings( const CGPProperty& grp );
+	bool ParsePlayFxStrings( const CGPProperty& grp );
 
 	// Group keys
-	bool ParseRGBStart( const char *val );
-	bool ParseRGBEnd( const char *val );
-	bool ParseRGBParm( const char *val );
-	bool ParseRGBFlags( const char *val );
+	bool ParseRGBStart( const gsl::cstring_view& val );
+	bool ParseRGBEnd( const gsl::cstring_view& val );
+	bool ParseRGBParm( const gsl::cstring_view& val );
+	bool ParseRGBFlags( const gsl::cstring_view& val );
 
-	bool ParseAlphaStart( const char *val );
-	bool ParseAlphaEnd( const char *val );
-	bool ParseAlphaParm( const char *val );
-	bool ParseAlphaFlags( const char *val );
+	bool ParseAlphaStart( const gsl::cstring_view& val );
+	bool ParseAlphaEnd( const gsl::cstring_view& val );
+	bool ParseAlphaParm( const gsl::cstring_view& val );
+	bool ParseAlphaFlags( const gsl::cstring_view& val );
 
-	bool ParseSizeStart( const char *val );
-	bool ParseSizeEnd( const char *val );
-	bool ParseSizeParm( const char *val );
-	bool ParseSizeFlags( const char *val );
+	bool ParseSizeStart( const gsl::cstring_view& val );
+	bool ParseSizeEnd( const gsl::cstring_view& val );
+	bool ParseSizeParm( const gsl::cstring_view& val );
+	bool ParseSizeFlags( const gsl::cstring_view& val );
 
-	bool ParseSize2Start( const char *val );
-	bool ParseSize2End( const char *val );
-	bool ParseSize2Parm( const char *val );
-	bool ParseSize2Flags( const char *val );
+	bool ParseSize2Start( const gsl::cstring_view& val );
+	bool ParseSize2End( const gsl::cstring_view& val );
+	bool ParseSize2Parm( const gsl::cstring_view& val );
+	bool ParseSize2Flags( const gsl::cstring_view& val );
 
-	bool ParseLengthStart( const char *val );
-	bool ParseLengthEnd( const char *val );
-	bool ParseLengthParm( const char *val );
-	bool ParseLengthFlags( const char *val );
+	bool ParseLengthStart( const gsl::cstring_view& val );
+	bool ParseLengthEnd( const gsl::cstring_view& val );
+	bool ParseLengthParm( const gsl::cstring_view& val );
+	bool ParseLengthFlags( const gsl::cstring_view& val );
 
 
 public:
 
 	CPrimitiveTemplate();
+	CPrimitiveTemplate( const CPrimitiveTemplate& rhs );
 	~CPrimitiveTemplate()	{};
 
-	bool ParsePrimitive( CGPGroup *grp );
+	bool ParsePrimitive( const CGPGroup& grp );
 
 	void operator=(const CPrimitiveTemplate &that);
 };
@@ -452,7 +462,7 @@ private:
 	SEffectTemplate *GetNewEffectTemplate( int *id, const char *file );
 
 	void	AddPrimitiveToEffect( SEffectTemplate *fx, CPrimitiveTemplate *prim );
-	int		ParseEffect( const char *file, CGPGroup *base );
+	int		ParseEffect( const char *file, const CGPGroup& base );
 
 	void	CreateEffect( CPrimitiveTemplate *fx, const vec3_t origin, vec3_t axis[3], int lateTime, int clientID = -1, int modelNum = -1, int boltNum = -1 );
 	void	CreateEffect( CPrimitiveTemplate *fx, int clientID, int lateTime );

--- a/code/cgame/FxSystem.cpp
+++ b/code/cgame/FxSystem.cpp
@@ -136,21 +136,23 @@ void SFxHelper::AddFxToScene( refEntity_t *ent )
 }
 
 //------------------------------------------------------
-int SFxHelper::RegisterShader( const char *shader )
+int SFxHelper::RegisterShader( const gsl::cstring_view& shader )
 {
-	return cgi_R_RegisterShader( shader );
+	// TODO: it would be nice to change the ABI here to allow for passing of string views
+	return cgi_R_RegisterShader( std::string( shader.begin(), shader.end() ).c_str() );
 }
 
 //------------------------------------------------------
-int SFxHelper::RegisterSound( const char *sound )
+int SFxHelper::RegisterSound( const gsl::cstring_view& sound )
 {
-	return cgi_S_RegisterSound( sound );
+	// TODO: it would be nice to change the ABI here to allow for passing of string views
+	return cgi_S_RegisterSound( std::string( sound.begin(), sound.end() ).c_str() );
 }
 
 //------------------------------------------------------
-int SFxHelper::RegisterModel( const char *model )
+int SFxHelper::RegisterModel( const gsl::cstring_view& model )
 {
-	return cgi_R_RegisterModel( model );
+	return cgi_R_RegisterModel( std::string( model.begin(), model.end() ).c_str() );
 }
 
 //------------------------------------------------------

--- a/code/cgame/FxSystem.h
+++ b/code/cgame/FxSystem.h
@@ -27,6 +27,8 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #ifndef FX_SYSTEM_H_INC
 #define FX_SYSTEM_H_INC
 
+#include "qcommon/safe/gsl.h"
+
 
 #define irand	Q_irand
 #define flrand	Q_flrand
@@ -76,7 +78,7 @@ struct SFxHelper
 	// Sound
 	void	PlaySound( const vec3_t origin, int entityNum, int entchannel, sfxHandle_t sfx );
 	void	PlayLocalSound( sfxHandle_t sfx, int channelNum );
-	int		RegisterSound( const char *sound );
+	int		RegisterSound( const gsl::cstring_view& sound );
 
 	//G2
 	int		GetOriginAxisFromBolt(const centity_t &cent, int modelNum, int boltNum, vec3_t /*out*/origin, vec3_t /*out*/*axis);
@@ -88,8 +90,8 @@ struct SFxHelper
 	void	AddFxToScene( refEntity_t *ent );
 	void	AddLightToScene( vec3_t org, float radius, float red, float green, float blue );
 
-	int		RegisterShader( const char *shader );
-	int		RegisterModel( const char *model );
+	int		RegisterShader( const gsl::cstring_view& shader );
+	int		RegisterModel( const gsl::cstring_view& model );
 
 	void	AddPolyToScene( int shader, int count, polyVert_t *verts );
 

--- a/code/cgame/FxTemplate.cpp
+++ b/code/cgame/FxTemplate.cpp
@@ -26,6 +26,11 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 	#include "FxScheduler.h"
 #endif
 
+#include "../game/genericparser2.h"
+#include "qcommon/safe/string.h"
+
+#include <array>
+
 //------------------------------------------------------
 // CPrimitiveTemplate
 //	Set up our minimal default values
@@ -188,16 +193,10 @@ void CPrimitiveTemplate::operator=(const CPrimitiveTemplate &that)
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseFloat( const char *val, float *min, float *max )
+bool CPrimitiveTemplate::ParseFloat( const gsl::cstring_view& val, float& min, float& max )
 {
-	// We don't allow passing in a null for either of the fields
-	if ( min == 0 || max == 0 )
-	{ // failue
-		return false;
-	}
-
 	// attempt to read out the values
-	int v = sscanf( val, "%f %f", min, max );
+	int v = Q::sscanf( val, min, max );
 
 	if ( v == 0 )
 	{ // nothing was there, failure
@@ -205,7 +204,7 @@ bool CPrimitiveTemplate::ParseFloat( const char *val, float *min, float *max )
 	}
 	else if ( v == 1 )
 	{ // only one field entered, this is ok, but we should copy min into max
-		*max = *min;
+		max = min;
 	}
 
 	return true;
@@ -225,16 +224,16 @@ bool CPrimitiveTemplate::ParseFloat( const char *val, float *min, float *max )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseVector( const char *val, vec3_t min, vec3_t max )
+bool CPrimitiveTemplate::ParseVector( const gsl::cstring_view& val, vec3_t min, vec3_t max )
 {
 	// we don't allow passing in a null
-	if ( min == 0 || max == 0 )
+	if ( min == nullptr || max == nullptr )
 	{
 		return false;
 	}
 
 	// attempt to read out our values
-	int v = sscanf( val, "%f %f %f   %f %f %f", &min[0], &min[1], &min[2], &max[0], &max[1], &max[2] );
+	int v = Q::sscanf( val, min[0], min[1], min[2], max[0], max[1], max[2] );
 
 	// Check for completeness
 	if ( v < 3 || v == 4 || v == 5 )
@@ -247,6 +246,38 @@ bool CPrimitiveTemplate::ParseVector( const char *val, vec3_t min, vec3_t max )
 	}
 
 	return true;
+}
+
+namespace detail
+{
+	// calls Q::sscanf with the elements of the given array as arguments
+
+	template< std::size_t remaining >
+	struct ScanStrings
+	{
+		template< std::size_t count, typename... Args >
+		static int call( const gsl::cstring_view& val, std::array< gsl::cstring_view, count >& arr, Args... args )
+		{
+			return ScanStrings< remaining - 1 >::call( val, arr, arr[ remaining - 1 ], args... );
+		}
+	};
+
+	template<>
+	struct ScanStrings< 0 >
+	{
+		template< std::size_t count, typename... Args >
+		static int call( const gsl::cstring_view& val, std::array< gsl::cstring_view, count >& arr, Args... args )
+		{
+			return Q::sscanf( val, args... );
+		}
+	};
+}
+
+template< std::size_t count >
+static gsl::array_view< gsl::cstring_view > scanStrings( const gsl::cstring_view& val, std::array< gsl::cstring_view, count >& arr )
+{
+	int numParsed = detail::ScanStrings< count >::call( val, arr );
+	return{ arr.data(), arr.data() + numParsed };
 }
 
 //------------------------------------------------------
@@ -262,53 +293,35 @@ bool CPrimitiveTemplate::ParseVector( const char *val, vec3_t min, vec3_t max )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseGroupFlags( const char *val, int *flags )
+bool CPrimitiveTemplate::ParseGroupFlags( const gsl::cstring_view& val, int& flags )
 {
-	// Must pass in a non-null pointer
-	if ( flags == 0 )
-	{
-		return false;
-	}
-
-	char	flag[][32] = {"\0","\0","\0","0"};
-	bool	ok = true;
-
 	// For a sub group, really you probably only have one or two flags set
-	int v = sscanf( val, "%s %s %s %s", flag[0], flag[1], flag[2], flag[3] );
+	std::array< gsl::cstring_view, 4 > flag;
+
+	const auto availableFlag = scanStrings( val, flag );
 
 	// Clear out the flags field, then convert the flag string to an actual value ( use generic flags )
-	*flags = 0;
+	flags = 0;
 
-	for ( int i = 0; i < 4; i++ )
+	bool ok = true;
+	for( auto& cur : availableFlag  )
 	{
-		if ( i + 1 > v )
-		{
-			return true;
-		}
+		static StringViewIMap< int > flagNames{
+			{ CSTRING_VIEW( "linear" ), FX_LINEAR },
+			{ CSTRING_VIEW( "nonlinear" ), FX_NONLINEAR },
+			{ CSTRING_VIEW( "wave" ), FX_WAVE },
+			{ CSTRING_VIEW( "random" ), FX_RAND },
+			{ CSTRING_VIEW( "clamp" ), FX_CLAMP },
+		};
 
-		if ( !Q_stricmp( flag[i], "linear" ))
+		auto pos = flagNames.find( cur );
+		if( pos == flagNames.end() )
 		{
-			*flags |= FX_LINEAR;
-		}
-		else if ( !Q_stricmp( flag[i], "nonlinear" ))
-		{
-			*flags |= FX_NONLINEAR;
-		}
-		else if ( !Q_stricmp( flag[i], "wave" ))
-		{
-			*flags |= FX_WAVE;
-		}
-		else if ( !Q_stricmp( flag[i], "random" ))
-		{
-			*flags |= FX_RAND;
-		}
-		else if ( !Q_stricmp( flag[i], "clamp" ))
-		{
-			*flags |= FX_CLAMP;
+			ok = false;
 		}
 		else
-		{ // we have badness going on, but continue on in case there are any valid fields in here
-			ok = false;
+		{
+			flags |= pos->second;
 		}
 	}
 
@@ -325,7 +338,7 @@ bool CPrimitiveTemplate::ParseGroupFlags( const char *val, int *flags )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseMin( const char *val )
+bool CPrimitiveTemplate::ParseMin( const gsl::cstring_view& val )
 {
 	vec3_t min;
 
@@ -351,7 +364,7 @@ bool CPrimitiveTemplate::ParseMin( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseMax( const char *val )
+bool CPrimitiveTemplate::ParseMax( const gsl::cstring_view& val )
 {
 	vec3_t max;
 
@@ -377,11 +390,11 @@ bool CPrimitiveTemplate::ParseMax( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseLife( const char *val )
+bool CPrimitiveTemplate::ParseLife( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mLife.SetRange( min, max );
 		return true;
@@ -400,11 +413,11 @@ bool CPrimitiveTemplate::ParseLife( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseDelay( const char *val )
+bool CPrimitiveTemplate::ParseDelay( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mSpawnDelay.SetRange( min, max );
 		return true;
@@ -423,11 +436,11 @@ bool CPrimitiveTemplate::ParseDelay( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseCount( const char *val )
+bool CPrimitiveTemplate::ParseCount( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mSpawnCount.SetRange( min, max );
 		return true;
@@ -446,11 +459,11 @@ bool CPrimitiveTemplate::ParseCount( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseElasticity( const char *val )
+bool CPrimitiveTemplate::ParseElasticity( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mElasticity.SetRange( min, max );
 
@@ -473,7 +486,7 @@ bool CPrimitiveTemplate::ParseElasticity( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseOrigin1( const char *val )
+bool CPrimitiveTemplate::ParseOrigin1( const gsl::cstring_view& val )
 {
 	vec3_t min, max;
 
@@ -498,7 +511,7 @@ bool CPrimitiveTemplate::ParseOrigin1( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseOrigin2( const char *val )
+bool CPrimitiveTemplate::ParseOrigin2( const gsl::cstring_view& val )
 {
 	vec3_t min, max;
 
@@ -523,11 +536,11 @@ bool CPrimitiveTemplate::ParseOrigin2( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseRadius( const char *val )
+bool CPrimitiveTemplate::ParseRadius( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mRadius.SetRange( min, max );
 		return true;
@@ -546,11 +559,11 @@ bool CPrimitiveTemplate::ParseRadius( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseHeight( const char *val )
+bool CPrimitiveTemplate::ParseHeight( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mHeight.SetRange( min, max );
 		return true;
@@ -569,11 +582,11 @@ bool CPrimitiveTemplate::ParseHeight( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseWindModifier( const char *val )
+bool CPrimitiveTemplate::ParseWindModifier( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mWindModifier.SetRange( min, max );
 		return true;
@@ -592,11 +605,11 @@ bool CPrimitiveTemplate::ParseWindModifier( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseRotation( const char *val )
+bool CPrimitiveTemplate::ParseRotation( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == qtrue )
+	if ( ParseFloat( val, min, max ) == qtrue )
 	{
 		mRotation.SetRange( min, max );
 		return true;
@@ -615,11 +628,11 @@ bool CPrimitiveTemplate::ParseRotation( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseRotationDelta( const char *val )
+bool CPrimitiveTemplate::ParseRotationDelta( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == qtrue )
+	if ( ParseFloat( val, min, max ) == qtrue )
 	{
 		mRotationDelta.SetRange( min, max );
 		return true;
@@ -638,7 +651,7 @@ bool CPrimitiveTemplate::ParseRotationDelta( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseAngle( const char *val )
+bool CPrimitiveTemplate::ParseAngle( const gsl::cstring_view& val )
 {
 	vec3_t min, max;
 
@@ -663,7 +676,7 @@ bool CPrimitiveTemplate::ParseAngle( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseAngleDelta( const char *val )
+bool CPrimitiveTemplate::ParseAngleDelta( const gsl::cstring_view& val )
 {
 	vec3_t min, max;
 
@@ -688,7 +701,7 @@ bool CPrimitiveTemplate::ParseAngleDelta( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseVelocity( const char *val )
+bool CPrimitiveTemplate::ParseVelocity( const gsl::cstring_view& val )
 {
 	vec3_t min, max;
 
@@ -714,78 +727,42 @@ bool CPrimitiveTemplate::ParseVelocity( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseFlags( const char *val )
+bool CPrimitiveTemplate::ParseFlags( const gsl::cstring_view& val )
 {
-	char	flag[][32] = {"\0","\0","\0","\0","\0","\0","\0"};
-	bool	ok = true;
-
 	// For a primitive, really you probably only have two or less flags set
-	int v = sscanf( val, "%s %s %s %s %s %s %s", flag[0], flag[1], flag[2], flag[3], flag[4], flag[5], flag[6] );
+	std::array< gsl::cstring_view, 7 > flag;
 
-	for ( int i = 0; i < 7; i++ )
+	const auto availableFlag = scanStrings( val, flag );
+
+	bool	ok = true;
+	for( auto& cur : availableFlag )
 	{
-		if ( i + 1 > v )
-		{
-			return true;
-		}
+		static StringViewIMap< int > flagNames{
+			{ CSTRING_VIEW( "useModel" ), FX_ATTACHED_MODEL },
+			{ CSTRING_VIEW( "useBBox" ), FX_USE_BBOX },
+			{ CSTRING_VIEW( "usePhysics" ), FX_APPLY_PHYSICS },
+			{ CSTRING_VIEW( "expensivePhysics" ), FX_EXPENSIVE_PHYSICS },
+			//rww - begin g2 stuff
+			{ CSTRING_VIEW( "ghoul2Collision" ), ( FX_GHOUL2_TRACE | FX_APPLY_PHYSICS | FX_EXPENSIVE_PHYSICS ) },
+			{ CSTRING_VIEW( "ghoul2Decals" ), FX_GHOUL2_DECALS },
+			//rww - end
+			{ CSTRING_VIEW( "impactKills" ), FX_KILL_ON_IMPACT },
+			{ CSTRING_VIEW( "impactFx" ), FX_IMPACT_RUNS_FX },
+			{ CSTRING_VIEW( "deathFx" ), FX_DEATH_RUNS_FX },
+			{ CSTRING_VIEW( "useAlpha" ), FX_CLAMP },
+			{ CSTRING_VIEW( "emitFx" ), FX_EMIT_FX },
+			{ CSTRING_VIEW( "depthHack" ), FX_DEPTH_HACK },
+			{ CSTRING_VIEW( "setShaderTime" ), FX_SET_SHADER_TIME },
+		};
 
-		if ( !Q_stricmp( flag[i], "useModel" ))
-		{
-			mFlags |= FX_ATTACHED_MODEL;
-		}
-		else if ( !Q_stricmp( flag[i], "useBBox" ))
-		{
-			mFlags |= FX_USE_BBOX;
-		}
-		else if ( !Q_stricmp( flag[i], "usePhysics" ))
-		{
-			mFlags |= FX_APPLY_PHYSICS;
-		}
-		else if ( !Q_stricmp( flag[i], "expensivePhysics" ))
-		{
-			mFlags |= FX_EXPENSIVE_PHYSICS;
-		}
-		//rww - begin g2 stuff
-		else if ( !Q_stricmp( flag[i], "ghoul2Collision" ))
-		{
-			mFlags |= (FX_GHOUL2_TRACE|FX_APPLY_PHYSICS|FX_EXPENSIVE_PHYSICS);
-		}
-		else if ( !Q_stricmp( flag[i], "ghoul2Decals" ))
-		{
-			mFlags |= FX_GHOUL2_DECALS;
-		}
-		//rww - end
-		else if ( !Q_stricmp( flag[i], "impactKills" ))
-		{
-			mFlags |= FX_KILL_ON_IMPACT;
-		}
-		else if ( !Q_stricmp( flag[i], "impactFx" ))
-		{
-			mFlags |= FX_IMPACT_RUNS_FX;
-		}
-		else if ( !Q_stricmp( flag[i], "deathFx" ))
-		{
-			mFlags |= FX_DEATH_RUNS_FX;
-		}
-		else if ( !Q_stricmp( flag[i], "useAlpha" ))
-		{
-			mFlags |= FX_USE_ALPHA;
-		}
-		else if ( !Q_stricmp( flag[i], "emitFx" ))
-		{
-			mFlags |= FX_EMIT_FX;
-		}
-		else if ( !Q_stricmp( flag[i], "depthHack" ))
-		{
-			mFlags |= FX_DEPTH_HACK;
-		}
-		else if ( !Q_stricmp( flag[i], "setShaderTime" ))
-		{
-			mFlags |= FX_SET_SHADER_TIME;
-		}
-		else
+		auto pos = flagNames.find( cur );
+		if( pos == flagNames.end() )
 		{ // we have badness going on, but continue on in case there are any valid fields in here
 			ok = false;
+		}
+		else
+		{
+			mFlags |= pos->second;
 		}
 	}
 
@@ -803,80 +780,40 @@ bool CPrimitiveTemplate::ParseFlags( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSpawnFlags( const char *val )
+bool CPrimitiveTemplate::ParseSpawnFlags( const gsl::cstring_view& val )
 {
-	char	flag[][32] = {"\0","\0","\0","\0","\0","\0","\0"};
-	bool	ok = true;
+	std::array< gsl::cstring_view, 7 > flag;
 
 	// For a primitive, really you probably only have two or less flags set
-	int v = sscanf( val, "%s %s %s %s %s %s %s", flag[0], flag[1], flag[2], flag[3], flag[4], flag[5], flag[6] );
+	const auto availableFlag = scanStrings( val, flag );
 
-	for ( int i = 0; i < 7; i++ )
+	bool ok = true;
+	for( auto& cur : availableFlag )
 	{
-		if ( i + 1 > v )
+		static StringViewIMap< int > flagNames{
+			{ CSTRING_VIEW( "org2fromTrace" ), FX_ORG2_FROM_TRACE },
+			{ CSTRING_VIEW( "traceImpactFx" ), FX_TRACE_IMPACT_FX },
+			{ CSTRING_VIEW( "org2isOffset" ), FX_ORG2_IS_OFFSET },
+			{ CSTRING_VIEW( "cheapOrgCalc" ), FX_CHEAP_ORG_CALC },
+			{ CSTRING_VIEW( "cheapOrg2Calc" ), FX_CHEAP_ORG2_CALC },
+			{ CSTRING_VIEW( "absoluteVel" ), FX_VEL_IS_ABSOLUTE },
+			{ CSTRING_VIEW( "absoluteAccel" ), FX_ACCEL_IS_ABSOLUTE },
+			{ CSTRING_VIEW( "orgOnSphere" ), FX_ORG_ON_SPHERE },
+			{ CSTRING_VIEW( "orgOnCylinder" ), FX_ORG_ON_CYLINDER },
+			{ CSTRING_VIEW( "axisFromSphere" ), FX_AXIS_FROM_SPHERE },
+			{ CSTRING_VIEW( "randrotaroundfwd" ), FX_RAND_ROT_AROUND_FWD },
+			{ CSTRING_VIEW( "evenDistribution" ), FX_EVEN_DISTRIBUTION },
+			{ CSTRING_VIEW( "rgbComponentInterpolation" ), FX_RGB_COMPONENT_INTERP },
+			{ CSTRING_VIEW( "lessAttenuation" ), FX_SND_LESS_ATTENUATION },
+		};
+		auto pos = flagNames.find( cur );
+		if( pos == flagNames.end() )
 		{
-			return true;
-		}
-
-		if ( !Q_stricmp( flag[i], "org2fromTrace" ))
-		{
-			mSpawnFlags |= FX_ORG2_FROM_TRACE;
-		}
-		else if ( !Q_stricmp( flag[i], "traceImpactFx" ))
-		{
-			mSpawnFlags |= FX_TRACE_IMPACT_FX;
-		}
-		else if ( !Q_stricmp( flag[i], "org2isOffset" ))
-		{
-			mSpawnFlags |= FX_ORG2_IS_OFFSET;
-		}
-		else if ( !Q_stricmp( flag[i], "cheapOrgCalc" ))
-		{
-			mSpawnFlags |= FX_CHEAP_ORG_CALC;
-		}
-		else if ( !Q_stricmp( flag[i], "cheapOrg2Calc" ))
-		{
-			mSpawnFlags |= FX_CHEAP_ORG2_CALC;
-		}
-		else if ( !Q_stricmp( flag[i], "absoluteVel" ))
-		{
-			mSpawnFlags |= FX_VEL_IS_ABSOLUTE;
-		}
-		else if ( !Q_stricmp( flag[i], "absoluteAccel" ))
-		{
-			mSpawnFlags |= FX_ACCEL_IS_ABSOLUTE;
-		}
-		else if ( !Q_stricmp( flag[i], "orgOnSphere" )) // sphere/ellipsoid
-		{
-			mSpawnFlags |= FX_ORG_ON_SPHERE;
-		}
-		else if ( !Q_stricmp( flag[i], "orgOnCylinder" )) // cylinder/disk
-		{
-			mSpawnFlags |= FX_ORG_ON_CYLINDER;
-		}
-		else if ( !Q_stricmp( flag[i], "axisFromSphere" ))
-		{
-			mSpawnFlags |= FX_AXIS_FROM_SPHERE;
-		}
-		else if ( !Q_stricmp( flag[i], "randrotaroundfwd" ))
-		{
-			mSpawnFlags |= FX_RAND_ROT_AROUND_FWD;
-		}
-		else if ( !Q_stricmp( flag[i], "evenDistribution" ))
-		{
-			mSpawnFlags |= FX_EVEN_DISTRIBUTION;
-		}
-		else if ( !Q_stricmp( flag[i], "rgbComponentInterpolation" ))
-		{
-			mSpawnFlags |= FX_RGB_COMPONENT_INTERP;
-		}
-		else if ( !Q_stricmp( flag[i], "lessAttenuation" ))
-		{
-			mSpawnFlags |= FX_SND_LESS_ATTENUATION;
+			ok = false;
 		}
 		else
-		{ // we have badness going on, but continue on in case there are any valid fields in here
-			ok = false;
+		{
+			mSpawnFlags |= pos->second;
 		}
 	}
 
@@ -893,7 +830,7 @@ bool CPrimitiveTemplate::ParseSpawnFlags( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseAcceleration( const char *val )
+bool CPrimitiveTemplate::ParseAcceleration( const gsl::cstring_view& val )
 {
 	vec3_t min, max;
 
@@ -918,11 +855,11 @@ bool CPrimitiveTemplate::ParseAcceleration( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseGravity( const char *val )
+bool CPrimitiveTemplate::ParseGravity( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mGravity.SetRange( min, max );
 		return true;
@@ -943,11 +880,11 @@ bool CPrimitiveTemplate::ParseGravity( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseDensity( const char *val )
+bool CPrimitiveTemplate::ParseDensity( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mDensity.SetRange( min, max );
 		return true;
@@ -969,11 +906,11 @@ bool CPrimitiveTemplate::ParseDensity( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseVariance( const char *val )
+bool CPrimitiveTemplate::ParseVariance( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mVariance.SetRange( min, max );
 		return true;
@@ -992,7 +929,7 @@ bool CPrimitiveTemplate::ParseVariance( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseRGBStart( const char *val )
+bool CPrimitiveTemplate::ParseRGBStart( const gsl::cstring_view& val )
 {
 	vec3_t min, max;
 
@@ -1017,7 +954,7 @@ bool CPrimitiveTemplate::ParseRGBStart( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseRGBEnd( const char *val )
+bool CPrimitiveTemplate::ParseRGBEnd( const gsl::cstring_view& val )
 {
 	vec3_t min, max;
 
@@ -1042,11 +979,11 @@ bool CPrimitiveTemplate::ParseRGBEnd( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseRGBParm( const char *val )
+bool CPrimitiveTemplate::ParseRGBParm( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mRGBParm.SetRange( min, max );
 		return true;
@@ -1065,11 +1002,11 @@ bool CPrimitiveTemplate::ParseRGBParm( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseRGBFlags( const char *val )
+bool CPrimitiveTemplate::ParseRGBFlags( const gsl::cstring_view& val )
 {
 	int flags;
 
-	if ( ParseGroupFlags( val, &flags ) == true )
+	if ( ParseGroupFlags( val, flags ) == true )
 	{
 		// Convert our generic flag values into type specific ones
 		mFlags |= ( flags << FX_RGB_SHIFT );
@@ -1089,11 +1026,11 @@ bool CPrimitiveTemplate::ParseRGBFlags( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseAlphaStart( const char *val )
+bool CPrimitiveTemplate::ParseAlphaStart( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mAlphaStart.SetRange( min, max );
 		return true;
@@ -1112,11 +1049,11 @@ bool CPrimitiveTemplate::ParseAlphaStart( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseAlphaEnd( const char *val )
+bool CPrimitiveTemplate::ParseAlphaEnd( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mAlphaEnd.SetRange( min, max );
 		return true;
@@ -1135,11 +1072,11 @@ bool CPrimitiveTemplate::ParseAlphaEnd( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseAlphaParm( const char *val )
+bool CPrimitiveTemplate::ParseAlphaParm( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mAlphaParm.SetRange( min, max );
 		return true;
@@ -1158,11 +1095,11 @@ bool CPrimitiveTemplate::ParseAlphaParm( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseAlphaFlags( const char *val )
+bool CPrimitiveTemplate::ParseAlphaFlags( const gsl::cstring_view& val )
 {
 	int flags;
 
-	if ( ParseGroupFlags( val, &flags ) == true )
+	if ( ParseGroupFlags( val, flags ) == true )
 	{
 		// Convert our generic flag values into type specific ones
 		mFlags |= ( flags << FX_ALPHA_SHIFT );
@@ -1182,11 +1119,11 @@ bool CPrimitiveTemplate::ParseAlphaFlags( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSizeStart( const char *val )
+bool CPrimitiveTemplate::ParseSizeStart( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mSizeStart.SetRange( min, max );
 		return true;
@@ -1205,11 +1142,11 @@ bool CPrimitiveTemplate::ParseSizeStart( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSizeEnd( const char *val )
+bool CPrimitiveTemplate::ParseSizeEnd( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mSizeEnd.SetRange( min, max );
 		return true;
@@ -1228,11 +1165,11 @@ bool CPrimitiveTemplate::ParseSizeEnd( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSizeParm( const char *val )
+bool CPrimitiveTemplate::ParseSizeParm( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mSizeParm.SetRange( min, max );
 		return true;
@@ -1251,11 +1188,11 @@ bool CPrimitiveTemplate::ParseSizeParm( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSizeFlags( const char *val )
+bool CPrimitiveTemplate::ParseSizeFlags( const gsl::cstring_view& val )
 {
 	int flags;
 
-	if ( ParseGroupFlags( val, &flags ) == true )
+	if ( ParseGroupFlags( val, flags ) == true )
 	{
 		// Convert our generic flag values into type specific ones
 		mFlags |= ( flags << FX_SIZE_SHIFT );
@@ -1275,11 +1212,11 @@ bool CPrimitiveTemplate::ParseSizeFlags( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSize2Start( const char *val )
+bool CPrimitiveTemplate::ParseSize2Start( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mSize2Start.SetRange( min, max );
 		return true;
@@ -1298,11 +1235,11 @@ bool CPrimitiveTemplate::ParseSize2Start( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSize2End( const char *val )
+bool CPrimitiveTemplate::ParseSize2End( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mSize2End.SetRange( min, max );
 		return true;
@@ -1321,11 +1258,11 @@ bool CPrimitiveTemplate::ParseSize2End( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSize2Parm( const char *val )
+bool CPrimitiveTemplate::ParseSize2Parm( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mSize2Parm.SetRange( min, max );
 		return true;
@@ -1344,11 +1281,11 @@ bool CPrimitiveTemplate::ParseSize2Parm( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSize2Flags( const char *val )
+bool CPrimitiveTemplate::ParseSize2Flags( const gsl::cstring_view& val )
 {
 	int flags;
 
-	if ( ParseGroupFlags( val, &flags ) == true )
+	if ( ParseGroupFlags( val, flags ) == true )
 	{
 		// Convert our generic flag values into type specific ones
 		mFlags |= ( flags << FX_SIZE2_SHIFT );
@@ -1368,11 +1305,11 @@ bool CPrimitiveTemplate::ParseSize2Flags( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseLengthStart( const char *val )
+bool CPrimitiveTemplate::ParseLengthStart( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mLengthStart.SetRange( min, max );
 		return true;
@@ -1391,11 +1328,11 @@ bool CPrimitiveTemplate::ParseLengthStart( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseLengthEnd( const char *val )
+bool CPrimitiveTemplate::ParseLengthEnd( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mLengthEnd.SetRange( min, max );
 		return true;
@@ -1414,11 +1351,11 @@ bool CPrimitiveTemplate::ParseLengthEnd( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseLengthParm( const char *val )
+bool CPrimitiveTemplate::ParseLengthParm( const gsl::cstring_view& val )
 {
 	float min, max;
 
-	if ( ParseFloat( val, &min, &max ) == true )
+	if ( ParseFloat( val, min, max ) == true )
 	{
 		mLengthParm.SetRange( min, max );
 		return true;
@@ -1437,11 +1374,11 @@ bool CPrimitiveTemplate::ParseLengthParm( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseLengthFlags( const char *val )
+bool CPrimitiveTemplate::ParseLengthFlags( const gsl::cstring_view& val )
 {
 	int flags;
 
-	if ( ParseGroupFlags( val, &flags ) == true )
+	if ( ParseGroupFlags( val, flags ) == true )
 	{
 		// Convert our generic flag values into type specific ones
 		mFlags |= ( flags << FX_LENGTH_SHIFT );
@@ -1461,45 +1398,24 @@ bool CPrimitiveTemplate::ParseLengthFlags( const char *val )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseShaders( CGPValue *grp )
+bool CPrimitiveTemplate::ParseShaders( const CGPProperty& grp )
 {
-	const char	*val;
-	int			handle;
-
-	if ( grp->IsList() )
+	bool any = false;
+	for( auto& value : grp.GetValues() )
 	{
-		// If we are a list we have to do separate processing
-		CGPObject *list = grp->GetList();
-
-		while ( list )
+		if( !value.empty() )
 		{
-			// name is actually the value contained in the list
-			val = list->GetName();
-
-			handle = theFxHelper.RegisterShader( val );
-			mMediaHandles.AddHandle( handle );
-
-			list = (CGPValue *)list->GetNext();
-		}
-	}
-	else
-	{
-		// Let's get a value
-		val = grp->GetTopValue();
-
-		if ( val )
-		{
-			handle = theFxHelper.RegisterShader( val );
+			any = true;
+			int handle = theFxHelper.RegisterShader( value );
 			mMediaHandles.AddHandle( handle );
 		}
-		else
-		{
-			// empty "list"
-			theFxHelper.Print( "CPrimitiveTemplate::ParseShaders called with an empty list!\n" );
-			return false;
-		}
 	}
-
+	if( !any )
+	{
+		// empty "list"
+		theFxHelper.Print( "CPrimitiveTemplate::ParseShaders called with an empty list!\n" );
+		return false;
+	}
 	return true;
 }
 
@@ -1513,45 +1429,24 @@ bool CPrimitiveTemplate::ParseShaders( CGPValue *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSounds( CGPValue *grp )
+bool CPrimitiveTemplate::ParseSounds( const CGPProperty& grp )
 {
-	const char	*val;
-	int			handle;
-
-	if ( grp->IsList() )
+	bool any = false;
+	for( auto& value : grp.GetValues() )
 	{
-		// If we are a list we have to do separate processing
-		CGPObject *list = grp->GetList();
-
-		while ( list )
+		if( !value.empty() )
 		{
-			// name is actually the value contained in the list
-			val = list->GetName();
-
-			handle = theFxHelper.RegisterSound( val );
-			mMediaHandles.AddHandle( handle );
-
-			list = (CGPValue *)list->GetNext();
-		}
-	}
-	else
-	{
-		// Let's get a value
-		val = grp->GetTopValue();
-
-		if ( val )
-		{
-			handle = theFxHelper.RegisterSound( val );
+			any = true;
+			int handle = theFxHelper.RegisterSound( value );
 			mMediaHandles.AddHandle( handle );
 		}
-		else
-		{
-			// empty "list"
-			theFxHelper.Print( "CPrimitiveTemplate::ParseSounds called with an empty list!\n" );
-			return false;
-		}
 	}
-
+	if( !any )
+	{
+		// empty "list"
+		theFxHelper.Print( "CPrimitiveTemplate::ParseSounds called with an empty list!\n" );
+		return false;
+	}
 	return true;
 }
 
@@ -1565,48 +1460,54 @@ bool CPrimitiveTemplate::ParseSounds( CGPValue *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseModels( CGPValue *grp )
+bool CPrimitiveTemplate::ParseModels( const CGPProperty& grp )
 {
-	const char	*val;
-	int			handle;
-
-	if ( grp->IsList() )
+	bool any = false;
+	for( auto& value : grp.GetValues() )
 	{
-		// If we are a list we have to do separate processing
-		CGPObject *list = grp->GetList();
-
-		while ( list )
+		if( !value.empty() )
 		{
-			// name is actually the value contained in the list
-			val = list->GetName();
-
-			handle = theFxHelper.RegisterModel( val );
-			mMediaHandles.AddHandle( handle );
-
-			list = (CGPValue *)list->GetNext();
-		}
-	}
-	else
-	{
-		// Let's get a value
-		val = grp->GetTopValue();
-
-		if ( val )
-		{
-			handle = theFxHelper.RegisterModel( val );
+			any = true;
+			int handle = theFxHelper.RegisterModel( value );
 			mMediaHandles.AddHandle( handle );
 		}
-		else
-		{
-			// empty "list"
-			theFxHelper.Print( "CPrimitiveTemplate::ParseModels called with an empty list!\n" );
-			return false;
-		}
 	}
-
+	if( !any )
+	{
+		// empty "list"
+		theFxHelper.Print( "CPrimitiveTemplate::ParseModels called with an empty list!\n" );
+		return false;
+	}
 	mFlags |= FX_ATTACHED_MODEL;
-
 	return true;
+}
+
+static bool ParseFX( const CGPProperty& grp, CFxScheduler& scheduler, CMediaHandles& handles, SFxHelper& helper, int& flags, int successFlags, gsl::czstring loadError, gsl::czstring emptyError )
+{
+	bool any = false;
+	for( auto& value : grp.GetValues() )
+	{
+		if( !value.empty() )
+		{
+			any = true;
+			// TODO: string_view parameter
+			int handle = scheduler.RegisterEffect( std::string( value.begin(), value.end() ).c_str() );
+			if( handle )
+			{
+				handles.AddHandle( handle );
+				flags |= successFlags;
+			}
+			else
+			{
+				helper.Print( "%s", loadError );
+			}
+		}
+	}
+	if( !any )
+	{
+		helper.Print( "%s", emptyError );
+	}
+	return any;
 }
 
 //------------------------------------------------------
@@ -1619,65 +1520,15 @@ bool CPrimitiveTemplate::ParseModels( CGPValue *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseImpactFxStrings( CGPValue *grp )
+bool CPrimitiveTemplate::ParseImpactFxStrings( const CGPProperty& grp )
 {
-	const char	*val;
-	int			handle;
-
-	if ( grp->IsList() )
-	{
-		// If we are a list we have to do separate processing
-		CGPObject *list = grp->GetList();
-
-		while ( list )
-		{
-			// name is actually the value contained in the list
-			val = list->GetName();
-			handle = theFxScheduler.RegisterEffect( val );
-
-			if ( handle )
-			{
-				mImpactFxHandles.AddHandle( handle );
-			}
-			else
-			{
-				theFxHelper.Print( "FxTemplate: Impact effect file not found.\n" );
-				return false;
-			}
-
-			list = (CGPValue *)list->GetNext();
-		}
-	}
-	else
-	{
-		// Let's get a value
-		val = grp->GetTopValue();
-
-		if ( val )
-		{
-			handle = theFxScheduler.RegisterEffect( val );
-
-			if ( handle )
-			{
-				mImpactFxHandles.AddHandle( handle );
-			}
-			else
-			{
-				theFxHelper.Print( "FxTemplate: Impact effect file not found.\n" );
-				return false;
-			}
-		}
-		else
-		{
-			// empty "list"
-			theFxHelper.Print( "CPrimitiveTemplate::ParseImpactFxStrings called with an empty list!\n" );
-			return false;
-		}
-	}
-
-	mFlags |= FX_IMPACT_RUNS_FX | FX_APPLY_PHYSICS;
-
-	return true;
+	return ParseFX(
+		grp,
+		theFxScheduler, mImpactFxHandles, theFxHelper,
+		mFlags, FX_IMPACT_RUNS_FX | FX_APPLY_PHYSICS,
+		"FxTemplate: Impact effect file not found.\n",
+		"CPrimitiveTemplate::ParseImpactFxStrings called with an empty list!\n"
+		);
 }
 
 //------------------------------------------------------
@@ -1690,65 +1541,15 @@ bool CPrimitiveTemplate::ParseImpactFxStrings( CGPValue *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseDeathFxStrings( CGPValue *grp )
+bool CPrimitiveTemplate::ParseDeathFxStrings( const CGPProperty& grp )
 {
-	const char	*val;
-	int			handle;
-
-	if ( grp->IsList() )
-	{
-		// If we are a list we have to do separate processing
-		CGPObject *list = grp->GetList();
-
-		while ( list )
-		{
-			// name is actually the value contained in the list
-			val = list->GetName();
-			handle = theFxScheduler.RegisterEffect( val );
-
-			if ( handle )
-			{
-				mDeathFxHandles.AddHandle( handle );
-			}
-			else
-			{
-				theFxHelper.Print( "FxTemplate: Death effect file not found.\n" );
-				return false;
-			}
-
-			list = (CGPValue *)list->GetNext();
-		}
-	}
-	else
-	{
-		// Let's get a value
-		val = grp->GetTopValue();
-
-		if ( val )
-		{
-			handle = theFxScheduler.RegisterEffect( val );
-
-			if ( handle )
-			{
-				mDeathFxHandles.AddHandle( handle );
-			}
-			else
-			{
-				theFxHelper.Print( "FxTemplate: Death effect file not found.\n" );
-				return false;
-			}
-		}
-		else
-		{
-			// empty "list"
-			theFxHelper.Print( "CPrimitiveTemplate::ParseDeathFxStrings called with an empty list!\n" );
-			return false;
-		}
-	}
-
-	mFlags |= FX_DEATH_RUNS_FX;
-
-	return true;
+	return ParseFX(
+		grp,
+		theFxScheduler, mDeathFxHandles, theFxHelper,
+		mFlags, FX_DEATH_RUNS_FX,
+		"FxTemplate: Death effect file not found.\n",
+		"CPrimitiveTemplate::ParseDeathFxStrings called with an empty list!\n"
+		);
 }
 
 //------------------------------------------------------
@@ -1761,65 +1562,15 @@ bool CPrimitiveTemplate::ParseDeathFxStrings( CGPValue *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseEmitterFxStrings( CGPValue *grp )
+bool CPrimitiveTemplate::ParseEmitterFxStrings( const CGPProperty& grp )
 {
-	const char	*val;
-	int			handle;
-
-	if ( grp->IsList() )
-	{
-		// If we are a list we have to do separate processing
-		CGPObject *list = grp->GetList();
-
-		while ( list )
-		{
-			// name is actually the value contained in the list
-			val = list->GetName();
-			handle = theFxScheduler.RegisterEffect( val );
-
-			if ( handle )
-			{
-				mEmitterFxHandles.AddHandle( handle );
-			}
-			else
-			{
-				theFxHelper.Print( "FxTemplate: Emitter effect file not found.\n" );
-				return false;
-			}
-
-			list = (CGPValue *)list->GetNext();
-		}
-	}
-	else
-	{
-		// Let's get a value
-		val = grp->GetTopValue();
-
-		if ( val )
-		{
-			handle = theFxScheduler.RegisterEffect( val );
-
-			if ( handle )
-			{
-				mEmitterFxHandles.AddHandle( handle );
-			}
-			else
-			{
-				theFxHelper.Print( "FxTemplate: Emitter effect file not found.\n" );
-				return false;
-			}
-		}
-		else
-		{
-			// empty "list"
-			theFxHelper.Print( "CPrimitiveTemplate::ParseEmitterFxStrings called with an empty list!\n" );
-			return false;
-		}
-	}
-
-	mFlags |= FX_EMIT_FX;
-
-	return true;
+	return ParseFX(
+		grp,
+		theFxScheduler, mEmitterFxHandles, theFxHelper,
+		mFlags, FX_EMIT_FX,
+		"FxTemplate: Emitter effect file not found.\n",
+		"CPrimitiveTemplate::ParseEmitterFxStrings called with an empty list!\n"
+		);
 }
 
 //------------------------------------------------------
@@ -1832,62 +1583,32 @@ bool CPrimitiveTemplate::ParseEmitterFxStrings( CGPValue *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParsePlayFxStrings( CGPValue *grp )
+bool CPrimitiveTemplate::ParsePlayFxStrings( const CGPProperty& grp )
 {
-	const char	*val;
-	int			handle;
+	return ParseFX(
+		grp,
+		theFxScheduler, mPlayFxHandles, theFxHelper,
+		mFlags, 0,
+		"FxTemplate: Effect file not found.\n",
+		"CPrimitiveTemplate::ParsePlayFxStrings called with an empty list!\n"
+		);
+}
 
-	if ( grp->IsList() )
+bool CPrimitiveTemplate::ParseGroup( const CGPGroup& grp, const StringViewIMap< ParseMethod >& parseMethods, gsl::czstring name )
+{
+	for( auto& cur : grp.GetProperties() )
 	{
-		// If we are a list we have to do separate processing
-		CGPObject *list = grp->GetList();
-
-		while ( list )
+		auto pos = parseMethods.find( cur.GetName() );
+		if( pos == parseMethods.end() )
 		{
-			// name is actually the value contained in the list
-			val = list->GetName();
-			handle = theFxScheduler.RegisterEffect( val );
-
-			if ( handle )
-			{
-				mPlayFxHandles.AddHandle( handle );
-			}
-			else
-			{
-				theFxHelper.Print( "FxTemplate: Effect file not found.\n" );
-				return false;
-			}
-
-			list = (CGPValue *)list->GetNext();
-		}
-	}
-	else
-	{
-		// Let's get a value
-		val = grp->GetTopValue();
-
-		if ( val )
-		{
-			handle = theFxScheduler.RegisterEffect( val );
-
-			if ( handle )
-			{
-				mPlayFxHandles.AddHandle( handle );
-			}
-			else
-			{
-				theFxHelper.Print( "FxTemplate: Effect file not found.\n" );
-				return false;
-			}
+			theFxHelper.Print( "Unknown key parsing %s group!", name );
 		}
 		else
 		{
-			// empty "list"
-			theFxHelper.Print( "CPrimitiveTemplate::ParsePlayFxStrings called with an empty list!\n" );
-			return false;
+			ParseMethod method = pos->second;
+			( this->*method )( cur.GetTopValue() );
 		}
 	}
-
 	return true;
 }
 
@@ -1902,47 +1623,20 @@ bool CPrimitiveTemplate::ParsePlayFxStrings( CGPValue *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseRGB( CGPGroup *grp )
+bool CPrimitiveTemplate::ParseRGB( const CGPGroup& grp )
 {
-	CGPValue	*pairs;
-	const char	*key;
-	const char	*val;
+	static StringViewIMap< ParseMethod > parseMethods{
+		{ CSTRING_VIEW( "start" ), &CPrimitiveTemplate::ParseRGBStart },
 
-	// Inside of the group, we should have a series of pairs
-	pairs = grp->GetPairs();
+		{ CSTRING_VIEW( "end" ), &CPrimitiveTemplate::ParseRGBEnd },
 
-	while( pairs )
-	{
-		// Let's get the key field
-		key = pairs->GetName();
-		val = pairs->GetTopValue();
+		{ CSTRING_VIEW( "parm" ), &CPrimitiveTemplate::ParseRGBParm },
+		{ CSTRING_VIEW( "parms" ), &CPrimitiveTemplate::ParseRGBParm },
 
-		// Huge stricmp lists suxor
-		if ( !Q_stricmp( key, "start" ))
-		{
-			ParseRGBStart( val );
-		}
-		else if ( !Q_stricmp( key, "end" ))
-		{
-			ParseRGBEnd( val );
-		}
-		else if ( !Q_stricmp( key, "parm" ) || !Q_stricmp( key, "parms" ))
-		{
-			ParseRGBParm( val );
-		}
-		else if ( !Q_stricmp( key, "flags" ) || !Q_stricmp( key, "flag" ))
-		{
-			ParseRGBFlags( val );
-		}
-		else
-		{
-			theFxHelper.Print( "Unknown key parsing an RGB group: %s\n", key );
-		}
-
-		pairs = (CGPValue *)pairs->GetNext();
-	}
-
-	return true;
+		{ CSTRING_VIEW( "flag" ), &CPrimitiveTemplate::ParseRGBFlags },
+		{ CSTRING_VIEW( "flags" ), &CPrimitiveTemplate::ParseRGBFlags },
+	};
+	return ParseGroup( grp, parseMethods, "RGB" );
 }
 
 //------------------------------------------------------
@@ -1956,47 +1650,20 @@ bool CPrimitiveTemplate::ParseRGB( CGPGroup *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseAlpha( CGPGroup *grp )
+bool CPrimitiveTemplate::ParseAlpha( const CGPGroup& grp )
 {
-	CGPValue	*pairs;
-	const char	*key;
-	const char	*val;
+	static StringViewIMap< ParseMethod > parseMethods{
+		{ CSTRING_VIEW( "start" ), &CPrimitiveTemplate::ParseAlphaStart },
 
-	// Inside of the group, we should have a series of pairs
-	pairs = grp->GetPairs();
+		{ CSTRING_VIEW( "end" ), &CPrimitiveTemplate::ParseAlphaEnd },
 
-	while( pairs )
-	{
-		// Let's get the key field
-		key = pairs->GetName();
-		val = pairs->GetTopValue();
+		{ CSTRING_VIEW( "parm" ), &CPrimitiveTemplate::ParseAlphaParm },
+		{ CSTRING_VIEW( "parms" ), &CPrimitiveTemplate::ParseAlphaParm },
 
-		// Huge stricmp lists suxor
-		if ( !Q_stricmp( key, "start" ))
-		{
-			ParseAlphaStart( val );
-		}
-		else if ( !Q_stricmp( key, "end" ))
-		{
-			ParseAlphaEnd( val );
-		}
-		else if ( !Q_stricmp( key, "parm" ) || !Q_stricmp( key, "parms" ))
-		{
-			ParseAlphaParm( val );
-		}
-		else if ( !Q_stricmp( key, "flags" ) || !Q_stricmp( key, "flag" ))
-		{
-			ParseAlphaFlags( val );
-		}
-		else
-		{
-			theFxHelper.Print( "Unknown key parsing an Alpha group: %s\n", key );
-		}
-
-		pairs = (CGPValue *)pairs->GetNext();
-	}
-
-	return true;
+		{ CSTRING_VIEW( "flag" ), &CPrimitiveTemplate::ParseAlphaFlags },
+		{ CSTRING_VIEW( "flags" ), &CPrimitiveTemplate::ParseAlphaFlags },
+	};
+	return ParseGroup( grp, parseMethods, "Alpha" );
 }
 
 //------------------------------------------------------
@@ -2010,47 +1677,20 @@ bool CPrimitiveTemplate::ParseAlpha( CGPGroup *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSize( CGPGroup *grp )
+bool CPrimitiveTemplate::ParseSize( const CGPGroup& grp )
 {
-	CGPValue	*pairs;
-	const char	*key;
-	const char	*val;
+	static StringViewIMap< ParseMethod > parseMethods{
+		{ CSTRING_VIEW( "start" ), &CPrimitiveTemplate::ParseSizeStart },
 
-	// Inside of the group, we should have a series of pairs
-	pairs = grp->GetPairs();
+		{ CSTRING_VIEW( "end" ), &CPrimitiveTemplate::ParseSizeEnd },
 
-	while( pairs )
-	{
-		// Let's get the key field
-		key = pairs->GetName();
-		val = pairs->GetTopValue();
+		{ CSTRING_VIEW( "parm" ), &CPrimitiveTemplate::ParseSizeParm },
+		{ CSTRING_VIEW( "parms" ), &CPrimitiveTemplate::ParseSizeParm },
 
-		// Huge stricmp lists suxor
-		if ( !Q_stricmp( key, "start" ))
-		{
-			ParseSizeStart( val );
-		}
-		else if ( !Q_stricmp( key, "end" ))
-		{
-			ParseSizeEnd( val );
-		}
-		else if ( !Q_stricmp( key, "parm" ) || !Q_stricmp( key, "parms" ))
-		{
-			ParseSizeParm( val );
-		}
-		else if ( !Q_stricmp( key, "flags" ) || !Q_stricmp( key, "flag" ))
-		{
-			ParseSizeFlags( val );
-		}
-		else
-		{
-			theFxHelper.Print( "Unknown key parsing a Size group: %s\n", key );
-		}
-
-		pairs = (CGPValue *)pairs->GetNext();
-	}
-
-	return true;
+		{ CSTRING_VIEW( "flag" ), &CPrimitiveTemplate::ParseSizeFlags },
+		{ CSTRING_VIEW( "flags" ), &CPrimitiveTemplate::ParseSizeFlags },
+	};
+	return ParseGroup( grp, parseMethods, "Size" );
 }
 
 //------------------------------------------------------
@@ -2064,47 +1704,20 @@ bool CPrimitiveTemplate::ParseSize( CGPGroup *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseSize2( CGPGroup *grp )
+bool CPrimitiveTemplate::ParseSize2( const CGPGroup& grp )
 {
-	CGPValue	*pairs;
-	const char	*key;
-	const char	*val;
+	static StringViewIMap< ParseMethod > parseMethods{
+		{ CSTRING_VIEW( "start" ), &CPrimitiveTemplate::ParseSize2Start },
 
-	// Inside of the group, we should have a series of pairs
-	pairs = grp->GetPairs();
+		{ CSTRING_VIEW( "end" ), &CPrimitiveTemplate::ParseSize2End },
 
-	while( pairs )
-	{
-		// Let's get the key field
-		key = pairs->GetName();
-		val = pairs->GetTopValue();
+		{ CSTRING_VIEW( "parm" ), &CPrimitiveTemplate::ParseSize2Parm },
+		{ CSTRING_VIEW( "parms" ), &CPrimitiveTemplate::ParseSize2Parm },
 
-		// Huge stricmp lists suxor
-		if ( !Q_stricmp( key, "start" ))
-		{
-			ParseSize2Start( val );
-		}
-		else if ( !Q_stricmp( key, "end" ))
-		{
-			ParseSize2End( val );
-		}
-		else if ( !Q_stricmp( key, "parm" ) || !Q_stricmp( key, "parms" ))
-		{
-			ParseSize2Parm( val );
-		}
-		else if ( !Q_stricmp( key, "flags" ) || !Q_stricmp( key, "flag" ))
-		{
-			ParseSize2Flags( val );
-		}
-		else
-		{
-			theFxHelper.Print( "Unknown key parsing a Size2 group: %s\n", key );
-		}
-
-		pairs = (CGPValue *)pairs->GetNext();
-	}
-
-	return true;
+		{ CSTRING_VIEW( "flag" ), &CPrimitiveTemplate::ParseSize2Flags },
+		{ CSTRING_VIEW( "flags" ), &CPrimitiveTemplate::ParseSize2Flags },
+	};
+	return ParseGroup( grp, parseMethods, "Size2" );
 }
 
 //------------------------------------------------------
@@ -2118,241 +1731,145 @@ bool CPrimitiveTemplate::ParseSize2( CGPGroup *grp )
 // return:
 //	success of parse operation.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParseLength( CGPGroup *grp )
+bool CPrimitiveTemplate::ParseLength( const CGPGroup& grp )
 {
-	CGPValue	*pairs;
-	const char	*key;
-	const char	*val;
+	static StringViewIMap< ParseMethod > parseMethods{
+		{ CSTRING_VIEW( "start" ), &CPrimitiveTemplate::ParseLengthStart },
 
-	// Inside of the group, we should have a series of pairs
-	pairs = grp->GetPairs();
+		{ CSTRING_VIEW( "end" ), &CPrimitiveTemplate::ParseLengthEnd },
 
-	while( pairs )
-	{
-		// Let's get the key field
-		key = pairs->GetName();
-		val = pairs->GetTopValue();
+		{ CSTRING_VIEW( "parm" ), &CPrimitiveTemplate::ParseLengthParm },
+		{ CSTRING_VIEW( "parms" ), &CPrimitiveTemplate::ParseLengthParm },
 
-		// Huge stricmp lists suxor
-		if ( !Q_stricmp( key, "start" ))
-		{
-			ParseLengthStart( val );
-		}
-		else if ( !Q_stricmp( key, "end" ))
-		{
-			ParseLengthEnd( val );
-		}
-		else if ( !Q_stricmp( key, "parm" ) || !Q_stricmp( key, "parms" ))
-		{
-			ParseLengthParm( val );
-		}
-		else if ( !Q_stricmp( key, "flags" ) || !Q_stricmp( key, "flag" ))
-		{
-			ParseLengthFlags( val );
-		}
-		else
-		{
-			theFxHelper.Print( "Unknown key parsing a Length group: %s\n", key );
-		}
-
-		pairs = (CGPValue *)pairs->GetNext();
-	}
-
-	return true;
+		{ CSTRING_VIEW( "flag" ), &CPrimitiveTemplate::ParseLengthFlags },
+		{ CSTRING_VIEW( "flags" ), &CPrimitiveTemplate::ParseLengthFlags },
+	};
+	return ParseGroup( grp, parseMethods, "Length" );
 }
 
 
 // Parse a primitive, apply defaults first, grab any base level
 //	key pairs, then process any sub groups we may contain.
 //------------------------------------------------------
-bool CPrimitiveTemplate::ParsePrimitive( CGPGroup *grp )
+bool CPrimitiveTemplate::ParsePrimitive( const CGPGroup& grp )
 {
-	CGPGroup	*subGrp;
-	CGPValue	*pairs;
-	const char	*key;
-	const char	*val;
-
-	// Lets work with the pairs first
-	pairs = grp->GetPairs();
-
-	while( pairs )
+	// Property
+	for( auto& prop : grp.GetProperties() )
 	{
-		// the fields
-		key = pairs->GetName();
-		val = pairs->GetTopValue();
-
-		// Huge stricmp lists suxor
-		if ( !Q_stricmp( key, "count" ))
+		// Single Value Parsing
 		{
-			ParseCount( val );
-		}
-		else if ( !Q_stricmp( key, "shaders" ) || !Q_stricmp( key, "shader" ))
-		{
-			ParseShaders( pairs );
-		}
-		else if ( !Q_stricmp( key, "models" ) || !Q_stricmp( key, "model" ))
-		{
-			ParseModels( pairs );
-		}
-		else if ( !Q_stricmp( key, "sounds" ) || !Q_stricmp( key, "sound" ))
-		{
-			ParseSounds( pairs );
-		}
-		else if ( !Q_stricmp( key, "impactfx" ))
-		{
-			ParseImpactFxStrings( pairs );
-		}
-		else if ( !Q_stricmp( key, "deathfx" ))
-		{
-			ParseDeathFxStrings( pairs );
-		}
-		else if ( !Q_stricmp( key, "emitfx" ))
-		{
-			ParseEmitterFxStrings( pairs );
-		}
-		else if ( !Q_stricmp( key, "playfx" ))
-		{
-			ParsePlayFxStrings( pairs );
-		}
-		else if ( !Q_stricmp( key, "life" ))
-		{
-			ParseLife( val );
-		}
-		else if ( !Q_stricmp( key, "cullrange" ))
-		{
-			mCullRange = atoi( val );
-			mCullRange *= mCullRange; // Square
-		}
-		else if ( !Q_stricmp( key, "delay" ))
-		{
-			ParseDelay( val );
-		}
-		else if ( !Q_stricmp( key, "bounce" ) || !Q_stricmp( key, "intensity" )) // me==bad for reusing this...but it shouldn't hurt anything)
-		{
-			ParseElasticity( val );
-		}
-		else if ( !Q_stricmp( key, "min" ))
-		{
-			ParseMin( val );
-		}
-		else if ( !Q_stricmp( key, "max" ))
-		{
-			ParseMax( val );
-		}
-		else if ( !Q_stricmp( key, "angle" ) || !Q_stricmp( key, "angles" ))
-		{
-			ParseAngle( val );
-		}
-		else if ( !Q_stricmp( key, "angleDelta" ))
-		{
-			ParseAngleDelta( val );
-		}
-		else if ( !Q_stricmp( key, "velocity" ) || !Q_stricmp( key, "vel" ))
-		{
-			ParseVelocity( val );
-		}
-		else if ( !Q_stricmp( key, "acceleration" ) || !Q_stricmp( key, "accel" ))
-		{
-			ParseAcceleration( val );
-		}
-		else if ( !Q_stricmp( key, "gravity" ))
-		{
-			ParseGravity( val );
-		}
-		else if ( !Q_stricmp( key, "density" ))
-		{
-			ParseDensity( val );
-		}
-		else if ( !Q_stricmp( key, "variance" ))
-		{
-			ParseVariance( val );
-		}
-		else if ( !Q_stricmp( key, "origin" ))
-		{
-			ParseOrigin1( val );
-		}
-		else if ( !Q_stricmp( key, "origin2" ))
-		{
-			ParseOrigin2( val );
-		}
-		else if ( !Q_stricmp( key, "radius" )) // part of ellipse/cylinder calcs.
-		{
-			ParseRadius( val );
-		}
-		else if ( !Q_stricmp( key, "height" )) // part of ellipse/cylinder calcs.
-		{
-			ParseHeight( val );
-		}
-		else if ( !Q_stricmp( key, "wind" ))
-		{
-			ParseWindModifier( val );
-		}
-		else if ( !Q_stricmp( key, "rotation" ))
-		{
-			ParseRotation( val );
-		}
-		else if ( !Q_stricmp( key, "rotationDelta" ))
-		{
-			ParseRotationDelta( val );
-		}
-		else if ( !Q_stricmp( key, "flags" ) || !Q_stricmp( key, "flag" ))
-		{ // these need to get passed on to the primitive
-			ParseFlags( val );
-		}
-		else if ( !Q_stricmp( key, "spawnFlags" ) || !Q_stricmp( key, "spawnFlag" ))
-		{ // these are used to spawn things in cool ways, but don't ever get passed on to prims.
-			ParseSpawnFlags( val );
-		}
-		else if ( !Q_stricmp( key, "name" ))
-		{
-			if ( val )
+			static StringViewIMap< ParseMethod > parseMethods{
+				{ CSTRING_VIEW( "count" ), &CPrimitiveTemplate::ParseCount },
+				{ CSTRING_VIEW( "life" ), &CPrimitiveTemplate::ParseLife },
+				{ CSTRING_VIEW( "delay" ), &CPrimitiveTemplate::ParseDelay },
+				{ CSTRING_VIEW( "bounce" ), &CPrimitiveTemplate::ParseElasticity },
+				{ CSTRING_VIEW( "intensity" ), &CPrimitiveTemplate::ParseElasticity },
+				{ CSTRING_VIEW( "min" ), &CPrimitiveTemplate::ParseMin },
+				{ CSTRING_VIEW( "max" ), &CPrimitiveTemplate::ParseMax },
+				{ CSTRING_VIEW( "angle" ), &CPrimitiveTemplate::ParseAngle },
+				{ CSTRING_VIEW( "angles" ), &CPrimitiveTemplate::ParseAngle },
+				{ CSTRING_VIEW( "angleDelta" ), &CPrimitiveTemplate::ParseAngleDelta },
+				{ CSTRING_VIEW( "velocity" ), &CPrimitiveTemplate::ParseVelocity },
+				{ CSTRING_VIEW( "vel" ), &CPrimitiveTemplate::ParseVelocity },
+				{ CSTRING_VIEW( "acceleration" ), &CPrimitiveTemplate::ParseAcceleration },
+				{ CSTRING_VIEW( "accel" ), &CPrimitiveTemplate::ParseAcceleration },
+				{ CSTRING_VIEW( "gravity" ), &CPrimitiveTemplate::ParseGravity },
+				{ CSTRING_VIEW( "density" ), &CPrimitiveTemplate::ParseDensity },
+				{ CSTRING_VIEW( "variance" ), &CPrimitiveTemplate::ParseVariance },
+				{ CSTRING_VIEW( "origin" ), &CPrimitiveTemplate::ParseOrigin1 },
+				{ CSTRING_VIEW( "origin2" ), &CPrimitiveTemplate::ParseOrigin2 },
+				{ CSTRING_VIEW( "radius" ), &CPrimitiveTemplate::ParseRadius },
+				{ CSTRING_VIEW( "height" ), &CPrimitiveTemplate::ParseHeight },
+				{ CSTRING_VIEW( "wind" ), &CPrimitiveTemplate::ParseWindModifier },
+				{ CSTRING_VIEW( "rotation" ), &CPrimitiveTemplate::ParseRotation },
+				{ CSTRING_VIEW( "rotationDelta" ), &CPrimitiveTemplate::ParseRotationDelta },
+				{ CSTRING_VIEW( "flags" ), &CPrimitiveTemplate::ParseFlags },
+				{ CSTRING_VIEW( "flag" ), &CPrimitiveTemplate::ParseFlags },
+				{ CSTRING_VIEW( "spawnFlags" ), &CPrimitiveTemplate::ParseSpawnFlags },
+				{ CSTRING_VIEW( "spawnFlag" ), &CPrimitiveTemplate::ParseSpawnFlags },
+			};
+			auto pos = parseMethods.find( prop.GetName() );
+			if( pos != parseMethods.end() )
 			{
-				// just stash the descriptive name of the primitive
-				strcpy( mName, val );
+				ParseMethod method = pos->second;
+				( this->*method )( prop.GetTopValue() );
+				continue;
 			}
 		}
+		// Property Parsing
+		{
+			using PropertyParseMethod = bool( CPrimitiveTemplate::* )( const CGPProperty& );
+			static StringViewIMap< PropertyParseMethod > parseMethods{
+				{ CSTRING_VIEW( "shaders" ), &CPrimitiveTemplate::ParseShaders },
+				{ CSTRING_VIEW( "shader" ), &CPrimitiveTemplate::ParseShaders },
+				{ CSTRING_VIEW( "models" ), &CPrimitiveTemplate::ParseModels },
+				{ CSTRING_VIEW( "model" ), &CPrimitiveTemplate::ParseModels },
+				{ CSTRING_VIEW( "sounds" ), &CPrimitiveTemplate::ParseSounds },
+				{ CSTRING_VIEW( "sound" ), &CPrimitiveTemplate::ParseSounds },
+				{ CSTRING_VIEW( "impactfx" ), &CPrimitiveTemplate::ParseImpactFxStrings },
+				{ CSTRING_VIEW( "deathfx" ), &CPrimitiveTemplate::ParseDeathFxStrings },
+				{ CSTRING_VIEW( "emitfx" ), &CPrimitiveTemplate::ParseEmitterFxStrings },
+				{ CSTRING_VIEW( "playfx" ), &CPrimitiveTemplate::ParsePlayFxStrings },
+			};
+			auto pos = parseMethods.find( prop.GetName() );
+			if( pos != parseMethods.end() )
+			{
+				PropertyParseMethod method = pos->second;
+				( this->*method )( prop );
+				continue;
+			}
+		}
+		// Special Cases
+		if( Q::stricmp( prop.GetName(), CSTRING_VIEW( "cullrange" ) ) == Q::Ordering::EQ )
+		{
+			mCullRange = Q::svtoi( prop.GetTopValue() );
+			mCullRange *= mCullRange; // Square
+		}
+		else if( Q::stricmp( prop.GetName(), CSTRING_VIEW( "name" ) ) == Q::Ordering::EQ )
+		{
+			if( !prop.GetTopValue().empty() )
+			{
+				// just stash the descriptive name of the primitive
+				std::size_t len = std::min< std::size_t >( prop.GetTopValue().size(), FX_MAX_PRIM_NAME - 1 );
+				auto begin = prop.GetTopValue().begin();
+				std::copy( begin, begin + len, &mName[ 0 ] );
+				mName[ len ] = '\0';
+			}
+		}
+		// Error
 		else
 		{
-			theFxHelper.Print( "Unknown key parsing an effect primitive: %s\n", key );
+			theFxHelper.Print( "Unknown key parsing an effect primitive!\n" );
 		}
-
-		pairs = (CGPValue *)pairs->GetNext();
 	}
 
-	subGrp = grp->GetSubGroups();
-
-	// Lets chomp on the groups now
-	while ( subGrp )
+	for( auto& subGrp : grp.GetSubGroups() )
 	{
-		key = subGrp->GetName();
+		using GroupParseMethod = bool ( CPrimitiveTemplate::* )( const CGPGroup& );
+		static StringViewIMap< GroupParseMethod > parseMethods{
+			{ CSTRING_VIEW( "rgb" ), &CPrimitiveTemplate::ParseRGB },
 
-		if ( !Q_stricmp( key, "rgb" ))
+			{ CSTRING_VIEW( "alpha" ), &CPrimitiveTemplate::ParseAlpha },
+
+			{ CSTRING_VIEW( "size" ), &CPrimitiveTemplate::ParseSize },
+			{ CSTRING_VIEW( "width" ), &CPrimitiveTemplate::ParseSize },
+
+			{ CSTRING_VIEW( "size2" ), &CPrimitiveTemplate::ParseSize2 },
+			{ CSTRING_VIEW( "width2" ), &CPrimitiveTemplate::ParseSize2 },
+
+			{ CSTRING_VIEW( "length" ), &CPrimitiveTemplate::ParseLength },
+			{ CSTRING_VIEW( "height" ), &CPrimitiveTemplate::ParseLength },
+		};
+		auto pos = parseMethods.find( subGrp.GetName() );
+		if( pos == parseMethods.end() )
 		{
-			ParseRGB( subGrp );
-		}
-		else if ( !Q_stricmp( key, "alpha" ))
-		{
-			ParseAlpha( subGrp );
-		}
-		else if ( !Q_stricmp( key, "size" ) || !Q_stricmp( key, "width" ))
-		{
-			ParseSize( subGrp );
-		}
-		else if ( !Q_stricmp( key, "size2" ) || !Q_stricmp( key, "width2" ))
-		{
-			ParseSize2( subGrp );
-		}
-		else if ( !Q_stricmp( key, "length" ) || !Q_stricmp( key, "height" ))
-		{
-			ParseLength( subGrp );
+			theFxHelper.Print( "Unknown group key parsing a particle!\n" );
 		}
 		else
 		{
-			theFxHelper.Print( "Unknown group key parsing a particle: %s\n", key );
+			GroupParseMethod method = pos->second;
+			( this->*method )( subGrp );
 		}
-
-		subGrp = (CGPGroup *)subGrp->GetNext();
 	}
-
 	return true;
 }

--- a/code/cgame/FxTemplate.cpp
+++ b/code/cgame/FxTemplate.cpp
@@ -256,7 +256,7 @@ namespace detail
 	struct ScanStrings
 	{
 		template< std::size_t count, typename... Args >
-		static int call( const gsl::cstring_view& val, std::array< gsl::cstring_view, count >& arr, Args... args )
+		static int call( const gsl::cstring_view& val, std::array< gsl::cstring_view, count >& arr, Args&... args )
 		{
 			return ScanStrings< remaining - 1 >::call( val, arr, arr[ remaining - 1 ], args... );
 		}
@@ -266,7 +266,7 @@ namespace detail
 	struct ScanStrings< 0 >
 	{
 		template< std::size_t count, typename... Args >
-		static int call( const gsl::cstring_view& val, std::array< gsl::cstring_view, count >& arr, Args... args )
+		static int call( const gsl::cstring_view& val, std::array< gsl::cstring_view, count >& arr, Args&... args )
 		{
 			return Q::sscanf( val, args... );
 		}

--- a/code/client/snd_music.cpp
+++ b/code/client/snd_music.cpp
@@ -30,6 +30,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "../qcommon/sstring.h"
 #include <algorithm>
 #include <string>
+#include <sstream>
 
 #include "snd_local.h"
 #include "cl_mp3.h"
@@ -41,28 +42,24 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 extern qboolean S_FileExists( const char *psFilename );
 
-#define sKEY_MUSICFILES	"musicfiles"
-#define sKEY_ENTRY		"entry"
-#define sKEY_EXIT		"exit"
-#define sKEY_MARKER		"marker"
-#define sKEY_TIME		"time"
-#define sKEY_NEXTFILE	"nextfile"
-#define sKEY_NEXTMARK	"nextmark"
-#define sKEY_LEVELMUSIC	"levelmusic"
-#define sKEY_EXPLORE	"explore"
-#define sKEY_ACTION		"action"
-#define sKEY_BOSS		"boss"
-#define sKEY_DEATH		"death"
-#define sKEY_USES		"uses"
-#define sKEY_USEBOSS	"useboss"
+#define sKEY_MUSICFILES	CSTRING_VIEW( "musicfiles" )
+#define sKEY_ENTRY		CSTRING_VIEW( "entry" )
+#define sKEY_EXIT		CSTRING_VIEW( "exit" )
+#define sKEY_MARKER		CSTRING_VIEW( "marker" )
+#define sKEY_TIME		CSTRING_VIEW( "time" )
+#define sKEY_NEXTFILE	CSTRING_VIEW( "nextfile" )
+#define sKEY_NEXTMARK	CSTRING_VIEW( "nextmark" )
+#define sKEY_LEVELMUSIC	CSTRING_VIEW( "levelmusic" )
+#define sKEY_EXPLORE	CSTRING_VIEW( "explore" )
+#define sKEY_ACTION		CSTRING_VIEW( "action" )
+#define sKEY_BOSS		CSTRING_VIEW( "boss" )
+#define sKEY_DEATH		CSTRING_VIEW( "death" )
+#define sKEY_USES		CSTRING_VIEW( "uses" )
+#define sKEY_USEBOSS	CSTRING_VIEW( "useboss" )
 
 #define sKEY_PLACEHOLDER "placeholder"	// ignore these
 
 #define sFILENAME_DMS	"ext_data/dms.dat"
-
-
-#define MUSIC_PARSE_ERROR(_string)		Music_Parse_Error(_string)	// only use during parse, not run-time use, and bear in mid that data is zapped after error message, so exit any loops immediately
-#define MUSIC_PARSE_WARNING(_string)	Music_Parse_Warning(_string)
 
 typedef struct
 {
@@ -113,22 +110,49 @@ void Music_Free(void)
 	MusicData = NULL;
 }
 
-// some sort of error in the music data...
-//
-static void Music_Parse_Error(const char *psError)
+namespace detail
 {
-	Com_Printf(S_COLOR_RED "Error parsing music data ( in \"%s\" ):\n%s\n",sFILENAME_DMS,psError);
+	static void build_string( std::ostream& stream )
+	{
+	}
+
+	template< typename T, typename... Tail >
+	static void build_string( std::ostream& stream, const T& head, Tail... tail )
+	{
+		stream << head;
+		build_string( stream, tail... );
+	}
+}
+
+template< typename... Tail >
+static std::string build_string( Tail... tail )
+{
+	std::ostringstream os;
+	detail::build_string( os, tail... );
+	return os.str();
+}
+
+// some sort of error in the music data...
+// only use during parse, not run-time use, and bear in mid that data is zapped after error message, so exit any loops immediately
+//
+static void Music_Parse_Error( gsl::czstring filename, const std::string& error )
+{
+	std::string message = build_string(
+		S_COLOR_RED "Error parsing music data (in \"", filename, "\"):\n",
+		error , "\n"
+		);
+	Com_Printf( "%s", message.c_str() );
 	MusicData->clear();
 }
 
 // something to just mention if interested...
 //
-static void Music_Parse_Warning(const char *psError)
+static void Music_Parse_Warning( const std::string& error )
 {
 	extern cvar_t *s_debugdynamic;
-	if (s_debugdynamic && s_debugdynamic->integer)
+	if( s_debugdynamic && s_debugdynamic->integer )
 	{
-		Com_Printf(S_COLOR_YELLOW "%s", psError);
+		Com_Printf( S_COLOR_YELLOW "%s", error.c_str() );
 	}
 }
 
@@ -180,224 +204,162 @@ const char *Music_BaseStateToString( MusicState_e eMusicState, qboolean bDebugPr
 	return NULL;
 }
 
-static qboolean Music_ParseMusic(CGenericParser2 &Parser, MusicData_t *MusicData, CGPGroup *pgMusicFiles, const char *psMusicName, const char *psMusicNameKey, MusicState_e eMusicState)
+static sstring_t StringViewToSString( const gsl::cstring_view& view )
 {
-	qboolean bReturn = qfalse;
+	std::size_t len = std::min< std::size_t >( view.size(), MAX_QPATH - 1 );
+	return sstring_t( std::string( view.begin(), view.begin() + len ).c_str() );
+}
+
+static bool Music_ParseMusic( gsl::czstring filename, const CGenericParser2& Parser, MusicData_t* MusicData, const CGPGroup& pgMusicFiles, const gsl::cstring_view& psMusicName, const gsl::cstring_view& psMusicNameKey, MusicState_e eMusicState )
+{
+	bool bReturn = false;
 	MusicFile_t MusicFile;
 
-	CGPGroup *pgMusicFile = pgMusicFiles->FindSubGroup(psMusicName);
-	if (pgMusicFile)
+	const CGPGroup* pgMusicFile = pgMusicFiles.FindSubGroup( psMusicName );
+	if( pgMusicFile )
 	{
 		// read subgroups...
 		//
-		qboolean bEntryFound = qfalse;
-		qboolean bExitFound  = qfalse;
+		bool bEntryFound = false;
+		bool bExitFound = false;
 		//
 		// (read entry points first, so I can check exit points aren't too close in time)
 		//
-		CGPGroup *pEntryGroup = pgMusicFile->FindSubGroup(sKEY_ENTRY);
-		if (pEntryGroup)
+		const CGPGroup* pEntryGroup = pgMusicFile->FindSubGroup( sKEY_ENTRY );
+		if( pEntryGroup )
 		{
 			// read entry points...
 			//
-			for (CGPValue *pValue = pEntryGroup->GetPairs(); pValue; pValue = pValue->GetNext())
+			for( auto& prop : pEntryGroup->GetProperties() )
 			{
-				const char *psKey	= pValue->GetName();
-				const char *psValue	= pValue->GetTopValue();
-
 				//if (!strncmp(psKey,sKEY_MARKER,strlen(sKEY_MARKER)))	// for now, assume anything is a marker
-				{
-					MusicFile.MusicEntryTimes[psKey] = atof(psValue);
-					bEntryFound = qtrue;						// harmless to keep setting
-				}
+				MusicFile.MusicEntryTimes[ StringViewToSString( prop.GetName() ) ] = Q::svtoi( prop.GetTopValue() );
+				bEntryFound = true;
 			}
 		}
 
-		for (CGPGroup *pGroup = pgMusicFile->GetSubGroups(); pGroup; pGroup = pGroup->GetNext())
+		for( auto& group : pgMusicFile->GetSubGroups() )
 		{
-			const char *psGroupName = pGroup->GetName();
+			auto& groupName = group.GetName();
 
-			if (!strcmp(psGroupName,sKEY_ENTRY))
+			if( groupName == sKEY_ENTRY )
 			{
 				// skip entry points, I've already read them in above
 				//
 			}
-			else
-			if (!strcmp(psGroupName,sKEY_EXIT))
+			else if( groupName == sKEY_EXIT )
 			{
 				int iThisExitPointIndex = MusicFile.MusicExitPoints.size();	// must eval this first, so unaffected by push_back etc
 				//
 				// read this set of exit points...
 				//
 				MusicExitPoint_t MusicExitPoint;
-				for (CGPValue *pValue = pGroup->GetPairs(); pValue; pValue = pValue->GetNext())
+				for( auto& prop : group.GetProperties() )
 				{
-					const char *psKey	= pValue->GetName();
-					const char *psValue	= pValue->GetTopValue();
+					auto& key = prop.GetName();
+					auto& value = prop.GetTopValue();
 
-					if (!strcmp(psKey,sKEY_NEXTFILE))
+					if( key == sKEY_NEXTFILE )
 					{
-						MusicExitPoint.sNextFile = psValue;
-						bExitFound  = qtrue;	// harmless to keep setting
+						MusicExitPoint.sNextFile = StringViewToSString( value );
+						bExitFound = true;	// harmless to keep setting
 					}
-					else
-					if (!strcmp(psKey,sKEY_NEXTMARK))
+					else if( key == sKEY_NEXTMARK )
 					{
-						MusicExitPoint.sNextMark = psValue;
+						MusicExitPoint.sNextMark = StringViewToSString( value );
 					}
-					else
-					if (!strncmp(psKey,sKEY_TIME,strlen(sKEY_TIME)))
+					else if( key == sKEY_TIME )
 					{
 						MusicExitTime_t MusicExitTime;
-										MusicExitTime.fTime		= atof(psValue);
-										MusicExitTime.iExitPoint= iThisExitPointIndex;
+						MusicExitTime.fTime = Q::svtof( value );
+						MusicExitTime.iExitPoint = iThisExitPointIndex;
 
 						// new check, don't keep this this exit point if it's within 1.5 seconds either way of an entry point...
 						//
-						qboolean bTooCloseToEntryPoint = qfalse;
-						for (MusicEntryTimes_t::iterator itEntryTimes = MusicFile.MusicEntryTimes.begin(); itEntryTimes != MusicFile.MusicEntryTimes.end(); ++itEntryTimes)
+						bool bTooCloseToEntryPoint = false;
+						for( auto& item : MusicFile.MusicEntryTimes )
 						{
-							float fThisEntryTime = (*itEntryTimes).second;
+							float fThisEntryTime = item.second;
 
-							if (Q_fabs(fThisEntryTime - MusicExitTime.fTime) < 1.5f)
+							if( Q_fabs( fThisEntryTime - MusicExitTime.fTime ) < 1.5f )
 							{
-//								bTooCloseToEntryPoint = qtrue;	// not sure about this, ignore for now
+								//								bTooCloseToEntryPoint = true;	// not sure about this, ignore for now
 								break;
 							}
 						}
-						if (!bTooCloseToEntryPoint)
+						if( !bTooCloseToEntryPoint )
 						{
-							MusicFile.MusicExitTimes.push_back(MusicExitTime);
+							MusicFile.MusicExitTimes.push_back( MusicExitTime );
 						}
 					}
 				}
 
-				MusicFile.MusicExitPoints.push_back(MusicExitPoint);
+				MusicFile.MusicExitPoints.push_back( MusicExitPoint );
 				int iNumExitPoints = MusicFile.MusicExitPoints.size();
 
 				// error checking...
 				//
-				switch (eMusicState)
+				switch( eMusicState )
 				{
-					case eBGRNDTRACK_EXPLORE:
-						if (iNumExitPoints > iMAX_EXPLORE_TRANSITIONS)
-						{
-							MUSIC_PARSE_ERROR( va("\"%s\" has > %d %s transitions defined!\n",psMusicName,iMAX_EXPLORE_TRANSITIONS,psMusicNameKey) );
-							return qfalse;
-						}
-						break;
+				case eBGRNDTRACK_EXPLORE:
+					if( iNumExitPoints > iMAX_EXPLORE_TRANSITIONS )
+					{
+						Music_Parse_Error( filename, build_string( "\"", psMusicName, "\" has > ", iMAX_EXPLORE_TRANSITIONS, " ", psMusicNameKey, " transitions defined!\n" ) );
+						return false;
+					}
+					break;
 
-					case eBGRNDTRACK_ACTION:
-						if (iNumExitPoints > iMAX_ACTION_TRANSITIONS)
-						{
-							MUSIC_PARSE_ERROR( va("\"%s\" has > %d %s transitions defined!\n",psMusicName,iMAX_ACTION_TRANSITIONS,psMusicNameKey) );
-							return qfalse;
-						}
-						break;
+				case eBGRNDTRACK_ACTION:
+					if( iNumExitPoints > iMAX_ACTION_TRANSITIONS )
+					{
+						Music_Parse_Error( filename, build_string( "\"", psMusicName, "\" has > ", iMAX_ACTION_TRANSITIONS, " ", psMusicNameKey, " transitions defined!\n" ) );
+						return false;
+					}
+					break;
 
-					case eBGRNDTRACK_BOSS:
-					case eBGRNDTRACK_DEATH:
+				case eBGRNDTRACK_BOSS:
+				case eBGRNDTRACK_DEATH:
 
-						MUSIC_PARSE_ERROR( va("\"%s\" has %s transitions defined, this is not allowed!\n",psMusicName,psMusicNameKey) );
-						break;
-					default:
-						break;
+					Music_Parse_Error( filename, build_string( "\"", psMusicName, "\" has ", psMusicNameKey, " transitions defined, this is not allowed!\n" ) );
+					return false;
+				default:
+					break;
 				}
 			}
 		}
 
 		// for now, assume everything was ok unless some obvious things are missing...
 		//
-		bReturn = qtrue;
+		bReturn = true;
 
-		if (eMusicState != eBGRNDTRACK_BOSS && eMusicState != eBGRNDTRACK_DEATH)	// boss & death pieces can omit entry/exit stuff
+		// boss & death pieces can omit entry/exit stuff
+		if( eMusicState != eBGRNDTRACK_BOSS && eMusicState != eBGRNDTRACK_DEATH )
 		{
-			if (!bEntryFound)
+			if( !bEntryFound )
 			{
-				MUSIC_PARSE_ERROR(va("Unable to find subgroup \"%s\" in group \"%s\"\n",sKEY_ENTRY,psMusicName));
-				bReturn = qfalse;
+				Music_Parse_Error( filename, build_string( "Unable to find subgroup \"", sKEY_ENTRY, "\" in group \"", psMusicName, "\"\n" ) );
+				bReturn = false;
 			}
-			if (!bExitFound)
+			if( !bExitFound )
 			{
-				MUSIC_PARSE_ERROR(va("Unable to find subgroup \"%s\" in group \"%s\"\n",sKEY_EXIT,psMusicName));
-				bReturn = qfalse;
+				Music_Parse_Error( filename, build_string( "Unable to find subgroup \"", sKEY_EXIT, "\" in group \"", psMusicName, "\"\n" ) );
+				bReturn = false;
 			}
 		}
 	}
 	else
 	{
-		MUSIC_PARSE_ERROR(va("Unable to find musicfiles entry \"%s\"\n",psMusicName));
+		Music_Parse_Error( filename, build_string( "Unable to find musicfiles entry \"", psMusicName, "\"\n" ) );
 	}
 
-	if (bReturn)
+	if( bReturn )
 	{
-		MusicFile.sFileNameBase  = psMusicName;
-		(*MusicData)[ psMusicNameKey ] = MusicFile;
+		MusicFile.sFileNameBase = StringViewToSString( psMusicName );
+		( *MusicData )[ StringViewToSString( psMusicNameKey ) ] = MusicFile;
 	}
 
 	return bReturn;
 }
-
-
-
-
-// I only need this because GP2 can't cope with trailing whitespace (for !@#$%^'s sake!!!!)...
-//
-// (output buffer will always be just '\n' seperated, regardless of possible "\r\n" pairs)
-//
-// (remember to Z_Free() the returned char * when done with it!!!)
-//
-static char *StripTrailingWhiteSpaceOnEveryLine(char *pText)
-{
-	std::string strNewText;
-
-	while (*pText)
-	{
-		char sOneLine[1024];	// BTO: was 16k
-
-		// find end of line...
-		//
-		size_t pos = 0;
-		while (pText[pos] != '\0' && pText[pos] != '\r' && (pos < sizeof(sOneLine)-1))
-		{
-			pos++;
-		}
-
-		strncpy(sOneLine, pText, pos);
-				sOneLine[pos]='\0';
-		pText += pos;
-		while (*pText == '\n' || *pText == '\r') pText++;
-
-		// trim trailing...
-		//
-		qboolean bTrimmed = qfalse;
-		do
-		{
-			bTrimmed = qfalse;
-			int iStrLen = strlen(sOneLine);
-
-			if (iStrLen)
-			{
-				if (sOneLine[iStrLen-1] == '\t' || sOneLine[iStrLen-1] == ' ')
-				{
-					sOneLine[iStrLen-1] = '\0';
-					bTrimmed = qtrue;
-				}
-			}
-		}
-		while (bTrimmed);
-
-		strNewText += sOneLine;
-		strNewText += "\n";
-	}
-
-	char  *pNewText = (char *) Z_Malloc( strlen(strNewText.c_str())+1,
-								TAG_TEMP_WORKSPACE,
-								qfalse);
-	strcpy(pNewText, strNewText.c_str());
-	return pNewText;
-}
-
 
 // called from SV_SpawnServer, but before map load and music start etc.
 //
@@ -409,7 +371,7 @@ void Music_SetLevelName(const char *psLevelName)
 	gsLevelNameFromServer = psLevelName;
 }
 
-static qboolean Music_ParseLeveldata(const char *psLevelName)
+static qboolean Music_ParseLeveldata( gsl::czstring psLevelName )
 {
 	qboolean bReturn = qfalse;
 
@@ -436,192 +398,161 @@ static qboolean Music_ParseLeveldata(const char *psLevelName)
 	gsLevelNameForCompare	= sLevelName;	// harmless to init here even if we fail to parse dms.dat file
 	gsLevelNameForBossLoad	= sLevelName;	// harmless to init here even if we fail to parse dms.dat file
 
-	char *pText = NULL;
-	/*int iTotalBytesLoaded = */FS_ReadFile(sFILENAME_DMS, (void **)&pText );
-	if (pText)
+	gsl::czstring filename = sFILENAME_DMS;
+	CGenericParser2 Parser;
+	if( !Parser.Parse( filename ) )
 	{
-		char *psStrippedText = StripTrailingWhiteSpaceOnEveryLine(pText);
-		CGenericParser2 Parser;
-		const char *psDataPtr = psStrippedText;	// because ptr gets advanced, so we supply a clone that GP can alter
-		if (Parser.Parse(&psDataPtr, true))
+		Music_Parse_Error( filename, "Error using GP to parse file\n" );
+	}
+	else
+	{
+		const CGPGroup& pFileGroup = Parser.GetBaseParseGroup();
+		const CGPGroup* pgMusicFiles = pFileGroup.FindSubGroup( sKEY_MUSICFILES );
+		if( pgMusicFiles )
 		{
-			CGPGroup *pFileGroup = Parser.GetBaseParseGroup();
-			if (pFileGroup)
+			const CGPGroup* pgLevelMusic = pFileGroup.FindSubGroup( sKEY_LEVELMUSIC );
+
+			if( !pgLevelMusic )
 			{
-				CGPGroup *pgMusicFiles = pFileGroup->FindSubGroup(sKEY_MUSICFILES);
-				if (pgMusicFiles)
+				Music_Parse_Error( filename, build_string( "Unable to find subgroup \"", sKEY_MUSICFILES, "\"\n" ) );
+			}
+			else
+			{
+				const CGPGroup *pgThisLevelMusic = nullptr;
+				//
+				// check for new USE keyword...
+				//
+				int iSanityLimit = 0;
+				gsl::cstring_view searchName{ &sLevelName[ 0 ], &sLevelName[ strlen( &sLevelName[ 0 ] ) ] };
+
+				while( !searchName.empty() && iSanityLimit < 10 )
 				{
-					CGPGroup *pgLevelMusic = pFileGroup->FindSubGroup(sKEY_LEVELMUSIC);
+					gsLevelNameForLoad = StringViewToSString( searchName );
+					gsLevelNameForBossLoad = gsLevelNameForLoad;
+					pgThisLevelMusic = pgLevelMusic->FindSubGroup( searchName );
 
-					if (pgLevelMusic)
+					if( pgThisLevelMusic )
 					{
-						CGPGroup *pgThisLevelMusic = NULL;
-						//
-						// check for new USE keyword...
-						//
-						int iSanityLimit = 0;
-						sstring_t sSearchName(sLevelName);
-
-						while (sSearchName.c_str()[0] && iSanityLimit < 10)
+						const CGPProperty* pValue = pgThisLevelMusic->FindProperty( sKEY_USES );
+						if( pValue )
 						{
-							gsLevelNameForLoad		= sSearchName;
-							gsLevelNameForBossLoad	= sSearchName;
-							pgThisLevelMusic = pgLevelMusic->FindSubGroup(sSearchName.c_str());
-
-							if (pgThisLevelMusic)
-							{
-								CGPValue *pValue = pgThisLevelMusic->FindPair(sKEY_USES);
-								if (pValue)
-								{
-									// re-search using the USE param...
-									//
-									sSearchName = pValue->GetTopValue();
-									iSanityLimit++;
-//									Com_DPrintf("Using \"%s\"\n",sSearchName.c_str());
-								}
-								else
-								{
-									// no new USE keyword found...
-									//
-									sSearchName = "";
-								}
-							}
-							else
-							{
-								// level entry not found...
-								//
-								break;
-							}
-						}
-
-						// now go ahead and use the final music set we've decided on...
-						//
-						if (pgThisLevelMusic && iSanityLimit < 10)
-						{
-							// these are optional fields, so see which ones we find...
+							// re-search using the USE param...
 							//
-							const char *psName_Explore = NULL;
-							const char *psName_Action  = NULL;
-							const char *psName_Boss	  = NULL;
-							//const char *psName_Death	  = NULL;
-							//
-							const char *psName_UseBoss = NULL;
-
-							for (CGPValue *pValue = pgThisLevelMusic->GetPairs(); pValue; pValue = pValue->GetNext())
-							{
-								const char *psKey	= pValue->GetName();
-								const char *psValue	= pValue->GetTopValue();
-
-								if (Q_stricmp(psValue,sKEY_PLACEHOLDER))	// ignore "placeholder" items
-								{
-									if (!Q_stricmp(psKey,sKEY_EXPLORE))
-									{
-										psName_Explore = psValue;
-									}
-									else
-									if (!Q_stricmp(psKey,sKEY_ACTION))
-									{
-										psName_Action  = psValue;
-									}
-									else
-									if (!Q_stricmp(psKey,sKEY_USEBOSS))
-									{
-										psName_UseBoss = psValue;
-									}
-									else
-									if (!Q_stricmp(psKey,sKEY_BOSS))
-									{
-										psName_Boss = psValue;
-									}
-									/*else
-									if (!Q_stricmp(psKey,sKEY_DEATH))
-									{
-										psName_Death = psValue;
-									}*/
-								}
-							}
-
-							bReturn = qtrue;	// defualt to ON now, so I can turn it off if "useboss" fails
-
-							if (psName_UseBoss)
-							{
-								CGPGroup *pgLevelMusicOfBoss = pgLevelMusic->FindSubGroup(psName_UseBoss);
-								if (pgLevelMusicOfBoss)
-								{
-									CGPValue *pValueBoss = pgLevelMusicOfBoss->FindPair(sKEY_BOSS);
-									if (pValueBoss)
-									{
-										psName_Boss = pValueBoss->GetTopValue();
-										gsLevelNameForBossLoad = psName_UseBoss;
-									}
-									else
-									{
-										MUSIC_PARSE_ERROR(va("'useboss' \"%s\" has no \"boss\" entry!\n",psName_UseBoss));
-										bReturn = qfalse;
-									}
-								}
-								else
-								{
-									MUSIC_PARSE_ERROR(va("Unable to find 'useboss' entry \"%s\"\n",psName_UseBoss));
-									bReturn = qfalse;
-								}
-							}
-
-
-							// done this way in case I want to conditionally pass any bools depending on music type...
-							//
-							if (bReturn && psName_Explore)
-							{
-								bReturn = Music_ParseMusic(Parser, MusicData, pgMusicFiles, psName_Explore,	sKEY_EXPLORE, eBGRNDTRACK_EXPLORE);
-							}
-							if (bReturn && psName_Action)
-							{
-								bReturn = Music_ParseMusic(Parser, MusicData, pgMusicFiles, psName_Action,	sKEY_ACTION,  eBGRNDTRACK_ACTION);
-							}
-							if (bReturn && psName_Boss)
-							{
-								bReturn = Music_ParseMusic(Parser, MusicData, pgMusicFiles, psName_Boss,	sKEY_BOSS,    eBGRNDTRACK_BOSS);
-							}
-							if (bReturn /*&& psName_Death*/)	// LAST MINUTE HACK!!, always force in some death music!!!!
-							{
-								//bReturn = Music_ParseMusic(Parser, MusicData, pgMusicFiles, psName_Death,	sKEY_DEATH,   eBGRNDTRACK_DEATH);
-
-								MusicFile_t m;
-											m.sFileNameBase = "death_music";
-								(*MusicData)[ sKEY_DEATH ] = m;
-							}
+							searchName = pValue->GetTopValue();
+							iSanityLimit++;
+							//									Com_DPrintf("Using \"%s\"\n",sSearchName.c_str());
 						}
 						else
 						{
-							MUSIC_PARSE_WARNING(va("Unable to find entry for \"%s\" in \"%s\"\n",sLevelName,sFILENAME_DMS));
+							// no new USE keyword found...
+							//
+							searchName = {};
 						}
 					}
 					else
 					{
-						MUSIC_PARSE_ERROR(va("Unable to find subgroup \"%s\"\n",sKEY_LEVELMUSIC));
+						// level entry not found...
+						//
+						break;
 					}
+				}
+
+				// now go ahead and use the final music set we've decided on...
+				//
+				if( pgThisLevelMusic && iSanityLimit < 10 )
+				{
+					Music_Parse_Warning( build_string( "Unable to find entry for \"", sLevelName, "\" in \"", filename, "\"\n" ) );
 				}
 				else
 				{
-					MUSIC_PARSE_ERROR(va("Unable to find subgroup \"%s\"\n",sKEY_MUSICFILES));
+					// these are optional fields, so see which ones we find...
+					//
+					gsl::cstring_view psName_Explore;
+					gsl::cstring_view psName_Action;
+					gsl::cstring_view psName_Boss;
+					gsl::cstring_view psName_UseBoss;
+
+					for( auto& prop : pgThisLevelMusic->GetProperties() )
+					{
+						auto& key = prop.GetName();
+						auto& value = prop.GetTopValue();
+
+						if( Q::stricmp( value, sKEY_PLACEHOLDER ) == Q::Ordering::EQ )
+						{
+							// ignore "placeholder" items
+							continue;
+						}
+
+						if( Q::stricmp( key, sKEY_EXPLORE ) == Q::Ordering::EQ )
+						{
+							psName_Explore = value;
+						}
+						else if( Q::stricmp( key, sKEY_ACTION ) == Q::Ordering::EQ )
+						{
+							psName_Action = value;
+						}
+						else if( Q::stricmp( key, sKEY_USEBOSS ) == Q::Ordering::EQ )
+						{
+							psName_UseBoss = value;
+						}
+						else if( Q::stricmp( key, sKEY_BOSS ) == Q::Ordering::EQ )
+						{
+							psName_Boss = value;
+						}
+					}
+
+					bReturn = qtrue;	// defualt to ON now, so I can turn it off if "useboss" fails
+
+					if( !psName_UseBoss.empty() )
+					{
+						const CGPGroup *pgLevelMusicOfBoss = pgLevelMusic->FindSubGroup( psName_UseBoss );
+						if( !pgLevelMusicOfBoss )
+						{
+							Music_Parse_Error( filename, build_string( "Unable to find 'useboss' entry \"", psName_UseBoss, "\"\n", psName_UseBoss ) );
+							bReturn = qfalse;
+						}
+						else
+						{
+							const CGPProperty *pValueBoss = pgLevelMusicOfBoss->FindProperty( sKEY_BOSS );
+							if( pValueBoss )
+							{
+								Music_Parse_Error( filename, build_string( "'useboss' \"", psName_UseBoss, "\" has no \"boss\" entry!\n" ) );
+								bReturn = qfalse;
+							}
+							else
+							{
+								psName_Boss = pValueBoss->GetTopValue();
+								gsLevelNameForBossLoad = StringViewToSString( psName_UseBoss );
+							}
+						}
+					}
+
+
+					// done this way in case I want to conditionally pass any bools depending on music type...
+					//
+					if( bReturn && psName_Explore )
+					{
+						bReturn = Music_ParseMusic( filename, Parser, MusicData, *pgMusicFiles, psName_Explore, sKEY_EXPLORE, eBGRNDTRACK_EXPLORE );
+					}
+					if( bReturn && psName_Action )
+					{
+						bReturn = Music_ParseMusic( filename, Parser, MusicData, *pgMusicFiles, psName_Action, sKEY_ACTION, eBGRNDTRACK_ACTION );
+					}
+					if( bReturn && psName_Boss )
+					{
+						bReturn = Music_ParseMusic( filename, Parser, MusicData, *pgMusicFiles, psName_Boss, sKEY_BOSS, eBGRNDTRACK_BOSS );
+					}
+					if( bReturn /*&& psName_Death*/ )	// LAST MINUTE HACK!!, always force in some death music!!!!
+					{
+						//bReturn = Music_ParseMusic(Parser, MusicData, pgMusicFiles, psName_Death,	sKEY_DEATH,   eBGRNDTRACK_DEATH);
+
+						MusicFile_t m;
+						m.sFileNameBase = "death_music";
+						( *MusicData )[ "death" ] = m;
+					}
 				}
 			}
-			else
-			{
-				MUSIC_PARSE_ERROR( "Error calling GP2.GetBaseParseGroup()\n" );
-			}
 		}
-		else
-		{
-			MUSIC_PARSE_ERROR( "Error using GP to parse file\n" );
-		}
-
-		Z_Free(psStrippedText);
-		FS_FreeFile( pText );
-	}
-	else
-	{
-		MUSIC_PARSE_ERROR( "Unable to even read main file\n" );	// file name specified in error message
 	}
 
 	if (bReturn)
@@ -647,7 +578,7 @@ static qboolean Music_ParseLeveldata(const char *psLevelName)
 			const char *psMusicFileName = Music_BuildFileName( MusicFile.sFileNameBase.c_str(), eMusicState );
 			if (!S_FileExists( psMusicFileName ))
 			{
-				MUSIC_PARSE_ERROR(va("Music file \"%s\" not found!\n",psMusicFileName));
+				Music_Parse_Error( filename, build_string( "Music file \"", psMusicFileName, "\" not found!\n" ) );
 				return qfalse;		// have to return, because music data destroyed now
 			}
 
@@ -660,7 +591,7 @@ static qboolean Music_ParseLeveldata(const char *psLevelName)
 				const char *psTransitionFileName = Music_BuildFileName( MusicExitPoint.sNextFile.c_str(), eMusicState );
 				if (!S_FileExists( psTransitionFileName ))
 				{
-					MUSIC_PARSE_ERROR(va("Transition file \"%s\" (entry \"%s\" ) not found!\n",psTransitionFileName, MusicExitPoint.sNextFile.c_str()));
+					Music_Parse_Error( filename, build_string( "Transition file \"", psTransitionFileName, "\" (entry \"", MusicExitPoint.sNextFile.c_str(), "\" ) not found!\n" ) );
 					return qfalse;		// have to return, because music data destroyed now
 				}
 
@@ -680,64 +611,19 @@ static qboolean Music_ParseLeveldata(const char *psLevelName)
 
 						if (!MusicFile_Explore.MusicEntryTimes.count(psNextMark))
 						{
-							MUSIC_PARSE_ERROR( va("Unable to find entry point \"%s\" in description for \"%s\"\n",psNextMark,MusicFile_Explore.sFileNameBase.c_str()) );
+							Music_Parse_Error( filename, build_string( "Unable to find entry point \"", psNextMark, "\" in description for \"", MusicFile_Explore.sFileNameBase.c_str(), "\"\n" ) );
 							return qfalse;		// have to return, because music data destroyed now
 						}
 					}
 					else
 					{
-						MUSIC_PARSE_ERROR( va("Unable to find %s piece to match \"%s\"\n", Music_BaseStateToString(eBGRNDTRACK_EXPLORE), MusicFile.sFileNameBase.c_str() ) );
+						Music_Parse_Error( filename, build_string( "Unable to find ", Music_BaseStateToString( eBGRNDTRACK_EXPLORE ), " piece to match \"", MusicFile.sFileNameBase.c_str(), "\"\n" ) );
 						return qfalse;		// have to return, because music data destroyed now
 					}
 				}
 			}
 		}
 	}
-
-#ifdef _DEBUG
-/*
-	// dump the whole thing out to prove it was read in ok...
-	//
-	if (bReturn)
-	{
-		for (MusicData_t::iterator itMusicData = MusicData->begin(); itMusicData != MusicData->end(); ++itMusicData)
-		{
-			const char *psMusicState		= (*itMusicData).first.c_str();
-			MusicFile_t &MusicFile	= (*itMusicData).second;
-
-			OutputDebugString(va("Music State:  \"%s\",  File: \"%s\"\n",psMusicState, MusicFile.sFileNameBase.c_str()));
-
-			// entry times...
-			//
-			for (MusicEntryTimes_t::iterator itEntryTimes = MusicFile.MusicEntryTimes.begin(); itEntryTimes != MusicFile.MusicEntryTimes.end(); ++itEntryTimes)
-			{
-				const char *psMarkerName	= (*itEntryTimes).first.c_str();
-				float	fEntryTime		= (*itEntryTimes).second;
-
-				OutputDebugString(va("Entry time for \"%s\": %f\n", psMarkerName, fEntryTime));
-			}
-
-			// exit points...
-			//
-			for (int i=0; i<MusicFile.MusicExitPoints.size(); i++)
-			{
-				MusicExitPoint_t &MusicExitPoint = MusicFile.MusicExitPoints[i];
-
-				OutputDebugString(va("Exit point %d:	sNextFile: \"%s\", sNextMark: \"%s\"\n",i,MusicExitPoint.sNextFile.c_str(),MusicExitPoint.sNextMark.c_str()));
-			}
-
-			// exit times...
-			//
-			for (i=0; i<MusicFile.MusicExitTimes.size(); i++)
-			{
-				MusicExitTime_t &MusicExitTime = MusicFile.MusicExitTimes[i];
-
-				OutputDebugString(va("Exit time %d:		fTime: %f, iExitPoint: %d\n",i,MusicExitTime.fTime,MusicExitTime.iExitPoint));
-			}
-		}
-	}
-*/
-#endif
 
 	return bReturn;
 }

--- a/code/client/snd_music.cpp
+++ b/code/client/snd_music.cpp
@@ -442,7 +442,7 @@ static qboolean Music_ParseLeveldata(const char *psLevelName)
 	{
 		char *psStrippedText = StripTrailingWhiteSpaceOnEveryLine(pText);
 		CGenericParser2 Parser;
-		char *psDataPtr = psStrippedText;	// because ptr gets advanced, so we supply a clone that GP can alter
+		const char *psDataPtr = psStrippedText;	// because ptr gets advanced, so we supply a clone that GP can alter
 		if (Parser.Parse(&psDataPtr, true))
 		{
 			CGPGroup *pFileGroup = Parser.GetBaseParseGroup();

--- a/code/game/genericparser2.cpp
+++ b/code/game/genericparser2.cpp
@@ -482,8 +482,7 @@ CGPGroup::CGPGroup(const char *initName, CGPGroup *initParent) :
 	mSubGroups(0),
 	mInOrderSubGroups(0),
 	mCurrentSubGroup(0),
-	mParent(initParent),
-	mWriteable(false)
+	mParent(initParent)
 {
 }
 
@@ -543,7 +542,6 @@ void CGPGroup::Clean(void)
 	mPairs = mInOrderPairs = mCurrentPair = 0;
 	mSubGroups = mInOrderSubGroups = mCurrentSubGroup = 0;
 	mParent = 0;
-	mWriteable = false;
 }
 
 CGPGroup *CGPGroup::Duplicate(CTextPool **textPool, CGPGroup *initParent)
@@ -727,7 +725,6 @@ bool CGPGroup::Parse(char **dataPtr, CTextPool **textPool)
 		if (Q_stricmp(token, "{") == 0)
 		{	// new sub group
 			newSubGroup = AddGroup(lastToken, textPool);
-			newSubGroup->SetWriteable(mWriteable);
 			if (!newSubGroup->Parse(dataPtr, textPool))
 			{
 				return false;
@@ -840,8 +837,7 @@ const char *CGPGroup::FindPairValue(const char *key, const char *defaultVal)
 
 
 CGenericParser2::CGenericParser2(void) :
-	mTextPool(0),
-	mWriteable(false)
+	mTextPool(0)
 {
 }
 
@@ -850,7 +846,7 @@ CGenericParser2::~CGenericParser2(void)
 	Clean();
 }
 
-bool CGenericParser2::Parse(char **dataPtr, bool cleanFirst, bool writeable)
+bool CGenericParser2::Parse(char **dataPtr, bool cleanFirst)
 {
 	CTextPool	*topPool;
 
@@ -864,8 +860,6 @@ bool CGenericParser2::Parse(char **dataPtr, bool cleanFirst, bool writeable)
 		mTextPool = new CTextPool;
 	}
 
-	SetWriteable(writeable);
-	mTopLevel.SetWriteable(writeable);
 	topPool = mTextPool;
 	bool ret = mTopLevel.Parse(dataPtr, &topPool);
 	return ret;
@@ -896,12 +890,12 @@ bool CGenericParser2::Write(CTextPool *textPool)
 // C++ users should just use the objects as normally and not call these routines below
 //
 // CGenericParser2 (void *) routines
-TGenericParser2 GP_Parse(char **dataPtr, bool cleanFirst, bool writeable)
+TGenericParser2 GP_Parse(char **dataPtr, bool cleanFirst)
 {
 	CGenericParser2		*parse;
 
 	parse = new CGenericParser2;
-	if (parse->Parse(dataPtr, cleanFirst, writeable))
+	if (parse->Parse(dataPtr, cleanFirst))
 	{
 		return parse;
 	}

--- a/code/game/genericparser2.cpp
+++ b/code/game/genericparser2.cpp
@@ -703,19 +703,22 @@ bool CGPGroup::Parse(const char **dataPtr, CTextPool **textPool)
 		token = GetToken(dataPtr, true);
 
 		if (!token[0])
-		{	// end of data - error!
+		{
 			if (mParent)
 			{
+				// end of data - error!
 				return false;
 			}
 			else
 			{
-				break;
+				// top level parse; there was no opening "{", so there should be no closing one either.
+				return true;
 			}
 		}
 		else if (Q_stricmp(token, "}") == 0)
-		{	// ending brace for this group
-			break;
+		{
+			// ending brace for this group
+			return true;
 		}
 
 		strcpy(lastToken, token);
@@ -743,8 +746,6 @@ bool CGPGroup::Parse(const char **dataPtr, CTextPool **textPool)
 			AddPair(lastToken, token, textPool);
 		}
 	}
-
-	return true;
 }
 
 bool CGPGroup::Write(CTextPool **textPool, int depth)

--- a/code/game/genericparser2.cpp
+++ b/code/game/genericparser2.cpp
@@ -717,8 +717,16 @@ bool CGPGroup::Parse(const char **dataPtr, CTextPool **textPool)
 		}
 		else if (Q_stricmp(token, "}") == 0)
 		{
-			// ending brace for this group
-			return true;
+			if( mParent )
+			{
+				// ending brace for this group
+				return true;
+			}
+			else
+			{
+				// top-level group; there was no opening "{" so there should be no closing one, either.
+				return false;
+			}
 		}
 
 		strcpy(lastToken, token);

--- a/code/game/genericparser2.cpp
+++ b/code/game/genericparser2.cpp
@@ -31,9 +31,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define MAX_TOKEN_SIZE	1024
 static char	token[MAX_TOKEN_SIZE];
 
-static char *GetToken(char **text, bool allowLineBreaks, bool readUntilEOL = false)
+static char *GetToken(const char **text, bool allowLineBreaks, bool readUntilEOL = false)
 {
-	char	*pointer = *text;
+	const char	*pointer = *text;
 	int		length = 0;
 	int		c = 0;
 	bool	foundLineBreak;
@@ -378,7 +378,7 @@ void CGPValue::AddValue(const char *newValue, CTextPool **textPool)
 	}
 }
 
-bool CGPValue::Parse(char **dataPtr, CTextPool **textPool)
+bool CGPValue::Parse(const char **dataPtr, CTextPool **textPool)
 {
 	char		*token;
 	char		*value;
@@ -691,7 +691,7 @@ CGPGroup *CGPGroup::FindSubGroup(const char *name)
 	return(NULL);
 }
 
-bool CGPGroup::Parse(char **dataPtr, CTextPool **textPool)
+bool CGPGroup::Parse(const char **dataPtr, CTextPool **textPool)
 {
 	char		*token;
 	char		lastToken[MAX_TOKEN_SIZE];
@@ -846,7 +846,7 @@ CGenericParser2::~CGenericParser2(void)
 	Clean();
 }
 
-bool CGenericParser2::Parse(char **dataPtr, bool cleanFirst)
+bool CGenericParser2::Parse(const char **dataPtr, bool cleanFirst)
 {
 	CTextPool	*topPool;
 
@@ -890,7 +890,7 @@ bool CGenericParser2::Write(CTextPool *textPool)
 // C++ users should just use the objects as normally and not call these routines below
 //
 // CGenericParser2 (void *) routines
-TGenericParser2 GP_Parse(char **dataPtr, bool cleanFirst)
+TGenericParser2 GP_Parse(const char **dataPtr, bool cleanFirst)
 {
 	CGenericParser2		*parse;
 

--- a/code/game/genericparser2.cpp
+++ b/code/game/genericparser2.cpp
@@ -23,812 +23,255 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 // Filename:-	genericparser2.cpp
 
 #include "common_headers.h"
+#include "genericparser2.h"
 
 #ifdef _JK2EXE
 #include "../qcommon/qcommon.h"
 #endif
 
-#define MAX_TOKEN_SIZE	1024
-static char	token[MAX_TOKEN_SIZE];
+#include <algorithm>
+#include <cctype>
 
-static char *GetToken(const char **text, bool allowLineBreaks, bool readUntilEOL = false)
+
+static void skipWhitespace( gsl::cstring_view& text, const bool allowLineBreaks )
 {
-	const char	*pointer = *text;
-	int		length = 0;
-	int		c = 0;
-	bool	foundLineBreak;
-
-	token[0] = 0;
-	if (!pointer)
+	gsl::cstring_view::iterator whitespaceEnd = text.begin();
+	while( whitespaceEnd != text.end() // No EOF
+		&& std::isspace( *whitespaceEnd ) // No End of Whitespace
+		&& ( allowLineBreaks || *whitespaceEnd != '\n' ) ) // No unwanted newline
 	{
-		return token;
+		++whitespaceEnd;
+	}
+	text = { whitespaceEnd, text.end() };
+}
+
+static void skipWhitespaceAndComments( gsl::cstring_view& text, const bool allowLineBreaks )
+{
+	skipWhitespace( text, allowLineBreaks );
+	// skip single line comment
+	if( text.size() >= 2 && text[ 0 ] == '/' && text[ 1 ] == '/' )
+	{
+		auto commentEnd = std::find( text.begin() + 2, text.end(), '\n' );
+		if( commentEnd == text.end() )
+		{
+			text = { text.end(), text.end() };
+			return;
+		}
+		else
+		{
+			text = { commentEnd, text.end() };
+			skipWhitespaceAndComments( text, allowLineBreaks );
+			return;
+		}
 	}
 
-	while(1)
+	// skip multi line comments
+	if( text.size() >= 2 && text[ 0 ] == '/' && text[ 1 ] == '*' )
 	{
-		foundLineBreak = false;
-		while(1)
+		static const std::array< char, 2 > endStr{ '*', '/' };
+		auto commentEnd = std::search( text.begin(), text.end(), endStr.begin(), endStr.end() );
+		if( commentEnd == text.end() )
 		{
-			c = *pointer;
-			if (c > ' ')
-			{
-				break;
-			}
-			if (!c)
-			{
-				*text = 0;
-				return token;
-			}
-			if (c == '\n')
-			{
-				foundLineBreak = true;
-			}
-			pointer++;
+			text = { text.end(), text.end() };
+			return;
 		}
-		if (foundLineBreak && !allowLineBreaks)
+		else
 		{
-			*text = pointer;
+			text = { commentEnd + endStr.size(), text.end() };
+			skipWhitespace( text, allowLineBreaks );
+			return;
+		}
+	}
+
+	// found start of token
+	return;
+}
+
+static gsl::cstring_view removeTrailingWhitespace( const gsl::cstring_view& text )
+{
+	return{
+		text.begin(),
+		std::find_if_not(
+			std::reverse_iterator< const char *>( text.end() ), std::reverse_iterator< const char* >( text.begin() ),
+			std::isspace
+			).base()
+	};
+}
+
+/**
+Skips whitespace (including lineBreaks, if desired) & comments, then reads one token.
+A token can be:
+- a string ("" delimited; ignores readToEOL)
+- whitespace-delimited (if readToEOL == false)
+- EOL- or comment-delimited (if readToEOL == true); i.e. reads to end of line or the first // or /*
+@param text adjusted to start beyond the read token
+*/
+static gsl::cstring_view GetToken( gsl::cstring_view& text, bool allowLineBreaks, bool readToEOL = false )
+{
+	skipWhitespaceAndComments( text, allowLineBreaks );
+	// EOF
+	if( text.empty() )
+	{
+		return{};
+	}
+	// string. ignores readToEOL.
+	if( text[ 0 ] == '"' )
+	{
+		// there are no escapes, string just ends at the next "
+		auto tokenEnd = std::find( text.begin() + 1, text.end(), '"' );
+		if( tokenEnd == text.end() )
+		{
+			gsl::cstring_view token = { text.begin() + 1, text.end() };
+			text = { text.end(), text.end() };
 			return token;
 		}
-
-		c = *pointer;
-
-		// skip single line comment
-		if (c == '/' && pointer[1] == '/')
-		{
-			pointer += 2;
-			while (*pointer && *pointer != '\n')
-			{
-				pointer++;
-			}
-		}
-		// skip multi line comments
-		else if (c == '/' && pointer[1] == '*')
-		{
-			pointer += 2;
-			while (*pointer && (*pointer != '*' || pointer[1] != '/'))
-			{
-				pointer++;
-			}
-			if (*pointer)
-			{
-				pointer += 2;
-			}
-		}
-		else
-		{	// found the start of a token
-			break;
-		}
-	}
-
-	if (c == '\"')
-	{	// handle a string
-		pointer++;
-		while (1)
-		{
-			c = *pointer++;
-			if (c == '\"')
-			{
-//				token[length++] = c;
-				break;
-			}
-			else if (!c)
-			{
-				break;
-			}
-			else if (length < MAX_TOKEN_SIZE)
-			{
-				token[length++] = c;
-			}
-		}
-	}
-	else if (readUntilEOL)
-	{
-		// absorb all characters until EOL
-		while(c != '\n' && c != '\r')
-		{
-			if (c == '/' && ((*(pointer+1)) == '/' || (*(pointer+1)) == '*'))
-			{
-				break;
-			}
-
-			if (length < MAX_TOKEN_SIZE)
-			{
-				token[length++] = c;
-			}
-			pointer++;
-			c = *pointer;
-		}
-		// remove trailing white space
-		while(length && token[length-1] < ' ')
-		{
-			length--;
-		}
-	}
-	else
-	{
-		while(c > ' ')
-		{
-			if (length < MAX_TOKEN_SIZE)
-			{
-				token[length++] = c;
-			}
-			pointer++;
-			c = *pointer;
-		}
-	}
-
-	if (token[0] == '\"')
-	{	// remove start quote
-		length--;
-		memmove(token, token+1, length);
-
-		if (length && token[length-1] == '\"')
-		{	// remove end quote
-			length--;
-		}
-	}
-
-	if (length >= MAX_TOKEN_SIZE)
-	{
-		length = 0;
-	}
-	token[length] = 0;
-	*text = (char *)pointer;
-
-	return token;
-}
-
-
-
-
-CTextPool::CTextPool(int initSize) :
-	mNext(0),
-	mSize(initSize),
-	mUsed(0)
-{
-#ifdef _EXE
-//	mPool = (char *)Z_Malloc(mSize, TAG_GP2);
-	mPool = (char *)Z_Malloc(mSize, TAG_TEXTPOOL, qtrue);
-#else
-	mPool = (char *)trap_Z_Malloc(mSize, TAG_GP2);
-#endif
-}
-
-CTextPool::~CTextPool(void)
-{
-#ifdef _EXE
-	Z_Free(mPool);
-#else
-	trap_Z_Free(mPool);
-#endif
-}
-
-char *CTextPool::AllocText(const char *text, bool addNULL, CTextPool **poolPtr)
-{
-	int	length = strlen(text) + (addNULL ? 1 : 0);
-
-	if (mUsed + length + 1> mSize)
-	{	// extra 1 to put a null on the end
-		if (poolPtr)
-		{
-			(*poolPtr)->SetNext(new CTextPool(mSize));
-			*poolPtr = (*poolPtr)->GetNext();
-
-			return (*poolPtr)->AllocText(text, addNULL);
-		}
-
-		return 0;
-	}
-
-	strcpy(mPool + mUsed, text);
-	mUsed += length;
-	mPool[mUsed] = 0;
-
-	return mPool + mUsed - length;
-}
-
-void CleanTextPool(CTextPool *pool)
-{
-	CTextPool *next;
-
-	while(pool)
-	{
-		next = pool->GetNext();
-		delete pool;
-		pool = next;
-	}
-}
-
-
-
-
-
-
-
-CGPObject::CGPObject(const char *initName) :
-	mName(initName),
-	mNext(0),
-	mInOrderNext(0),
-	mInOrderPrevious(0)
-{
-}
-
-bool CGPObject::WriteText(CTextPool **textPool, const char *text)
-{
-   if (strchr(text, ' ') || !text[0])
-   {
-	   (*textPool)->AllocText("\"", false, textPool);
-	   (*textPool)->AllocText((char *)text, false, textPool);
-	   (*textPool)->AllocText("\"", false, textPool);
-   }
-   else
-   {
-	   (*textPool)->AllocText((char *)text, false, textPool);
-   }
-
-   return true;
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-CGPValue::CGPValue(const char *initName, const char *initValue) :
-	CGPObject(initName),
-	mList(0)
-{
-	if (initValue)
-	{
-		AddValue(initValue);
-	}
-}
-
-CGPValue::~CGPValue(void)
-{
-	CGPObject	*next;
-
-	while(mList)
-	{
-		next = mList->GetNext();
-		delete mList;
-		mList = next;
-	}
-}
-
-CGPValue *CGPValue::Duplicate(CTextPool **textPool)
-{
-	CGPValue	*newValue;
-	CGPObject	*iterator;
-	char		*name;
-
-	if (textPool)
-	{
-		name = (*textPool)->AllocText((char *)mName, true, textPool);
-	}
-	else
-	{
-		name = (char *)mName;
-	}
-
-	newValue = new CGPValue(name);
-	iterator = mList;
-	while(iterator)
-	{
-		if (textPool)
-		{
-			name = (*textPool)->AllocText((char *)iterator->GetName(), true, textPool);
-		}
 		else
 		{
-			name = (char *)iterator->GetName();
+			gsl::cstring_view token = { text.begin() + 1, tokenEnd };
+			text = { tokenEnd + 1, text.end() };
+			return token;
 		}
-		newValue->AddValue(name);
-		iterator = iterator->GetNext();
 	}
-
-	return newValue;
-}
-
-bool CGPValue::IsList(void)
-{
-	if (!mList || !mList->GetNext())
+	else if( readToEOL )
 	{
-		return false;
-	}
-
-	return true;
-}
-
-const char *CGPValue::GetTopValue(void)
-{
-	if (mList)
-	{
-		return mList->GetName();
-	}
-
-	return 0;
-}
-
-void CGPValue::AddValue(const char *newValue, CTextPool **textPool)
-{
-	if (textPool)
-	{
-		newValue = (*textPool)->AllocText((char *)newValue, true, textPool);
-	}
-
-	if (mList == 0)
-	{
-		mList = new CGPObject(newValue);
-		mList->SetInOrderNext(mList);
+		// find the first of '\n', "//" or "/*"; that's end of token
+		auto tokenEnd = std::find( text.begin(), text.end(), '\n' );
+		static const std::array< char, 2 > commentPatterns[]{
+			{ '/', '*' },
+			{ '/', '/' }
+		};
+		for( auto& pattern : commentPatterns )
+		{
+			tokenEnd = std::min(
+				tokenEnd,
+				std::search(
+					text.begin(), tokenEnd,
+					pattern.begin(), pattern.end()
+					)
+				);
+		}
+		gsl::cstring_view token{ text.begin(), tokenEnd };
+		text = { tokenEnd, text.end() };
+		return removeTrailingWhitespace( token );
 	}
 	else
 	{
-		mList->GetInOrderNext()->SetNext(new CGPObject(newValue));
-		mList->SetInOrderNext(mList->GetInOrderNext()->GetNext());
+		// consume until first whitespace (if allowLineBreaks == false, that may be text.begin(); in that case token is empty.)
+		auto tokenEnd = std::find_if( text.begin(), text.end(), std::isspace );
+		gsl::cstring_view token{ text.begin(), tokenEnd };
+		text = { tokenEnd, text.end() };
+		return token;
 	}
 }
 
-bool CGPValue::Parse(const char **dataPtr, CTextPool **textPool)
+
+
+
+
+CGPProperty::CGPProperty( gsl::cstring_view initKey, gsl::cstring_view initValue )
+	: mKey( initKey )
 {
-	char		*token;
-	char		*value;
-
-	while(1)
+	if( !initValue.empty() )
 	{
-		token = GetToken(dataPtr, true, true);
-
-		if (!token[0])
-		{	// end of data - error!
-			return false;
-		}
-		else if (Q_stricmp(token, "]") == 0)
-		{	// ending brace for this list
-			break;
-		}
-
-		value = (*textPool)->AllocText(token, true, textPool);
-		AddValue(value);
+		mValues.push_back( initValue );
 	}
-
-	return true;
 }
 
-bool CGPValue::Write(CTextPool **textPool, int depth)
+void CGPProperty::AddValue( gsl::cstring_view newValue )
 {
-	int				i;
-	CGPObject	*next;
+	mValues.push_back( newValue );
+}
 
-	if (!mList)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+CGPGroup::CGPGroup( const gsl::cstring_view& initName )
+	: mName( initName )
+{
+}
+
+bool CGPGroup::Parse( gsl::cstring_view& data, const bool topLevel )
+{
+	while( true )
 	{
-		return true;
-	}
+		gsl::cstring_view token = GetToken( data, true );
 
-	for(i=0;i<depth;i++)
-	{
-		(*textPool)->AllocText("\t", false, textPool);
-	}
-
-	WriteText(textPool, mName);
-
-	if (!mList->GetNext())
-	{
-		(*textPool)->AllocText("\t\t", false, textPool);
-		mList->WriteText(textPool, mList->GetName());
-		(*textPool)->AllocText("\r\n", false, textPool);
-	}
-	else
-	{
-		(*textPool)->AllocText("\r\n", false, textPool);
-
-		for(i=0;i<depth;i++)
+		if( token.empty() )
 		{
-			(*textPool)->AllocText("\t", false, textPool);
-		}
-		(*textPool)->AllocText("[\r\n", false, textPool);
-
-		next = mList;
-		while(next)
-		{
-			for(i=0;i<depth+1;i++)
-			{
-				(*textPool)->AllocText("\t", false, textPool);
-			}
-			mList->WriteText(textPool, next->GetName());
-			(*textPool)->AllocText("\r\n", false, textPool);
-
-			next = next->GetNext();
-		}
-
-		for(i=0;i<depth;i++)
-		{
-			(*textPool)->AllocText("\t", false, textPool);
-		}
-		(*textPool)->AllocText("]\r\n", false, textPool);
-	}
-
-	return true;
-}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-CGPGroup::CGPGroup(const char *initName, CGPGroup *initParent) :
-	CGPObject(initName),
-	mPairs(0),
-	mInOrderPairs(0),
-	mCurrentPair(0),
-	mSubGroups(0),
-	mInOrderSubGroups(0),
-	mCurrentSubGroup(0),
-	mParent(initParent)
-{
-}
-
-CGPGroup::~CGPGroup(void)
-{
-	Clean();
-}
-
-int CGPGroup::GetNumSubGroups(void)
-{
-	int			count;
-	CGPGroup	*group;
-
-	count = 0;
-	group = mSubGroups;
-	while(group)
-	{
-		count++;
-		group = (CGPGroup *)group->GetNext();
-	}
-
-	return(count);
-}
-
-int CGPGroup::GetNumPairs(void)
-{
-	int			count;
-	CGPValue	*pair;
-
-	count = 0;
-	pair = mPairs;
-	while(pair)
-	{
-		count++;
-		pair = (CGPValue *)pair->GetNext();
-	}
-
-	return(count);
-}
-
-void CGPGroup::Clean(void)
-{
-	while(mPairs)
-	{
-		mCurrentPair = (CGPValue *)mPairs->GetNext();
-		delete mPairs;
-		mPairs = mCurrentPair;
-	}
-
-	while(mSubGroups)
-	{
-		mCurrentSubGroup = (CGPGroup *)mSubGroups->GetNext();
-		delete mSubGroups;
-		mSubGroups = mCurrentSubGroup;
-	}
-
-	mPairs = mInOrderPairs = mCurrentPair = 0;
-	mSubGroups = mInOrderSubGroups = mCurrentSubGroup = 0;
-	mParent = 0;
-}
-
-CGPGroup *CGPGroup::Duplicate(CTextPool **textPool, CGPGroup *initParent)
-{
-	CGPGroup	*newGroup, *subSub, *newSub;
-	CGPValue	*newPair, *subPair;
-	char		*name;
-
-	if (textPool)
-	{
-		name = (*textPool)->AllocText((char *)mName, true, textPool);
-	}
-	else
-	{
-		name = (char *)mName;
-	}
-
-	newGroup = new CGPGroup(name);
-
-	subSub = mSubGroups;
-	while(subSub)
-	{
-		newSub = subSub->Duplicate(textPool, newGroup);
-		newGroup->AddGroup(newSub);
-
-		subSub = (CGPGroup *)subSub->GetNext();
-	}
-
-	subPair = mPairs;
-	while(subPair)
-	{
-		newPair = subPair->Duplicate(textPool);
-		newGroup->AddPair(newPair);
-
-		subPair = (CGPValue *)subPair->GetNext();
-	}
-
-	return newGroup;
-}
-
-void CGPGroup::SortObject(CGPObject *object, CGPObject **unsortedList, CGPObject **sortedList,
-							 CGPObject **lastObject)
-{
-	CGPObject	*test, *last;
-
-	if (!*unsortedList)
-	{
-		*unsortedList = *sortedList = object;
-	}
-	else
-	{
-		(*lastObject)->SetNext(object);
-
-		test = *sortedList;
-		last = 0;
-		while(test)
-		{
-			if (Q_stricmp(object->GetName(), test->GetName()) < 0)
-			{
-				break;
-			}
-
-			last = test;
-			test = test->GetInOrderNext();
-		}
-
-		if (test)
-		{
-			test->SetInOrderPrevious(object);
-			object->SetInOrderNext(test);
-		}
-		if (last)
-		{
-			last->SetInOrderNext(object);
-			object->SetInOrderPrevious(last);
-		}
-		else
-		{
-			*sortedList = object;
-		}
-	}
-
-	*lastObject = object;
-}
-
-CGPValue *CGPGroup::AddPair(const char *name, const char *value, CTextPool **textPool)
-{
-	CGPValue	*newPair;
-
-	if (textPool)
-	{
-		name = (*textPool)->AllocText((char *)name, true, textPool);
-		if (value)
-		{
-			value = (*textPool)->AllocText((char *)value, true, textPool);
-		}
-	}
-
-	newPair = new CGPValue(name, value);
-
-	AddPair(newPair);
-
-	return newPair;
-}
-
-void CGPGroup::AddPair(CGPValue *NewPair)
-{
-	SortObject(NewPair, (CGPObject **)&mPairs, (CGPObject **)&mInOrderPairs,
-		(CGPObject **)&mCurrentPair);
-}
-
-CGPGroup *CGPGroup::AddGroup(const char *name, CTextPool **textPool)
-{
-	CGPGroup	*newGroup;
-
-	if (textPool)
-	{
-		name = (*textPool)->AllocText((char *)name, true, textPool);
-	}
-
-	newGroup = new CGPGroup(name);
-
-	AddGroup(newGroup);
-
-	return newGroup;
-}
-
-void CGPGroup::AddGroup(CGPGroup *NewGroup)
-{
-	SortObject(NewGroup, (CGPObject **)&mSubGroups, (CGPObject **)&mInOrderSubGroups,
-		(CGPObject **)&mCurrentSubGroup);
-}
-
-CGPGroup *CGPGroup::FindSubGroup(const char *name)
-{
-	CGPGroup	*group;
-
-	group = mSubGroups;
-	while(group)
-	{
-		if(!Q_stricmp(name, group->GetName()))
-		{
-			return(group);
-		}
-		group = (CGPGroup *)group->GetNext();
-	}
-	return(NULL);
-}
-
-bool CGPGroup::Parse(const char **dataPtr, CTextPool **textPool)
-{
-	char		*token;
-	char		lastToken[MAX_TOKEN_SIZE];
-	CGPGroup	*newSubGroup;
-	CGPValue	*newPair;
-
-	while(1)
-	{
-		token = GetToken(dataPtr, true);
-
-		if (!token[0])
-		{
-			if (mParent)
-			{
-				// end of data - error!
-				return false;
-			}
-			else
+			if ( topLevel )
 			{
 				// top level parse; there was no opening "{", so there should be no closing one either.
 				return true;
 			}
-		}
-		else if (Q_stricmp(token, "}") == 0)
-		{
-			if( mParent )
-			{
-				// ending brace for this group
-				return true;
-			}
 			else
+			{
+				// end of data - error!
+				return false;
+			}
+		}
+		else if( token == CSTRING_VIEW( "}" ) )
+		{
+			if( topLevel )
 			{
 				// top-level group; there was no opening "{" so there should be no closing one, either.
 				return false;
 			}
+			else
+			{
+				// ending brace for this group
+				return true;
+			}
 		}
-
-		strcpy(lastToken, token);
+		gsl::cstring_view lastToken = token;
 
 		// read ahead to see what we are doing
-		token = GetToken(dataPtr, true, true);
-		if (Q_stricmp(token, "{") == 0)
-		{	// new sub group
-			newSubGroup = AddGroup(lastToken, textPool);
-			if (!newSubGroup->Parse(dataPtr, textPool))
+		token = GetToken( data, true, true );
+		if( token == CSTRING_VIEW( "{" ) )
+		{
+			// new sub group
+			mSubGroups.emplace_back( lastToken );
+			if( !mSubGroups.back().Parse( data, false ) )
 			{
 				return false;
 			}
 		}
-		else if (Q_stricmp(token, "[") == 0)
-		{	// new pair list
-			newPair = AddPair(lastToken, 0, textPool);
-			if (!newPair->Parse(dataPtr, textPool))
+		else if( token == CSTRING_VIEW( "[" ) )
+		{
+			// new list
+			mProperties.emplace_back( lastToken );
+			CGPProperty& list = mProperties.back();
+			while( true )
 			{
-				return false;
+				token = GetToken( data, true, true );
+				if( token.empty() )
+				{
+					return false;
+				}
+				if( token == CSTRING_VIEW( "]" ) )
+				{
+					break;
+				}
+				list.AddValue( token );
 			}
 		}
 		else
-		{	// new pair
-			AddPair(lastToken, token, textPool);
-		}
-	}
-}
-
-bool CGPGroup::Write(CTextPool **textPool, int depth)
-{
-	int				i;
-	CGPValue		*mPair = mPairs;
-	CGPGroup		*mSubGroup = mSubGroups;
-
-	if (depth >= 0)
-	{
-		for(i=0;i<depth;i++)
 		{
-			(*textPool)->AllocText("\t", false, textPool);
+			// new value
+			mProperties.emplace_back( lastToken, token );
 		}
-		WriteText(textPool, mName);
-		(*textPool)->AllocText("\r\n", false, textPool);
-
-		for(i=0;i<depth;i++)
-		{
-			(*textPool)->AllocText("\t", false, textPool);
-		}
-		(*textPool)->AllocText("{\r\n", false, textPool);
 	}
-
-	while(mPair)
-	{
-		mPair->Write(textPool, depth+1);
-		mPair = (CGPValue *)mPair->GetNext();
-	}
-
-	while(mSubGroup)
-	{
-		mSubGroup->Write(textPool, depth+1);
-		mSubGroup = (CGPGroup *)mSubGroup->GetNext();
-	}
-
-	if (depth >= 0)
-	{
-		for(i=0;i<depth;i++)
-		{
-			(*textPool)->AllocText("\t", false, textPool);
-		}
-		(*textPool)->AllocText("}\r\n", false, textPool);
-	}
-
-	return true;
-}
-
-CGPValue *CGPGroup::FindPair(const char *key)
-{
-	CGPValue		*pair = mPairs;
-
-	while(pair)
-	{
-		if (Q_stricmp(pair->GetName(), key) == 0)
-		{
-			return pair;
-		}
-
-		pair = pair->GetNext();
-	}
-
-	return 0;
-}
-
-const char *CGPGroup::FindPairValue(const char *key, const char *defaultVal)
-{
-	CGPValue		*pair = FindPair(key);
-
-	if (pair)
-	{
-		return pair->GetTopValue();
-	}
-
-	return defaultVal;
 }
 
 
@@ -844,292 +287,20 @@ const char *CGPGroup::FindPairValue(const char *key, const char *defaultVal)
 
 
 
-
-CGenericParser2::CGenericParser2(void) :
-	mTextPool(0)
+bool CGenericParser2::Parse( gsl::czstring filename )
 {
-}
-
-CGenericParser2::~CGenericParser2(void)
-{
-	Clean();
-}
-
-bool CGenericParser2::Parse(const char **dataPtr, bool cleanFirst)
-{
-	CTextPool	*topPool;
-
-	if (cleanFirst)
+	Clear();
+	mFileContent = FS::ReadFile( filename );
+	if( !mFileContent.valid() )
 	{
-		Clean();
+		return false;
 	}
-
-	if (!mTextPool)
-	{
-		mTextPool = new CTextPool;
-	}
-
-	topPool = mTextPool;
-	bool ret = mTopLevel.Parse(dataPtr, &topPool);
-	return ret;
+	return mTopLevel.Parse( mFileContent.view() );
 }
 
-void CGenericParser2::Clean(void)
+void CGenericParser2::Clear() NOEXCEPT
 {
-	mTopLevel.Clean();
-
-	CleanTextPool(mTextPool);
-	mTextPool = 0;
-}
-
-bool CGenericParser2::Write(CTextPool *textPool)
-{
-	return mTopLevel.Write(&textPool, -1);
-}
-
-
-
-
-
-
-
-
-
-// The following groups of routines are used for a C interface into GP2.
-// C++ users should just use the objects as normally and not call these routines below
-//
-// CGenericParser2 (void *) routines
-TGenericParser2 GP_Parse(const char **dataPtr, bool cleanFirst)
-{
-	CGenericParser2		*parse;
-
-	parse = new CGenericParser2;
-	if (parse->Parse(dataPtr, cleanFirst))
-	{
-		return parse;
-	}
-
-	delete parse;
-	return 0;
-}
-
-void GP_Clean(TGenericParser2 GP2)
-{
-	if (!GP2)
-	{
-		return;
-	}
-
-	((CGenericParser2 *)GP2)->Clean();
-}
-
-void GP_Delete(TGenericParser2 *GP2)
-{
-	if (!GP2 || !(*GP2))
-	{
-		return;
-	}
-
-	delete ((CGenericParser2 *)(*GP2));
-	(*GP2) = 0;
-}
-
-TGPGroup GP_GetBaseParseGroup(TGenericParser2 GP2)
-{
-	if (!GP2)
-	{
-		return 0;
-	}
-
-	return ((CGenericParser2 *)GP2)->GetBaseParseGroup();
-}
-
-
-
-
-// CGPGroup (void *) routines
-const char	*GPG_GetName(TGPGroup GPG)
-{
-	if (!GPG)
-	{
-		return "";
-	}
-
-	return ((CGPGroup *)GPG)->GetName();
-}
-
-TGPGroup GPG_GetNext(TGPGroup GPG)
-{
-	if (!GPG)
-	{
-		return 0;
-	}
-
-	return ((CGPGroup *)GPG)->GetNext();
-}
-
-TGPGroup GPG_GetInOrderNext(TGPGroup GPG)
-{
-	if (!GPG)
-	{
-		return 0;
-	}
-
-	return ((CGPGroup *)GPG)->GetInOrderNext();
-}
-
-TGPGroup GPG_GetInOrderPrevious(TGPGroup GPG)
-{
-	if (!GPG)
-	{
-		return 0;
-	}
-
-	return ((CGPGroup *)GPG)->GetInOrderPrevious();
-}
-
-TGPGroup GPG_GetPairs(TGPGroup GPG)
-{
-	if (!GPG)
-	{
-		return 0;
-	}
-
-	return ((CGPGroup *)GPG)->GetPairs();
-}
-
-TGPGroup GPG_GetInOrderPairs(TGPGroup GPG)
-{
-	if (!GPG)
-	{
-		return 0;
-	}
-
-	return ((CGPGroup *)GPG)->GetInOrderPairs();
-}
-
-TGPGroup GPG_GetSubGroups(TGPGroup GPG)
-{
-	if (!GPG)
-	{
-		return 0;
-	}
-
-	return ((CGPGroup *)GPG)->GetSubGroups();
-}
-
-TGPGroup GPG_GetInOrderSubGroups(TGPGroup GPG)
-{
-	if (!GPG)
-	{
-		return 0;
-	}
-
-	return ((CGPGroup *)GPG)->GetInOrderSubGroups();
-}
-
-TGPGroup GPG_FindSubGroup(TGPGroup GPG, const char *name)
-{
-	if (!GPG)
-	{
-		return 0;
-	}
-
-	return ((CGPGroup *)GPG)->FindSubGroup(name);
-}
-
-TGPValue GPG_FindPair(TGPGroup GPG, const char *key)
-{
-	if (!GPG)
-	{
-		return 0;
-	}
-
-	return ((CGPGroup *)GPG)->FindPair(key);
-}
-
-const char *GPG_FindPairValue(TGPGroup GPG, const char *key, const char *defaultVal)
-{
-	if (!GPG)
-	{
-		return defaultVal;
-	}
-
-	return ((CGPGroup *)GPG)->FindPairValue(key, defaultVal);
-}
-
-
-
-
-// CGPValue (void *) routines
-const char	*GPV_GetName(TGPValue GPV)
-{
-	if (!GPV)
-	{
-		return "";
-	}
-
-	return ((CGPValue *)GPV)->GetName();
-}
-
-TGPValue GPV_GetNext(TGPValue GPV)
-{
-	if (!GPV)
-	{
-		return 0;
-	}
-
-	return ((CGPValue *)GPV)->GetNext();
-}
-
-TGPValue GPV_GetInOrderNext(TGPValue GPV)
-{
-	if (!GPV)
-	{
-		return 0;
-	}
-
-	return ((CGPValue *)GPV)->GetInOrderNext();
-}
-
-TGPValue GPV_GetInOrderPrevious(TGPValue GPV)
-{
-	if (!GPV)
-	{
-		return 0;
-	}
-
-	return ((CGPValue *)GPV)->GetInOrderPrevious();
-}
-
-bool GPV_IsList(TGPValue GPV)
-{
-	if (!GPV)
-	{
-		return 0;
-	}
-
-	return ((CGPValue *)GPV)->IsList();
-}
-
-const char *GPV_GetTopValue(TGPValue GPV)
-{
-	if (!GPV)
-	{
-		return "";
-	}
-
-	return ((CGPValue *)GPV)->GetTopValue();
-}
-
-TGPValue GPV_GetList(TGPValue GPV)
-{
-	if (!GPV)
-	{
-		return 0;
-	}
-
-	return ((CGPValue *)GPV)->GetList();
+	mTopLevel.Clear();
 }
 
 

--- a/code/game/genericparser2.h
+++ b/code/game/genericparser2.h
@@ -150,7 +150,7 @@ public:
 	CGPGroup	*AddGroup(const char *name, CTextPool **textPool = 0);
 	void		AddGroup(CGPGroup *NewGroup);
 	CGPGroup	*FindSubGroup(const char *name);
-	bool		Parse(char **dataPtr, CTextPool **textPool);
+	bool		Parse(const char **dataPtr, CTextPool **textPool);
 	bool		Write(CTextPool **textPool, int depth);
 
 	CGPValue	*FindPair(const char *key);
@@ -169,8 +169,8 @@ public:
 
 	CGPGroup	*GetBaseParseGroup(void) { return &mTopLevel; }
 
-	bool	Parse(char **dataPtr, bool cleanFirst = true);
-	bool	Parse(char *dataPtr, bool cleanFirst = true)
+	bool	Parse(const char **dataPtr, bool cleanFirst = true);
+	bool	Parse(const char *dataPtr, bool cleanFirst = true)
 	{
 		return Parse(&dataPtr, cleanFirst);
 	}
@@ -190,7 +190,7 @@ typedef		void	*TGPGroup;
 typedef		void	*TGPValue;
 
 // CGenericParser2 (void *) routines
-TGenericParser2		GP_Parse(char **dataPtr, bool cleanFirst);
+TGenericParser2		GP_Parse(const char **dataPtr, bool cleanFirst);
 void				GP_Clean(TGenericParser2 GP2);
 void				GP_Delete(TGenericParser2 *GP2);
 TGPGroup			GP_GetBaseParseGroup(TGenericParser2 GP2);

--- a/code/game/genericparser2.h
+++ b/code/game/genericparser2.h
@@ -124,7 +124,6 @@ private:
 	CGPGroup			*mSubGroups, *mInOrderSubGroups;
 	CGPGroup			*mCurrentSubGroup;
 	CGPGroup			*mParent;
-	bool				mWriteable;
 
 	void	SortObject(CGPObject *object, CGPObject **unsortedList, CGPObject **sortedList,
 					   CGPObject **lastObject);
@@ -141,7 +140,6 @@ public:
 	void		Clean(void);
 	CGPGroup	*Duplicate(CTextPool **textPool = 0, CGPGroup *initParent = 0);
 
-	void		SetWriteable(const bool writeable) { mWriteable = writeable; }
 	CGPValue	*GetPairs(void) { return mPairs; }
 	CGPValue	*GetInOrderPairs(void) { return mInOrderPairs; }
 	CGPGroup	*GetSubGroups(void) { return mSubGroups; }
@@ -164,19 +162,17 @@ class CGenericParser2
 private:
 	CGPGroup		mTopLevel;
 	CTextPool		*mTextPool;
-	bool			mWriteable;
 
 public:
 	CGenericParser2(void);
 	~CGenericParser2(void);
 
-	void		SetWriteable(const bool writeable) { mWriteable = writeable; }
 	CGPGroup	*GetBaseParseGroup(void) { return &mTopLevel; }
 
-	bool	Parse(char **dataPtr, bool cleanFirst = true, bool writeable = false);
-	bool	Parse(char *dataPtr, bool cleanFirst = true, bool writeable = false)
+	bool	Parse(char **dataPtr, bool cleanFirst = true);
+	bool	Parse(char *dataPtr, bool cleanFirst = true)
 	{
-		return Parse(&dataPtr, cleanFirst, writeable);
+		return Parse(&dataPtr, cleanFirst);
 	}
 	void	Clean(void);
 
@@ -194,7 +190,7 @@ typedef		void	*TGPGroup;
 typedef		void	*TGPValue;
 
 // CGenericParser2 (void *) routines
-TGenericParser2		GP_Parse(char **dataPtr, bool cleanFirst, bool writeable);
+TGenericParser2		GP_Parse(char **dataPtr, bool cleanFirst);
 void				GP_Clean(TGenericParser2 GP2);
 void				GP_Delete(TGenericParser2 *GP2);
 TGPGroup			GP_GetBaseParseGroup(TGenericParser2 GP2);

--- a/code/game/genericparser2.h
+++ b/code/game/genericparser2.h
@@ -22,201 +22,145 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 // Filename:-	genericparser2.h
 
+#include <vector>
+#include <forward_list>
+#include <array>
+#include <cassert>
+
+#include "qcommon/safe/gsl.h"
+#include "qcommon/safe/memory.h"
+#include "qcommon/safe/files.h"
+#include "qcommon/safe/string.h"
+
 #ifndef GENERICPARSER2_H
 #define GENERICPARSER2_H
 
-// conditional expression is constant
-// conversion from int to char, possible loss of data
-// unreferenced inline funciton has been removed
-#ifdef _MSC_VER
-#ifdef DEBUG_LINKING
-	#pragma message("...including GenericParser2.h")
-#endif
-#endif
-
-#ifdef _JK2EXE
-#define trap_Z_Malloc(x, y)		Z_Malloc(x,y,qtrue)
-#define trap_Z_Free(x)			Z_Free(x)
-#else
-#define trap_Z_Malloc(x, y)		gi.Malloc(x,y,qtrue)
-#define trap_Z_Free(x)			gi.Free(x)
-#endif
-
-
-class CTextPool;
-class CGPObject;
-
-class CTextPool
+namespace GP2
 {
+	template< typename T >
+	using Vector = std::vector< T, Zone::Allocator< T, TAG_GP2 > >;
+}
+
+class CGPProperty
+{
+public:
+	using Values = GP2::Vector< gsl::cstring_view >;
 private:
-	char		*mPool;
-	CTextPool	*mNext;
-	int			mSize, mUsed;
+	gsl::cstring_view mKey;
+	Values mValues;
+
 
 public:
-	CTextPool(int initSize = 10240);
-	~CTextPool(void);
 
-	CTextPool	*GetNext(void) { return mNext; }
-	void		SetNext(CTextPool *which) { mNext = which; }
-	char		*GetPool(void) { return mPool; }
-	int			GetUsed(void) { return mUsed; }
+	CGPProperty( gsl::cstring_view initKey, gsl::cstring_view initValue = {} );
 
-	char		*AllocText(const char *text, bool addNULL = true, CTextPool **poolPtr = 0);
-};
-
-void CleanTextPool(CTextPool *pool);
-
-class CGPObject
-{
-protected:
-	const char	*mName;
-	CGPObject	*mNext, *mInOrderNext, *mInOrderPrevious;
-
-public:
-				CGPObject(const char *initName);
-		virtual	~CGPObject() {}
-
-	const char	*GetName(void) { return mName; }
-
-	CGPObject	*GetNext(void) { return mNext; }
-	void		SetNext(CGPObject *which) { mNext = which; }
-	CGPObject	*GetInOrderNext(void) { return mInOrderNext; }
-	void		SetInOrderNext(CGPObject *which) { mInOrderNext = which; }
-	CGPObject	*GetInOrderPrevious(void) { return mInOrderPrevious; }
-	void		SetInOrderPrevious(CGPObject *which) { mInOrderPrevious = which; }
-
-	bool		WriteText(CTextPool **textPool, const char *text);
+	gsl::cstring_view GetName() const { return mKey; }
+	bool IsList() const NOEXCEPT
+	{
+		return mValues.size() > 1;
+	}
+	gsl::cstring_view GetTopValue() const NOEXCEPT
+	{
+		return mValues.empty() ? gsl::cstring_view{} : mValues.front();
+	}
+	const Values& GetValues() const NOEXCEPT
+	{
+		return mValues;
+	}
+	// Copies the value into the textPool and adds a pointer to that copy to the end of the list.
+	void AddValue( gsl::cstring_view newValue );
 };
 
 
 
-class CGPValue : public CGPObject
+class CGPGroup
 {
+public:
+	/// Key-Value-Pairs
+	using Properties = GP2::Vector< CGPProperty >;
+	using SubGroups = GP2::Vector< CGPGroup >;
 private:
-	CGPObject	*mList;
-
+	Properties mProperties;
+	gsl::cstring_view mName = CSTRING_VIEW( "Top Level" );
+	SubGroups mSubGroups;
 public:
-					CGPValue(const char *initName, const char *initValue = 0);
-					~CGPValue(void);
+	CGPGroup() = default;
+	CGPGroup( const gsl::cstring_view& initName );
+	// non-copyable; but just for performance reasons, since it would incur a deep copy.
+	CGPGroup( const CGPGroup& ) = delete;
+	CGPGroup& operator=( const CGPGroup& ) = delete;
+	// movable
+	CGPGroup( CGPGroup&& ) = default;
+	CGPGroup& operator=( CGPGroup&& ) = default;
 
-	CGPValue		*GetNext(void) { return (CGPValue *)mNext; }
-
-	CGPValue		*Duplicate(CTextPool **textPool = 0);
-
-	bool			IsList(void);
-	const char		*GetTopValue(void);
-	CGPObject		*GetList(void) { return mList; }
-	void			AddValue(const char *newValue, CTextPool **textPool = 0);
-
-	bool			Parse(char **dataPtr, CTextPool **textPool);
-
-	bool			Write(CTextPool **textPool, int depth);
+	const Properties& GetProperties() const NOEXCEPT
+	{
+		return mProperties;
+	}
+	const SubGroups& GetSubGroups() const NOEXCEPT
+	{
+		return mSubGroups;
+	}
+	const CGPGroup* FindSubGroup( const gsl::cstring_view& name ) const NOEXCEPT
+	{
+		for( auto& sub : GetSubGroups() )
+		{
+			if( Q::stricmp( name, sub.GetName() ) == Q::Ordering::EQ )
+			{
+				return &sub;
+			}
+		}
+		return nullptr;
+	}
+	const CGPProperty* FindProperty( const gsl::cstring_view& name ) const NOEXCEPT
+	{
+		for( auto& prop : GetProperties() )
+		{
+			if( Q::stricmp( name, prop.GetName() ) == Q::Ordering::EQ )
+			{
+				return &prop;
+			}
+		}
+		return nullptr;
+	}
+	const gsl::cstring_view& GetName() const NOEXCEPT
+	{
+		return mName;
+	}
+	void Clear() NOEXCEPT
+	{
+		// name is retained
+		mProperties.clear();
+		mSubGroups.clear();
+	}
+	bool Parse( gsl::cstring_view& data, const bool topLevel = true );
 };
 
+/**
+Generic Text Parser.
 
-
-class CGPGroup : public CGPObject
-{
-private:
-	CGPValue			*mPairs, *mInOrderPairs;
-	CGPValue			*mCurrentPair;
-	CGPGroup			*mSubGroups, *mInOrderSubGroups;
-	CGPGroup			*mCurrentSubGroup;
-	CGPGroup			*mParent;
-
-	void	SortObject(CGPObject *object, CGPObject **unsortedList, CGPObject **sortedList,
-					   CGPObject **lastObject);
-
-public:
-				CGPGroup(const char *initName = "Top Level", CGPGroup *initParent = 0);
-				~CGPGroup(void);
-
-	CGPGroup	*GetParent(void) { return mParent; }
-	CGPGroup	*GetNext(void) { return (CGPGroup *)mNext; }
-	int			GetNumSubGroups(void);
-	int			GetNumPairs(void);
-
-	void		Clean(void);
-	CGPGroup	*Duplicate(CTextPool **textPool = 0, CGPGroup *initParent = 0);
-
-	CGPValue	*GetPairs(void) { return mPairs; }
-	CGPValue	*GetInOrderPairs(void) { return mInOrderPairs; }
-	CGPGroup	*GetSubGroups(void) { return mSubGroups; }
-	CGPGroup	*GetInOrderSubGroups(void) { return mInOrderSubGroups; }
-
-	CGPValue	*AddPair(const char *name, const char *value, CTextPool **textPool = 0);
-	void		AddPair(CGPValue *NewPair);
-	CGPGroup	*AddGroup(const char *name, CTextPool **textPool = 0);
-	void		AddGroup(CGPGroup *NewGroup);
-	CGPGroup	*FindSubGroup(const char *name);
-	bool		Parse(const char **dataPtr, CTextPool **textPool);
-	bool		Write(CTextPool **textPool, int depth);
-
-	CGPValue	*FindPair(const char *key);
-	const char	*FindPairValue(const char *key, const char *defaultVal = 0);
-};
-
+Used to parse effect files and the dynamic music system files. Parses blocks of the form `name { \n ... \n }`; blocks can contain other blocks or properties of the form `key value`. Value can also be a list; in that case the format is `key [\n value1 \n value2\n]`. Mind the separating newlines, values are actually newline-delimited.
+*/
 class CGenericParser2
 {
 private:
-	CGPGroup		mTopLevel;
-	CTextPool		*mTextPool;
+	CGPGroup mTopLevel;
+	FS::FileBuffer mFileContent;
 
 public:
-	CGenericParser2(void);
-	~CGenericParser2(void);
 
-	CGPGroup	*GetBaseParseGroup(void) { return &mTopLevel; }
-
-	bool	Parse(const char **dataPtr, bool cleanFirst = true);
-	bool	Parse(const char *dataPtr, bool cleanFirst = true)
+	const CGPGroup& GetBaseParseGroup()
 	{
-		return Parse(&dataPtr, cleanFirst);
+		return mTopLevel;
 	}
-	void	Clean(void);
 
-	bool	Write(CTextPool *textPool);
+	bool Parse( gsl::czstring filename );
+	void Clear() NOEXCEPT;
+	bool ValidFile() const NOEXCEPT
+	{
+		return mFileContent.valid();
+	}
 };
-
-
-
-// The following groups of routines are used for a C interface into GP2.
-// C++ users should just use the objects as normally and not call these routines below
-//
-
-typedef		void	*TGenericParser2;
-typedef		void	*TGPGroup;
-typedef		void	*TGPValue;
-
-// CGenericParser2 (void *) routines
-TGenericParser2		GP_Parse(const char **dataPtr, bool cleanFirst);
-void				GP_Clean(TGenericParser2 GP2);
-void				GP_Delete(TGenericParser2 *GP2);
-TGPGroup			GP_GetBaseParseGroup(TGenericParser2 GP2);
-
-// CGPGroup (void *) routines
-const char	*GPG_GetName(TGPGroup GPG);
-TGPGroup	GPG_GetNext(TGPGroup GPG);
-TGPGroup	GPG_GetInOrderNext(TGPGroup GPG);
-TGPGroup	GPG_GetInOrderPrevious(TGPGroup GPG);
-TGPGroup	GPG_GetPairs(TGPGroup GPG);
-TGPGroup	GPG_GetInOrderPairs(TGPGroup GPG);
-TGPGroup	GPG_GetSubGroups(TGPGroup GPG);
-TGPGroup	GPG_GetInOrderSubGroups(TGPGroup GPG);
-TGPGroup	GPG_FindSubGroup(TGPGroup GPG, const char *name);
-TGPValue	GPG_FindPair(TGPGroup GPG, const char *key);
-const char	*GPG_FindPairValue(TGPGroup GPG, const char *key, const char *defaultVal);
-
-// CGPValue (void *) routines
-const char	*GPV_GetName(TGPValue GPV);
-TGPValue	GPV_GetNext(TGPValue GPV);
-TGPValue	GPV_GetInOrderNext(TGPValue GPV);
-TGPValue	GPV_GetInOrderPrevious(TGPValue GPV);
-bool		GPV_IsList(TGPValue GPV);
-const char	*GPV_GetTopValue(TGPValue GPV);
-TGPValue	GPV_GetList(TGPValue GPV);
-
 
 #endif	// #ifndef GENERICPARSER2_H
 

--- a/code/qcommon/q_shared.h
+++ b/code/qcommon/q_shared.h
@@ -2576,7 +2576,4 @@ typedef enum
 
 } ForceReload_e;
 
-
-#include "../game/genericparser2.h"
-
 #endif	// __Q_SHARED_H

--- a/shared/openjk.natvis
+++ b/shared/openjk.natvis
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- This file tells the Visual Studio Debugger how to display types. -->
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  
   <Type Name="gsl::array_view&lt;*&gt;">
-    <DisplayString>{{ {begin_,[end_ - begin_]} }}</DisplayString>
+    <DisplayString>{begin_,[end_ - begin_]s}</DisplayString>
     <Expand>
       <ArrayItems>
         <Size>end_ - begin_</Size>
@@ -10,4 +11,32 @@
       </ArrayItems>
     </Expand>
   </Type>
+  
+  <Type Name="FS::FileBuffer">
+    <DisplayString Condition="_buffer == nullptr">{{ Empty File Buffer }}</DisplayString>
+    <DisplayString Condition="_buffer != nullptr">{{ {_size} Byte File Buffer }}</DisplayString>
+  </Type>
+  
+  <!-- Generic Parser 2 -->
+  
+  <Type Name="CGenericParser2">
+    <DisplayString>Generic Parser</DisplayString>
+    <Expand>
+      <Item Name="Content">mFileContent</Item>
+      <Item Name="Root Group">mTopLevel</Item>
+    </Expand>
+  </Type>
+  <Type Name="CGPGroup">
+    <DisplayString>{{ GP Group {mName}, {mProperties._Mypair._Myval2._Mylast - mProperties._Mypair._Myval2._Myfirst} Properties, {mSubGroups._Mypair._Myval2._Mylast - mSubGroups._Mypair._Myval2._Myfirst} Sub-Groups }}</DisplayString>
+    <Expand>
+      <Item Name="Properties">mProperties</Item>
+      <Item Name="Sub-Groups">mSubGroups</Item>
+    </Expand>
+  </Type>
+  <Type Name="CGPProperty">
+    <!-- this is for the VS2015 STL -->
+    <DisplayString Condition="mValues._Mypair._Myval2._Mylast - mValues._Mypair._Myval2._Myfirst == 1">{{ {mKey} = {mValues[0]} }}</DisplayString>
+    <DisplayString Condition="mValues._Mypair._Myval2._Mylast - mValues._Mypair._Myval2._Myfirst != 1">{{ {mKey} = {mValues} }}</DisplayString>
+  </Type>
+  
 </AutoVisualizer>

--- a/shared/qcommon/safe/sscanf.h
+++ b/shared/qcommon/safe/sscanf.h
@@ -178,6 +178,13 @@ namespace Q
 		{
 			return sscanf_impl_stream( input, accumulator, f, std::forward< Tail >( tail )... );
 		}
+
+		//    Int
+		template< typename... Tail >
+		std::size_t sscanf_impl( const gsl::cstring_view& input, const std::size_t accumulator, int& i, Tail&&... tail )
+		{
+			return sscanf_impl_stream( input, accumulator, i, std::forward< Tail >( tail )... );
+		}
 	}
 
 	/**

--- a/shared/qcommon/safe/string.cpp
+++ b/shared/qcommon/safe/string.cpp
@@ -1,4 +1,5 @@
 #include "string.h"
+#include "sscanf.h"
 
 #include <cctype>
 #include <algorithm>
@@ -40,43 +41,15 @@ namespace Q
 
 	int svtoi( const gsl::cstring_view& view )
 	{
-		gsl::cstring_view::iterator end = view.end();
-		// skip whitespace
-		gsl::cstring_view::iterator it = std::find_if_not<gsl::cstring_view::iterator, int( *)( int )>( view.begin(), end, std::isspace );
-		if( it == end )
-		{
-			return 0;
-		}
-		bool negate = false;
-		if( *it == '+' )
-		{
-			++it;
-		}
-		else if( *it == '-' )
-		{
-			negate = true;
-			++it;
-		}
 		int result = 0;
-		while( it != end )
-		{
-			if( *it < '0' || *it > '9' )
-			{
-				break;
-			}
-			const int digit = *it - '0';
-			result *= 10;
-			// not negating after the fact so we don't lose MIN_INT
-			if( negate )
-			{
-				result -= digit;
-			}
-			else
-			{
-				result += digit;
-			}
-			++it;
-		}
+		Q::sscanf( view, result );
+		return result;
+	}
+
+	float svtof( const gsl::cstring_view& view )
+	{
+		float result = 0.f;
+		Q::sscanf( view, result );
 		return result;
 	}
 }

--- a/shared/qcommon/safe/string.h
+++ b/shared/qcommon/safe/string.h
@@ -16,7 +16,7 @@ namespace Q
 		GT = 1
 	};
 	Ordering stricmp( const gsl::cstring_view& lhs, const gsl::cstring_view& rhs ) NOEXCEPT;
-	/// Case-insensitive less comparator for cstring_view
+	/// Case-insensitive less comparator for cstring_view; e.g. for case insensitive std::map
 	struct CStringViewILess
 	{
 		bool operator()( const gsl::cstring_view& lhs, const gsl::cstring_view& rhs ) const NOEXCEPT
@@ -26,6 +26,7 @@ namespace Q
 	};
 
 	int svtoi( const gsl::cstring_view& view );
+	float svtof( const gsl::cstring_view& view );
 }
 
 // operator<< overloads


### PR DESCRIPTION
I've greatly simplified & modernized the Generic Parser 2 in SP; this partially extends to the code using it, in particular the FX Parsing, which also got a first simplification pass (but there's still potential for much more).

The parser is used by FX and DMS parsing; at a glance both effects and music seem to work properly with the new system.

In particular this:
* Gets rid of the unused C interface to the parser
* Removes the unused & unfinished write functionality
* Removes the TextPool (to which all parsed strings were copied) in favor of using string views into the contents of the parsed file, thus removing the need for copies altogether (unless you need a string to be null-terminated)
  - as part of this a bunch of functions were made to use string views instead of null-terminated strings
* properly handles trailing whitespace (in theory; I have yet to verify this)
* removes some of the code duplication in FX Parsing; but it's still kind of a mess, as is the fx handling itself
* fixes a couple of small bugs like accepting a trailing '}' in the generic parser 2
* only includes genericparser2.h where it's needed

Initially this was in preparation of a rewrite of the DMS (dynamic music system) code to allow for the loading of additional files; I'm not sure when that will happen though.

~~The commits marked as [WIP] don't compile; and the commit dates are misleading, I've been rebasing.~~