### PR TITLE
Consistently use "static QINLINE" for inline C code

### DIFF
--- a/codemp/game/NPC_move.c
+++ b/codemp/game/NPC_move.c
@@ -95,7 +95,7 @@ NPC_CheckCombatMove
 -------------------------
 */
 
-QINLINE qboolean NPC_CheckCombatMove( void )
+static QINLINE qboolean NPC_CheckCombatMove( void )
 {
 	//return NPCInfo->combatMove;
 	if ( ( NPCS.NPCInfo->goalEntity && NPCS.NPC->enemy && NPCS.NPCInfo->goalEntity == NPCS.NPC->enemy ) || ( NPCS.NPCInfo->combatMove ) )
@@ -143,7 +143,7 @@ NPC_GetMoveInformation
 -------------------------
 */
 
-QINLINE qboolean NPC_GetMoveInformation( vec3_t dir, float *distance )
+static QINLINE qboolean NPC_GetMoveInformation( vec3_t dir, float *distance )
 {
 	//NOTENOTE: Use path stacks!
 

--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -259,7 +259,7 @@ qboolean BG_KnockDownable(playerState_t *ps)
 }
 
 //hacky assumption check, assume any client non-humanoid is a rocket trooper
-qboolean QINLINE PM_IsRocketTrooper(void)
+static QINLINE qboolean PM_IsRocketTrooper(void)
 {
 	/*
 	if (pm->ps->clientNum < MAX_CLIENTS &&

--- a/shared/qcommon/q_platform.h
+++ b/shared/qcommon/q_platform.h
@@ -123,11 +123,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 		#define OS_STRING "kFreeBSD"
 	#endif
 
-	#ifdef __clang__
-		#define QINLINE static inline
-	#else
-		#define QINLINE inline
-	#endif
+	#define QINLINE inline
 
 	#define PATH_SEP '/'
 


### PR DESCRIPTION
The portable idiom for type-safe macro-like constructs in C is to use
"static inline" where C99 inline is supported, or "static __inline"
on compilers that implement that keyword as a compiler-specific
extension (at least gcc, clang and MSVC do), falling back to just
"static" as a last resort on terrible compilers from the distant past.

Using "static QINLINE" everywhere means there is no point in defining
QINLINE to "static inline" on clang, so stop doing that; QINLINE now
consistently expands to Standard C/C++ inline, or __inline on MSVC,
or to nothing if we don't know how to inline functions on this
compiler.

This silences warnings about redundant qualifiers (static static inline)
for all the functions that were already inline.

There are a couple of uses of non-static QINLINE in C++ code; I've
left those intact, since inline has different (more useful)
semantics in C++, and as far as I'm aware all reasonable C++ compilers
implement it correctly.

---
As requested by @xycaleth on #869.