### PR TITLE
botlib: print long int correctly

### DIFF
--- a/codemp/botlib/l_precomp.cpp
+++ b/codemp/botlib/l_precomp.cpp
@@ -2510,7 +2510,7 @@ int PC_Directive_eval(source_t *source)
 	token.whitespace_p = source->scriptstack->script_p;
 	token.endwhitespace_p = source->scriptstack->script_p;
 	token.linescrossed = 0;
-	sprintf(token.string, "%d", abs(value));
+	sprintf(token.string, "%ld", abs(value));
 	token.type = TT_NUMBER;
 	token.subtype = TT_INTEGER|TT_LONG|TT_DECIMAL;
 	PC_UnreadSourceToken(source, &token);
@@ -2615,7 +2615,7 @@ int PC_DollarDirective_evalint(source_t *source)
 	token.whitespace_p = source->scriptstack->script_p;
 	token.endwhitespace_p = source->scriptstack->script_p;
 	token.linescrossed = 0;
-	sprintf(token.string, "%d", abs(value));
+	sprintf(token.string, "%ld", abs(value));
 	token.type = TT_NUMBER;
 	token.subtype = TT_INTEGER|TT_LONG|TT_DECIMAL;
 


### PR DESCRIPTION
value has type long, or equivalently signed long int. In C,
abs(some_long) returns int (to get a long result you would have to use
labs(some_long) due to lack of overloading), but in C++ it returns long.

---
Found by g++ 6 warnings. The fix should be portable (long int -> `%ld` is Standard C and C++).