### PR TITLE
Declare platform-independent byteswapping functions QINLINE

### DIFF
--- a/shared/qcommon/q_platform.h
+++ b/shared/qcommon/q_platform.h
@@ -299,17 +299,17 @@ static inline uint32_t LongSwap(uint32_t v)
 }
 #endif
 
-static void CopyShortSwap( void *dest, const void *src )
+static QINLINE void CopyShortSwap( void *dest, const void *src )
 {
     *(uint16_t*)dest = ShortSwap(*(uint16_t*)src);
 }
 
-static void CopyLongSwap( void *dest, const void *src )
+static QINLINE void CopyLongSwap( void *dest, const void *src )
 {
     *(uint32_t*)dest = LongSwap(*(uint32_t*)src);
 }
 
-static float FloatSwap(float f)
+static QINLINE float FloatSwap(float f)
 {
     float out;
     CopyLongSwap(&out, &f);


### PR DESCRIPTION
In addition to enabling inlining for these very simple functions,
this suppresses warnings from gcc 6:

```
…/shared/qcommon/q_platform.h:302:13: warning: 'void CopyShortSwap(void*, const void*)' defined but not used [-Wunused-function]
```

---
The travis-ci tests on my branch demonstrate this building successfully on g++ and clang, but it would be good if someone could try this on MSVC before merging (hopefully the Appveyor builds do that for us automatically).

`static QINLINE` provokes warnings from clang (because `QINLINE` already contains `static` for clang), but that isn't a regression: there's a lot of that already. As a follow-up change, it would be good if the OpenJK maintainers could choose one of these options:

* define `QINLINE` to `inline` or `__inline` (whichever is supported) on all compilers, the same as `ID_INLINE` in ioquake3; make sure that every C-style function that is declared `QINLINE` is `static QINLINE` (this resembles what is done in ioquake3)
* define `inline` to `__inline` if the compiler doesn't support the `inline` keyword, and replace all `QINLINE` or `static QINLINE` with `static inline` (this resembles what is commonly done in Unix-centric open source projects like GLib)
* define `QINLINE` to `static inline` or `static __inline` (whichever is supported) on all compilers; make sure that every C-style function that is declared `QINLINE` is **not** `static QINLINE`

My vote would be the first one, since OpenJK seems to be 90% of the way to it already.