### PR TITLE
Use same mechanism to say "no servers found" as to say how many we found

### DIFF
--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -7830,7 +7830,7 @@ static void UI_BuildFindPlayerList(qboolean force) {
 		// add a line that shows the number of servers found
 		if (!uiInfo.numFoundPlayerServers)
 		{
-			Com_sprintf(uiInfo.foundPlayerServerNames[uiInfo.numFoundPlayerServers-1], sizeof(uiInfo.foundPlayerServerAddresses[0]), "no servers found");
+			trap->Cvar_Set( "ui_playerServersFound", "no servers found" );
 		}
 		else
 		{


### PR DESCRIPTION
This avoids an array underflow: if no servers were found, we would
write to foundPlayerServerNames[-1], which is undefined behaviour, but
with a reasonable assumption of the stack layout is likely to result
in a write to foundPlayerServerAddresses[MAX - 1].

---
Underflow found via compiler warnings that are enabled by default in g++ 6.