### PR TITLE
Remove constexpr usage

### DIFF
--- a/code/game/g_savegame.cpp
+++ b/code/game/g_savegame.cpp
@@ -768,10 +768,10 @@ static void copy_retail_gclient_to_current(
 	const RetailGClient& src,
 	gclient_t& dst)
 {
-	constexpr size_t src_pre_size = offsetof(RetailGClient, ps.saber[0]);
-	constexpr size_t src_post_offset = offsetof(RetailGClient, ps.dualSabers);
-	constexpr size_t src_post_size = sizeof(RetailGClient) - src_post_offset;
-	constexpr size_t dst_post_offset = offsetof(gclient_t, ps.dualSabers);
+	const size_t src_pre_size = offsetof(RetailGClient, ps.saber[0]);
+	const size_t src_post_offset = offsetof(RetailGClient, ps.dualSabers);
+	const size_t src_post_size = sizeof(RetailGClient) - src_post_offset;
+	const size_t dst_post_offset = offsetof(gclient_t, ps.dualSabers);
 
 	::memcpy(
 		reinterpret_cast<char*>(&dst),

--- a/code/qcommon/ojk_saved_game.cpp
+++ b/code/qcommon/ojk_saved_game.cpp
@@ -138,7 +138,7 @@ bool SavedGame::create(
 
 	is_writable_ = true;
 
-	constexpr int sg_version = iSAVEGAME_VERSION;
+	const int sg_version = iSAVEGAME_VERSION;
 
 	SavedGameHelper sgsh(this);
 
@@ -963,7 +963,7 @@ void SavedGame::reset_buffer_offset()
 	io_buffer_offset_ = 0;
 }
 
-constexpr uint32_t SavedGame::get_jo_magic_value()
+const uint32_t SavedGame::get_jo_magic_value()
 {
 	return 0x1234ABCD;
 }

--- a/code/qcommon/ojk_saved_game.h
+++ b/code/qcommon/ojk_saved_game.h
@@ -183,7 +183,7 @@ private:
 	static std::string get_chunk_id_string(
 		uint32_t chunk_id);
 
-	static constexpr uint32_t get_jo_magic_value();
+	static const uint32_t get_jo_magic_value();
 }; // SavedGame
 
 

--- a/code/qcommon/ojk_saved_game_class_archivers.h
+++ b/code/qcommon/ojk_saved_game_class_archivers.h
@@ -19,10 +19,7 @@ template<>
 class SavedGameClassArchiver<cplane_t>
 {
 public:
-	static constexpr bool is_implemented()
-	{
-		return true;
-	}
+	enum { is_implemented = true };
 
 	static void sg_export(
 		SavedGameHelper& saved_game,

--- a/code/qcommon/ojk_saved_game_helper.h
+++ b/code/qcommon/ojk_saved_game_helper.h
@@ -334,7 +334,7 @@ bool SavedGameHelper::try_read(
 	TDst& dst_value,
 	NumericTag)
 {
-	constexpr int src_size = static_cast<int>(sizeof(TSrc));
+	const int src_size = static_cast<int>(sizeof(TSrc));
 
 	TSrc src_value;
 
@@ -393,7 +393,7 @@ bool SavedGameHelper::try_read(
 		"Unsupported types.");
 
 	using Tag = typename std::conditional<
-		SavedGameClassArchiver<TDst>::is_implemented(),
+		SavedGameClassArchiver<TDst>::is_implemented,
 		ExternalTag,
 		InternalTag
 	>::type;
@@ -474,26 +474,26 @@ bool SavedGameHelper::try_read(
 		TSrc
 	>::type;
 
-	constexpr bool is_src_pure_numeric =
+	const bool is_src_pure_numeric =
 		std::is_arithmetic<Src>::value &&
 		(!std::is_same<Src, bool>::value) &&
 		(!std::is_enum<Src>::value);
 
-	constexpr bool is_dst_pure_numeric =
+	const bool is_dst_pure_numeric =
 		std::is_arithmetic<TDst>::value &&
 		(!std::is_same<TDst, bool>::value) &&
 		(!std::is_enum<TDst>::value);
 
-	constexpr bool is_src_float_point =
+	const bool is_src_float_point =
 		std::is_floating_point<Src>::value;
 
-	constexpr bool is_dst_float_point =
+	const bool is_dst_float_point =
 		std::is_floating_point<TDst>::value;
 
-	constexpr bool has_same_size =
+	const bool has_same_size =
 		(sizeof(Src) == sizeof(TDst));
 
-	constexpr bool use_inplace =
+	const bool use_inplace =
 		is_src_pure_numeric &&
 		is_dst_pure_numeric &&
 		((!is_src_float_point && !is_dst_float_point) ||
@@ -634,7 +634,7 @@ void SavedGameHelper::write(
 	const TSrc& src_value,
 	NumericTag)
 {
-	constexpr int dst_size = static_cast<int>(sizeof(TDst));
+	const int dst_size = static_cast<int>(sizeof(TDst));
 
 	const TDst dst_value = static_cast<TDst>(src_value);
 
@@ -674,7 +674,7 @@ void SavedGameHelper::write(
 		"Unsupported types.");
 
 	using Tag = typename std::conditional<
-		SavedGameClassArchiver<TSrc>::is_implemented(),
+		SavedGameClassArchiver<TSrc>::is_implemented,
 		ExternalTag,
 		InternalTag
 	>::type;
@@ -750,26 +750,26 @@ void SavedGameHelper::write(
 		TSrc,
 		TDst>::type;
 
-	constexpr bool is_src_pure_numeric =
+	const bool is_src_pure_numeric =
 		std::is_arithmetic<TSrc>::value &&
 		(!std::is_same<TSrc, bool>::value) &&
 		(!std::is_enum<TSrc>::value);
 
-	constexpr bool is_dst_pure_numeric =
+	const bool is_dst_pure_numeric =
 		std::is_arithmetic<Dst>::value &&
 		(!std::is_same<Dst, bool>::value) &&
 		(!std::is_enum<Dst>::value);
 
-	constexpr bool is_src_float_point =
+	const bool is_src_float_point =
 		std::is_floating_point<TSrc>::value;
 
-	constexpr bool is_dst_float_point =
+	const bool is_dst_float_point =
 		std::is_floating_point<Dst>::value;
 
-	constexpr bool has_same_size =
+	const bool has_same_size =
 		(sizeof(TSrc) == sizeof(Dst));
 
-	constexpr bool use_inplace =
+	const bool use_inplace =
 		is_src_pure_numeric &&
 		is_dst_pure_numeric &&
 		((!is_src_float_point && !is_dst_float_point) ||

--- a/code/qcommon/ojk_saved_game_helper_fwd.h
+++ b/code/qcommon/ojk_saved_game_helper_fwd.h
@@ -290,11 +290,8 @@ template<typename T>
 class SavedGameClassArchiver
 {
 public:
-	static constexpr bool is_implemented()
-	{
-		return false;
-	}
-
+	enum { is_implemented = false };
+	
 	static void sg_export(
 		SavedGameHelper& saved_game,
 		const T& instance)


### PR DESCRIPTION
VS2013 does not support the `constexpr` keyword so it has been removed.