### PR TITLE
snd_mem: fix build failure on big-endian CPUs with C++11 compilers

### DIFF
--- a/code/client/snd_mem.cpp
+++ b/code/client/snd_mem.cpp
@@ -840,9 +840,11 @@ static qboolean S_LoadSound_Actual( sfx_t *sfx )
 						for (int i = 0; i < sfx->iSoundLengthInSamples; i++)
 						{
 							sfx->pSoundData[i] = LittleShort(sfx->pSoundData[i]);
-							if (sfx->fVolRange < (abs(sfx->pSoundData[i]) >> 8))
+							// C++11 defines double abs(short) which is not what we want here,
+							// because double >> int is not defined. Force interpretation as int
+							if (sfx->fVolRange < (abs(static_cast<int>(sfx->pSoundData[i])) >> 8))
 							{
-								sfx->fVolRange = abs(sfx->pSoundData[i]) >> 8;
+								sfx->fVolRange = abs(static_cast<int>(sfx->pSoundData[i])) >> 8;
 							}
 						}
 #endif

--- a/codemp/client/snd_mem.cpp
+++ b/codemp/client/snd_mem.cpp
@@ -839,9 +839,11 @@ static qboolean S_LoadSound_Actual( sfx_t *sfx )
 						for (int i = 0; i < sfx->iSoundLengthInSamples; i++)
 						{
 							sfx->pSoundData[i] = LittleShort(sfx->pSoundData[i]);
-							if (sfx->fVolRange < (abs(sfx->pSoundData[i]) >> 8))
+							// C++11 defines double abs(short) which is not what we want here,
+							// because double >> int is not defined. Force interpretation as int
+							if (sfx->fVolRange < (abs(static_cast<int>(sfx->pSoundData[i])) >> 8))
 							{
-								sfx->fVolRange = abs(sfx->pSoundData[i]) >> 8;
+								sfx->fVolRange = abs(static_cast<int>(sfx->pSoundData[i])) >> 8;
 							}
 						}
 #endif


### PR DESCRIPTION
The Debian `powerpc`, `mips` and `s390x` builds failed with:

```
.../code/client/snd_mem.cpp: In function 'qboolean S_LoadSound_Actual(sfx_t*)':
.../code/client/snd_mem.cpp:843:54: error: invalid operands of types '__gnu_cxx::__enable_if<true, double>::__type {aka double}' and 'int' to binary 'operator>>'
        if (sfx->fVolRange < (abs(sfx->pSoundData[i]) >> 8))
                              ~~~~~~~~~~~~~~~~~~~~~~~~^~~~
.../code/client/snd_mem.cpp:845:50: error: invalid operands of types '__gnu_cxx::__enable_if<true, double>::__type {aka double}' and 'int' to binary 'operator>>'
         sfx->fVolRange = abs(sfx->pSoundData[i]) >> 8;
                          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~
```

This appears to be because `sfx->pSoundData[i]` is of type `short`. C++98
only provided `int abs(int)`, `long abs(long)`, `float abs(float)`,
`double abs(double)` and `long double abs(long double)` overloads, but
C++11 also provides `double abs(T)` for all integral types _T_, including
`short`. `double` is not a valid left-hand side for `operator>>` so
compilation fails.

---

Compile-tested on one of Debian's remote PowerPC servers. My own PowerPC is in storage, so I can't test this further for a while.
