### PR TITLE
CVE-2017-11721: buffer overflow in MSG_ReadBits

### DIFF
--- a/codemp/qcommon/huffman.cpp
+++ b/codemp/qcommon/huffman.cpp
@@ -269,9 +269,14 @@ int Huff_Receive (node_t *node, int *ch, byte *fin) {
 }
 
 /* Get a symbol */
-void Huff_offsetReceive (node_t *node, int *ch, byte *fin, int *offset) {
+void Huff_offsetReceive (node_t *node, int *ch, byte *fin, int *offset, int maxoffset) {
 	bloc = *offset;
 	while (node && node->symbol == INTERNAL_NODE) {
+		if (bloc >= maxoffset) {
+			*ch = 0;
+			*offset = maxoffset + 1;
+			return;
+		}
 		if (get_bit(fin)) {
 			node = node->right;
 		} else {
@@ -288,11 +293,15 @@ void Huff_offsetReceive (node_t *node, int *ch, byte *fin, int *offset) {
 }
 
 /* Send the prefix code for this node */
-static void send(node_t *node, node_t *child, byte *fout) {
+static void send(node_t *node, node_t *child, byte *fout, int maxoffset) {
 	if (node->parent) {
-		send(node->parent, node, fout);
+		send(node->parent, node, fout, maxoffset);
 	}
 	if (child) {
+		if (bloc >= maxoffset) {
+			bloc = maxoffset + 1;
+			return;
+		}
 		if (node->right == child) {
 			add_bit(1, fout);
 		} else {
@@ -302,22 +311,22 @@ static void send(node_t *node, node_t *child, byte *fout) {
 }
 
 /* Send a symbol */
-void Huff_transmit (huff_t *huff, int ch, byte *fout) {
+void Huff_transmit (huff_t *huff, int ch, byte *fout, int maxoffset) {
 	int i;
 	if (huff->loc[ch] == NULL) {
 		/* node_t hasn't been transmitted, send a NYT, then the symbol */
-		Huff_transmit(huff, NYT, fout);
+		Huff_transmit(huff, NYT, fout, maxoffset);
 		for (i = 7; i >= 0; i--) {
 			add_bit((char)((ch >> i) & 0x1), fout);
 		}
 	} else {
-		send(huff->loc[ch], NULL, fout);
+		send(huff->loc[ch], NULL, fout, maxoffset);
 	}
 }
 
-void Huff_offsetTransmit (huff_t *huff, int ch, byte *fout, int *offset) {
+void Huff_offsetTransmit (huff_t *huff, int ch, byte *fout, int *offset, int maxoffset) {
 	bloc = *offset;
-	send(huff->loc[ch], NULL, fout);
+	send(huff->loc[ch], NULL, fout, maxoffset);
 	*offset = bloc;
 }
 
@@ -404,7 +413,7 @@ void Huff_Compress(msg_t *mbuf, int offset) {
 
 	for (i=0; i<size; i++ ) {
 		ch = buffer[i];
-		Huff_transmit(&huff, ch, seq);						/* Transmit symbol */
+		Huff_transmit(&huff, ch, seq, size<<3);						/* Transmit symbol */
 		Huff_addRef(&huff, (byte)ch);								/* Do update */
 	}
 

--- a/codemp/qcommon/msg.cpp
+++ b/codemp/qcommon/msg.cpp
@@ -139,9 +139,7 @@ void MSG_WriteBits( msg_t *msg, int value, int bits ) {
 
 	oldsize += bits;
 
-	// this isn't an exact overflow check, but close enough
-	if ( msg->maxsize - msg->cursize < 4 ) {
-		msg->overflowed = qtrue;
+	if ( msg->overflowed ) {
 		return;
 	}
 
@@ -175,6 +173,11 @@ void MSG_WriteBits( msg_t *msg, int value, int bits ) {
 		bits = -bits;
 	}
 	if (msg->oob) {
+		if ( msg->cursize + ( bits >> 3 ) > msg->maxsize ) {
+			msg->overflowed = qtrue;
+			return;
+		}
+
 		if (bits==8) {
 			msg->data[msg->cursize] = value;
 			msg->cursize += 1;
@@ -197,6 +200,10 @@ void MSG_WriteBits( msg_t *msg, int value, int bits ) {
 		if (bits&7) {
 			int nbits;
 			nbits = bits&7;
+			if ( msg->bit + nbits > msg->maxsize << 3 ) {
+				msg->overflowed = qtrue;
+				return;
+			}
 			for(i=0;i<nbits;i++) {
 				Huff_putBit((value&1), msg->data, &msg->bit);
 				value = (value>>1);
@@ -208,8 +215,13 @@ void MSG_WriteBits( msg_t *msg, int value, int bits ) {
 #ifdef _NEWHUFFTABLE_
 				fwrite(&value, 1, 1, fp);
 #endif // _NEWHUFFTABLE_
-				Huff_offsetTransmit (&msgHuff.compressor, (value&0xff), msg->data, &msg->bit);
+				Huff_offsetTransmit (&msgHuff.compressor, (value&0xff), msg->data, &msg->bit, msg->maxsize << 3);
 				value = (value>>8);
+
+				if ( msg->bit > msg->maxsize << 3 ) {
+					msg->overflowed = qtrue;
+					return;
+				}
 			}
 		}
 		msg->cursize = (msg->bit>>3)+1;
@@ -221,6 +233,11 @@ int MSG_ReadBits( msg_t *msg, int bits ) {
 	int			get;
 	qboolean	sgn;
 	int			i, nbits;
+
+	if ( msg->readcount > msg->cursize ) {
+		return 0;
+	}
+
 	value = 0;
 
 	if ( bits < 0 ) {
@@ -231,6 +248,11 @@ int MSG_ReadBits( msg_t *msg, int bits ) {
 	}
 
 	if (msg->oob) {
+		if (msg->readcount + (bits>>3) > msg->cursize) {
+			msg->readcount = msg->cursize + 1;
+			return 0;
+		}
+
 		if (bits==8) {
 			value = msg->data[msg->readcount];
 			msg->readcount += 1;
@@ -253,6 +275,10 @@ int MSG_ReadBits( msg_t *msg, int bits ) {
 		nbits = 0;
 		if (bits&7) {
 			nbits = bits&7;
+			if (msg->bit + nbits > msg->cursize << 3) {
+				msg->readcount = msg->cursize + 1;
+				return 0;
+			}
 			for(i=0;i<nbits;i++) {
 				value |= (Huff_getBit(msg->data, &msg->bit)<<i);
 			}
@@ -260,11 +286,16 @@ int MSG_ReadBits( msg_t *msg, int bits ) {
 		}
 		if (bits) {
 			for(i=0;i<bits;i+=8) {
-				Huff_offsetReceive (msgHuff.decompressor.tree, &get, msg->data, &msg->bit);
+				Huff_offsetReceive (msgHuff.decompressor.tree, &get, msg->data, &msg->bit, msg->cursize<<3);
 #ifdef _NEWHUFFTABLE_
 				fwrite(&get, 1, 1, fp);
 #endif // _NEWHUFFTABLE_
 				value |= (get<<(i+nbits));
+
+				if (msg->bit > msg->cursize<<3) {
+					msg->readcount = msg->cursize + 1;
+					return 0;
+				}
 			}
 		}
 		msg->readcount = (msg->bit>>3)+1;

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -1033,9 +1033,9 @@ void	Huff_Decompress(msg_t *buf, int offset);
 void	Huff_Init(huffman_t *huff);
 void	Huff_addRef(huff_t* huff, byte ch);
 int		Huff_Receive (node_t *node, int *ch, byte *fin);
-void	Huff_transmit (huff_t *huff, int ch, byte *fout);
-void	Huff_offsetReceive (node_t *node, int *ch, byte *fin, int *offset);
-void	Huff_offsetTransmit (huff_t *huff, int ch, byte *fout, int *offset);
+void	Huff_transmit (huff_t *huff, int ch, byte *fout, int maxoffset);
+void	Huff_offsetReceive (node_t *node, int *ch, byte *fin, int *offset, int maxoffset);
+void	Huff_offsetTransmit (huff_t *huff, int ch, byte *fout, int *offset, int maxoffset);
 void	Huff_putBit( int bit, byte *fout, int *offset);
 int		Huff_getBit( byte *fout, int *offset);
 


### PR DESCRIPTION
@zturtleman recently committed a fix to the Huffman coding in ioquake3's netcode (<https://github.com/ioquake/ioq3/commit/d2b1d124d4055c2fcbe5126863487c52fd58cca1>). This has been treated as a security vulnerability and CVE-2017-11721 was assigned (by someone, it isn't clear who requested this): see <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11721>. As another descendant of the Quake III Arena engine, OpenJK seems to have the same issue.

I believe the situation is:

* When reading data out of a message, a crafted message can arrange for the engine (client or server or both, I'm not sure) to read beyond the message bounds, potentially causing a crash (denial of service) or disclosure of memory contents. Remotely crashing a client or server is a minor security vulnerability (denial of service) so CVE-2017-11721 was assigned.
* When writing data into a message, there is no vulnerability, but the checks for overflow are too pessimistic and can report that a write would overflow when in fact there are a few bytes still available for writing. @zturtleman fixed this too, in the same commit.

(But my interpretation might be wrong, I haven't studied this in detail.)

I have ported the ioquake3 patch to OpenJK's netcode. The result seems to work in some very brief testing, so I have uploaded it to Debian. Please consider merging.