### PR TITLE
Fix a typo in Siege mode: attemtping -> attempting

### DIFF
--- a/codemp/game/ai_main.c
+++ b/codemp/game/ai_main.c
@@ -131,7 +131,7 @@ char *ctfStateDescriptions[] = {
 
 char *siegeStateDescriptions[] = {
 	"I'm not occupied",
-	"I'm attemtping to complete the current objective",
+	"I'm attempting to complete the current objective",
 	"I'm preventing the enemy from completing their objective"
 };
 


### PR DESCRIPTION
Found by Debian's Lintian tool, which (among many other checks) looks for common misspellings in the string tables of binaries.