### PR TITLE
R_PrintLongString bugfix

### DIFF
--- a/code/rd-vanilla/tr_init.cpp
+++ b/code/rd-vanilla/tr_init.cpp
@@ -1186,16 +1186,28 @@ Workaround for ri.Printf's 1024 characters buffer limit.
 
 void R_PrintLongString(const char *string) {
 	char buffer[1024];
-	const char *p;
+	const char *p, *s;
 	int size = strlen(string);
+	int copySize, bufferSize;
 
+	bufferSize = sizeof(buffer);
 	p = string;
-	while(size > 0)
+	while (size > 0)
 	{
-		Q_strncpyz(buffer, p, sizeof (buffer) );
-		Com_Printf( "%s", buffer );
-		p += 1023;
-		size -= 1023;
+		s = p + bufferSize - 1;
+		while (*s > ' ' && s != p) s--;
+		copySize = s - p;
+		if (copySize <= 0) {
+			Q_strncpyz(buffer, p, bufferSize);
+			p += bufferSize - 1;
+			size -= bufferSize - 1;
+		}
+		else {
+			Q_strncpyz(buffer, p, copySize);
+			p = s + 1;
+			size -= copySize;
+		}
+		Com_Printf("%s", buffer);
 	}
 }
 

--- a/codemp/rd-vanilla/tr_init.cpp
+++ b/codemp/rd-vanilla/tr_init.cpp
@@ -1350,16 +1350,20 @@ Workaround for ri->Printf's 1024 characters buffer limit.
 */
 void R_PrintLongString(const char *string) {
 	char buffer[1024];
-	const char *p;
+	const char *p, *s;
 	int size = strlen(string);
+	int bufferSize;
 
 	p = string;
-	while(size > 0)
+	while (size > 0)
 	{
-		Q_strncpyz(buffer, p, sizeof (buffer) );
-		ri->Printf( PRINT_ALL, "%s", buffer );
-		p += 1023;
-		size -= 1023;
+		s = p + 1023;
+		while (*s > ' ') s--;
+		bufferSize = s - p;
+		Q_strncpyz(buffer, p, bufferSize);
+		ri->Printf(PRINT_ALL, "%s", buffer);
+		p = s + 1;
+		size -= bufferSize;
 	}
 }
 

--- a/codemp/rd-vanilla/tr_init.cpp
+++ b/codemp/rd-vanilla/tr_init.cpp
@@ -1352,18 +1352,26 @@ void R_PrintLongString(const char *string) {
 	char buffer[1024];
 	const char *p, *s;
 	int size = strlen(string);
-	int bufferSize;
+	int copySize, bufferSize;
 
+	bufferSize = sizeof(buffer);
 	p = string;
 	while (size > 0)
 	{
-		s = p + 1023;
-		while (*s > ' ') s--;
-		bufferSize = s - p;
-		Q_strncpyz(buffer, p, bufferSize);
+		s = p + bufferSize - 1;
+		while (*s > ' ' && s != p) s--;
+		copySize = s - p;
+		if (copySize <= 0) {
+			Q_strncpyz(buffer, p, bufferSize);
+			p += bufferSize - 1;
+			size -= bufferSize - 1;
+		}
+		else {
+			Q_strncpyz(buffer, p, copySize);
+			p = s + 1;
+			size -= copySize;
+		}
 		ri->Printf(PRINT_ALL, "%s", buffer);
-		p = s + 1;
-		size -= bufferSize;
 	}
 }
 


### PR DESCRIPTION
Words are no longer cut off allowing console to word wrap properly. 