### PR TITLE
Use conventional formatting to avoid -Wmisleading-indentation

### DIFF
--- a/code/client/cl_cin.cpp
+++ b/code/client/cl_cin.cpp
@@ -592,8 +592,18 @@ static unsigned short yuv_to_rgb( long y, long u, long v )
 	g = (YY + ROQ_UG_tab[u] + ROQ_VG_tab[v]) >> 8;
 	b = (YY + ROQ_UB_tab[u]) >> 9;
 
-	if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
-	if (r > 31) r = 31; if (g > 63) g = 63; if (b > 31) b = 31;
+	if (r<0)
+		r = 0;
+	if (g<0)
+		g = 0;
+	if (b<0)
+		b = 0;
+	if (r > 31)
+		r = 31;
+	if (g > 63)
+		g = 63;
+	if (b > 31)
+		b = 31;
 
 	return (unsigned short)((r<<11)+(g<<5)+(b));
 }
@@ -614,8 +624,18 @@ static unsigned int yuv_to_rgb24( long y, long u, long v )
 	g = (YY + ROQ_UG_tab[u] + ROQ_VG_tab[v]) >> 6;
 	b = (YY + ROQ_UB_tab[u]) >> 6;
 
-	if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
-	if (r > 255) r = 255; if (g > 255) g = 255; if (b > 255) b = 255;
+	if (r<0)
+		r = 0;
+	if (g<0)
+		g = 0;
+	if (b<0)
+		b = 0;
+	if (r > 255)
+		r = 255;
+	if (g > 255)
+		g = 255;
+	if (b > 255)
+		b = 255;
 
 	return LittleLong ((r)|(g<<8)|(b<<16)|(255<<24));
 }

--- a/codemp/client/cl_cin.cpp
+++ b/codemp/client/cl_cin.cpp
@@ -588,8 +588,18 @@ static unsigned short yuv_to_rgb( long y, long u, long v )
 	g = (YY + ROQ_UG_tab[u] + ROQ_VG_tab[v]) >> 8;
 	b = (YY + ROQ_UB_tab[u]) >> 9;
 
-	if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
-	if (r > 31) r = 31; if (g > 63) g = 63; if (b > 31) b = 31;
+	if (r<0)
+		r = 0;
+	if (g<0)
+		g = 0;
+	if (b<0)
+		b = 0;
+	if (r > 31)
+		r = 31;
+	if (g > 63)
+		g = 63;
+	if (b > 31)
+		b = 31;
 
 	return (unsigned short)((r<<11)+(g<<5)+(b));
 }
@@ -609,8 +619,18 @@ static unsigned int yuv_to_rgb24( long y, long u, long v )
 	g = (YY + ROQ_UG_tab[u] + ROQ_VG_tab[v]) >> 6;
 	b = (YY + ROQ_UB_tab[u]) >> 6;
 
-	if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
-	if (r > 255) r = 255; if (g > 255) g = 255; if (b > 255) b = 255;
+	if (r<0)
+		r = 0;
+	if (g<0)
+		g = 0;
+	if (b<0)
+		b = 0;
+	if (r > 255)
+		r = 255;
+	if (g > 255)
+		g = 255;
+	if (b > 255)
+		b = 255;
 
 	return LittleLong ((r)|(g<<8)|(b<<16)|(255<<24));
 }


### PR DESCRIPTION
With clang 3.8:
```
.../codemp/client/cl_cin.cpp: In function ‘short unsigned int yuv_to_rgb(long int, long int, long int)’:
.../codemp/client/cl_cin.cpp:591:2: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
  ^~
.../codemp/client/cl_cin.cpp:591:18: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
  if (r<0) r = 0; if (g<0) g = 0; if (b<0) b = 0;
                  ^~
```