### PR TITLE
Suppress compiler warning for unused BufferToHexString

### DIFF
--- a/codemp/server/sv_challenge.cpp
+++ b/codemp/server/sv_challenge.cpp
@@ -30,6 +30,7 @@ static const size_t SECRET_KEY_LENGTH = MD5_DIGEST_SIZE; // Key length equal to 
 static qboolean challengerInitialized = qfalse;
 static hmacMD5Context_t challenger;
 
+#ifdef DEBUG_SV_CHALLENGE
 /*
 ====================
 BufferToHexString
@@ -52,6 +53,7 @@ static const char *BufferToHexString(byte *buffer, size_t bufferLen)
 	hexString[bufferLen * 2] = '\0';
 	return hexString;
 }
+#endif
 
 /*
 ====================


### PR DESCRIPTION
This function is only called when debugging challenges.

---
g++ 6 warns about unused static functions by default. It does not warn about unused static inline functions, so this could be made inline instead if desired, but I think this is the better fix.