### PR TITLE
Avoid undefined behavior to fix 'crashing when using force powers' issue

### DIFF
--- a/code/game/NPC_reactions.cpp
+++ b/code/game/NPC_reactions.cpp
@@ -375,7 +375,15 @@ void NPC_ChoosePainAnimation( gentity_t *self, gentity_t *other, const vec3_t po
 		{
 			self->painDebounceTime = level.time + 4000;
 		}
-		self->painDebounceTime = level.time + PM_AnimLength( self->client->clientInfo.animFileIndex, (animNumber_t) pain_anim );
+
+		if ( pain_anim >= 0 )
+		{
+			self->painDebounceTime = level.time + PM_AnimLength( self->client->clientInfo.animFileIndex, (animNumber_t) pain_anim );
+		}
+		else
+		{
+			self->painDebounceTime = level.time;
+		}
 		self->client->fireDelay = 0;
 	}
 }


### PR DESCRIPTION
on Clang builds

Please don't cast negative integers to enum, as it is undefined behavior.

This commit fixes:
https://jkhub.org/topic/9457-openjkmac-crashing-when-using-force-powers/