### PR TITLE
Avoid compiler warning when sscanf writes qboolean through %i

### DIFF
--- a/code/game/g_client.cpp
+++ b/code/game/g_client.cpp
@@ -696,6 +696,8 @@ static void Player_RestoreFromPrevLevel(gentity_t *ent, SavedGameJustLoaded_e eS
 
 		if (strlen(s))	// actually this would be safe anyway because of the way sscanf() works, but this is clearer
 		{//				|general info				  |-force powers |-saber 1										   |-saber 2										  |-general saber
+			int saber1BladeActive[8];
+			int saber2BladeActive[8];
 			unsigned int saber1BladeColor[8];
 			unsigned int saber2BladeColor[8];
 
@@ -718,14 +720,14 @@ static void Player_RestoreFromPrevLevel(gentity_t *ent, SavedGameJustLoaded_e eS
 								&client->ps.forcePowerRegenAmount,
 								//saber 1 data
 								saber0Name,
-								&client->ps.saber[0].blade[0].active,
-								&client->ps.saber[0].blade[1].active,
-								&client->ps.saber[0].blade[2].active,
-								&client->ps.saber[0].blade[3].active,
-								&client->ps.saber[0].blade[4].active,
-								&client->ps.saber[0].blade[5].active,
-								&client->ps.saber[0].blade[6].active,
-								&client->ps.saber[0].blade[7].active,
+								&saber1BladeActive[0],
+								&saber1BladeActive[1],
+								&saber1BladeActive[2],
+								&saber1BladeActive[3],
+								&saber1BladeActive[4],
+								&saber1BladeActive[5],
+								&saber1BladeActive[6],
+								&saber1BladeActive[7],
 								&saber1BladeColor[0],
 								&saber1BladeColor[1],
 								&saber1BladeColor[2],
@@ -736,14 +738,14 @@ static void Player_RestoreFromPrevLevel(gentity_t *ent, SavedGameJustLoaded_e eS
 								&saber1BladeColor[7],
 								//saber 2 data
 								saber1Name,
-								&client->ps.saber[1].blade[0].active,
-								&client->ps.saber[1].blade[1].active,
-								&client->ps.saber[1].blade[2].active,
-								&client->ps.saber[1].blade[3].active,
-								&client->ps.saber[1].blade[4].active,
-								&client->ps.saber[1].blade[5].active,
-								&client->ps.saber[1].blade[6].active,
-								&client->ps.saber[1].blade[7].active,
+								&saber2BladeActive[0],
+								&saber2BladeActive[1],
+								&saber2BladeActive[2],
+								&saber2BladeActive[3],
+								&saber2BladeActive[4],
+								&saber2BladeActive[5],
+								&saber2BladeActive[6],
+								&saber2BladeActive[7],
 								&saber2BladeColor[0],
 								&saber2BladeColor[1],
 								&saber2BladeColor[2],
@@ -760,7 +762,9 @@ static void Player_RestoreFromPrevLevel(gentity_t *ent, SavedGameJustLoaded_e eS
 					);
 			for (int j = 0; j < 8; j++)
 			{
+				client->ps.saber[0].blade[j].active = saber1BladeActive[j] ? qtrue : qfalse;
 				client->ps.saber[0].blade[j].color = (saber_colors_t)saber1BladeColor[j];
+				client->ps.saber[1].blade[j].active = saber2BladeActive[j] ? qtrue : qfalse;
 				client->ps.saber[1].blade[j].color = (saber_colors_t)saber2BladeColor[j];
 			}
 

--- a/code/game/g_session.cpp
+++ b/code/game/g_session.cpp
@@ -116,6 +116,7 @@ void G_ReadSessionData( gclient_t *client ) {
 	char	s[MAX_STRING_CHARS];
 	const char	*var;
 	int		i;
+	int		lightsideDisplay;
 
 	var = va( "session%i", client - level.clients );
 	gi.Cvar_VariableStringBuffer( var, s, sizeof(s) );
@@ -145,8 +146,9 @@ void G_ReadSessionData( gclient_t *client ) {
 
 	// Now load the LIGHTSIDE objective. That's the only cross level objective.
 	sscanf( var, "%i %i",
-		&client->sess.mission_objectives[LIGHTSIDE_OBJ].display,
+		&lightsideDisplay,
 		&client->sess.mission_objectives[LIGHTSIDE_OBJ].status);
+	client->sess.mission_objectives[LIGHTSIDE_OBJ].display = lightsideDisplay ? qtrue : qfalse;
 
 	var = va( "missionstats%i", client - level.clients );
 	gi.Cvar_VariableStringBuffer( var, s, sizeof(s) );

--- a/codeJK2/game/g_client.cpp
+++ b/codeJK2/game/g_client.cpp
@@ -696,6 +696,7 @@ void Player_RestoreFromPrevLevel(gentity_t *ent)
 	{
 		char	s[MAX_STRING_CHARS];
 		const char	*var;
+		int saberActive;
 
 		gi.Cvar_VariableStringBuffer( sCVARNAME_PLAYERSAVE, s, sizeof(s) );
 
@@ -714,11 +715,12 @@ void Player_RestoreFromPrevLevel(gentity_t *ent)
 								&client->ps.viewangles[2],
 								&client->ps.forcePowersKnown,
 								&client->ps.forcePower,
-								&client->ps.saberActive,
+								&saberActive,
 								&client->ps.saberAnimLevel,
 								&client->ps.saberLockEnemy,
 								&client->ps.saberLockTime
 					);
+			client->ps.saberActive = (saberActive ? qtrue : qfalse);
 			ent->health = client->ps.stats[STAT_HEALTH];
 
 // slight issue with ths for the moment in that although it'll correctly restore angles it doesn't take into account


### PR DESCRIPTION
```
.../code/game/g_client.cpp:760:6: warning: format '%i' expects argument of type 'int*', but argument 26 has type 'qboolean*' [-Wformat=]
```