### PR TITLE
Fix 2 (reproducible) assertion errors of Jedi Outcast

### DIFF
--- a/code/cgame/FxPrimitives.cpp
+++ b/code/cgame/FxPrimitives.cpp
@@ -307,9 +307,12 @@ bool CParticle::UpdateOrigin()
 				}
 			}
 
-			// Hit something
-			if ( trace.fraction < 1.0f )//|| trace.startsolid || trace.allsolid )
+			if ( trace.startsolid || trace.allsolid || trace.fraction == 1.0)
 			{
+			}
+			else
+			{
+				// Hit something
 				if ( mFlags & FX_IMPACT_RUNS_FX && !(trace.surfaceFlags & SURF_NOIMPACT ))
 				{
 					theFxScheduler.PlayEffect( mImpactFxID, trace.endpos, trace.plane.normal );

--- a/code/game/AI_Interrogator.cpp
+++ b/code/game/AI_Interrogator.cpp
@@ -67,8 +67,8 @@ void Interrogator_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacke
 	*/
 	{
 		self->client->moveType = MT_WALK;
-		self->client->ps.velocity[0] = Q_irand( -10, -20 );
-		self->client->ps.velocity[1] = Q_irand( -10, -20 );
+		self->client->ps.velocity[0] = Q_irand( -20, -10 );
+		self->client->ps.velocity[1] = Q_irand( -20, -10 );
 		self->client->ps.velocity[2] = -100;
 	}
 	//self->takedamage = qfalse;

--- a/codeJK2/cgame/FxPrimitives.cpp
+++ b/codeJK2/cgame/FxPrimitives.cpp
@@ -277,9 +277,12 @@ bool CParticle::UpdateOrigin()
 				theFxHelper.Trace( &trace, mOrigin1, NULL, NULL, new_origin, -1, ( MASK_SHOT | CONTENTS_WATER ) );
 			}
 
-			// Hit something
-			if ( trace.fraction < 1.0f )//|| trace.startsolid || trace.allsolid )
+			if ( trace.startsolid || trace.allsolid || trace.fraction == 1.0)
 			{
+			}
+			else
+			{
+				// Hit something
 				if ( mFlags & FX_IMPACT_RUNS_FX && !(trace.surfaceFlags & SURF_NOIMPACT ))
 				{
 					theFxScheduler.PlayEffect( mImpactFxID, trace.endpos, trace.plane.normal );

--- a/codeJK2/game/AI_Interrogator.cpp
+++ b/codeJK2/game/AI_Interrogator.cpp
@@ -69,8 +69,8 @@ void Interrogator_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacke
 	*/
 	{
 		self->NPC->stats.moveType = MT_WALK;
-		self->client->ps.velocity[0] = Q_irand( -10, -20 );
-		self->client->ps.velocity[1] = Q_irand( -10, -20 );
+		self->client->ps.velocity[0] = Q_irand( -20, -10 );
+		self->client->ps.velocity[1] = Q_irand( -20, -10 );
 		self->client->ps.velocity[2] = -100;
 	}
 	//self->takedamage = qfalse;

--- a/codemp/game/NPC_AI_Interrogator.c
+++ b/codemp/game/NPC_AI_Interrogator.c
@@ -68,8 +68,8 @@ void Interrogator_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacke
 	*/
 	{
 		self->client->ps.eFlags2 &= ~EF2_FLYING;//moveType = MT_WALK;
-		self->client->ps.velocity[0] = Q_irand( -10, -20 );
-		self->client->ps.velocity[1] = Q_irand( -10, -20 );
+		self->client->ps.velocity[0] = Q_irand( -20, -10 );
+		self->client->ps.velocity[1] = Q_irand( -20, -10 );
 		self->client->ps.velocity[2] = -100;
 	}
 	//self->takedamage = qfalse;

--- a/codemp/game/NPC_AI_Jedi.c
+++ b/codemp/game/NPC_AI_Jedi.c
@@ -4026,7 +4026,7 @@ static void Jedi_CombatTimersUpdate( int enemy_dist )
 		}
 		else if ( NPCS.NPC->client->ps.fd.forceRageRecoveryTime > level.time )
 		{//recovering
-			Jedi_Aggression( NPCS.NPC, Q_irand( 0, -2 ) );
+			Jedi_Aggression( NPCS.NPC, Q_irand( -2, 0 ) );
 		}
 		if ( NPCS.NPC->enemy && NPCS.NPC->enemy->client )
 		{


### PR DESCRIPTION
- In kejim_base, killing an interrogation drode at the prison would cause an assertion in Q_irand because of an inverted integer range.
- At the beginning of the artus_topside level, a NaN assertion is thrown.
I believe this commit fixes https://github.com/JACoders/OpenJK/issues/448.