### PR TITLE
Set per-target visibility flags in a way compatible with CMake 2.8.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,21 @@ if (NOT ("$ENV{SOURCE_DATE_EPOCH}" STREQUAL ""))
 	set(SharedDefines ${SharedDefines} "SOURCE_DATE=\"${source_date}\"")
 endif()
 
+# ojk_add_compile_options(<target> <options>)
+# Should be used to add compiler options on a per-target
+# basis while cmake_minimum_required is set to version
+# below 2.8.12.
+function(ojk_add_compile_options Target Options)
+    if (ARGN)
+        message(SEND_ERROR "Too many arguments for ojk_add_compile_option")
+    endif()
+
+    if (COMMAND target_compile_options)
+        target_compile_options(${Target} PRIVATE ${Options})
+    else()
+        set_property(TARGET ${Target} APPEND_STRING PROPERTY COMPILE_FLAGS " ${Options}")
+    endif()
+endfunction(ojk_add_compile_options)
 
 
 # Files shared across all projects

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -419,7 +419,7 @@ if(BuildSPEngine OR BuildJK2SPEngine)
 		set_target_properties(${ProjectName} PROPERTIES COMPILE_DEFINITIONS "${SPEngineDefines}")
 
 		# Hide symbols not explicitly marked public.
-		set_property(TARGET ${ProjectName} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+		ojk_add_compile_options(${ProjectName} "${OPENJK_VISIBILITY_FLAGS}")
 
 		set_target_properties(${ProjectName} PROPERTIES INCLUDE_DIRECTORIES "${SPEngineIncludeDirectories}")
 		set_target_properties(${ProjectName} PROPERTIES PROJECT_LABEL ${Label})

--- a/code/game/CMakeLists.txt
+++ b/code/game/CMakeLists.txt
@@ -375,7 +375,7 @@ endif(WIN32)
 add_library(${SPGame} SHARED ${SPGameFiles})
 
 # Hide symbols not explicitly marked public.
-set_property(TARGET ${SPGame} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+ojk_add_compile_options(${SPGame} "${OPENJK_VISIBILITY_FLAGS}")
 
 if(NOT MSVC)
 	# remove "lib" prefix for .so/.dylib files

--- a/code/rd-vanilla/CMakeLists.txt
+++ b/code/rd-vanilla/CMakeLists.txt
@@ -184,7 +184,7 @@ if(BuildSPRdVanilla OR BuildJK2SPRdVanilla)
 		set_target_properties(${ProjectName} PROPERTIES COMPILE_DEFINITIONS "${SPRDVanillaDefines}")
 
 		# Hide symbols not explicitly marked public.
-		set_property(TARGET ${ProjectName} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+		ojk_add_compile_options(${ProjectName} "${OPENJK_VISIBILITY_FLAGS}")
 
 		set_target_properties(${ProjectName} PROPERTIES INCLUDE_DIRECTORIES "${SPRDVanillaRendererIncludeDirectories}")
 		set_target_properties(${ProjectName} PROPERTIES PROJECT_LABEL ${Label})

--- a/codeJK2/game/CMakeLists.txt
+++ b/codeJK2/game/CMakeLists.txt
@@ -303,7 +303,7 @@ endif(WIN32)
 set_target_properties(${JK2SPGame} PROPERTIES COMPILE_DEFINITIONS "${JK2SPGameDefines}")
 
 # Hide symbols not explicitly marked public.
-set_property(TARGET ${JK2SPGame} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+ojk_add_compile_options(${JK2SPGame} "${OPENJK_VISIBILITY_FLAGS}")
 
 set_target_properties(${JK2SPGame} PROPERTIES INCLUDE_DIRECTORIES "${JK2SPGameIncludeDirectories}")
 set_target_properties(${JK2SPGame} PROPERTIES PROJECT_LABEL "JK2 SP Game Library")

--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -159,7 +159,7 @@ if(BuildMPEngine OR BuildMPDed)
 	add_library(${MPBotLib} STATIC ${MPBotlibFiles})
 
 	# Hide symbols not explicitly marked public.
-	set_property(TARGET ${MPBotLib} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+	ojk_add_compile_options(${MPBotLib} "${OPENJK_VISIBILITY_FLAGS}")
 
 	set_target_properties(${MPBotLib} PROPERTIES COMPILE_DEFINITIONS "${MPBotlibDefines}")
 	set_target_properties(${MPBotLib} PROPERTIES INCLUDE_DIRECTORIES "${MPBotlibIncludeDirectories}")
@@ -597,7 +597,7 @@ if(BuildMPEngine)
 	set_target_properties(${MPEngine} PROPERTIES COMPILE_DEFINITIONS "${MPEngineDefines}")
 
 	# Hide symbols not explicitly marked public.
-	set_property(TARGET ${MPEngine} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+	ojk_add_compile_options(${MPEngine} "${OPENJK_VISIBILITY_FLAGS}")
 
 	set_target_properties(${MPEngine} PROPERTIES INCLUDE_DIRECTORIES "${MPEngineIncludeDirectories}")
 	set_target_properties(${MPEngine} PROPERTIES PROJECT_LABEL "MP Client")
@@ -689,7 +689,7 @@ if(BuildMPDed)
 	set_target_properties(${MPDed} PROPERTIES COMPILE_DEFINITIONS "${MPDedDefines}")
 
 	# Hide symbols not explicitly marked public.
-	set_property(TARGET ${MPDed} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+	ojk_add_compile_options(${MPDed} "${OPENJK_VISIBILITY_FLAGS}")
 
 	set_target_properties(${MPDed} PROPERTIES INCLUDE_DIRECTORIES "${MPDedIncludeDirectories}")
 	set_target_properties(${MPDed} PROPERTIES PROJECT_LABEL "MP Dedicated Server")

--- a/codemp/cgame/CMakeLists.txt
+++ b/codemp/cgame/CMakeLists.txt
@@ -182,7 +182,7 @@ endif()
 set_target_properties(${MPCGame} PROPERTIES COMPILE_DEFINITIONS "${MPCGameDefines}")
 
 # Hide symbols not explicitly marked public.
-set_property(TARGET ${MPCGame} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+ojk_add_compile_options(${MPCGame} "${OPENJK_VISIBILITY_FLAGS}")
 
 set_target_properties(${MPCGame} PROPERTIES INCLUDE_DIRECTORIES "${MPCGameIncludeDirectories}")
 set_target_properties(${MPCGame} PROPERTIES PROJECT_LABEL "MP Client Game Library")

--- a/codemp/game/CMakeLists.txt
+++ b/codemp/game/CMakeLists.txt
@@ -250,7 +250,7 @@ endif()
 set_target_properties(${MPGame} PROPERTIES COMPILE_DEFINITIONS "${MPGameDefines}")
 
 # Hide symbols not explicitly marked public.
-set_property(TARGET ${MPGame} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+ojk_add_compile_options(${MPGame} "${OPENJK_VISIBILITY_FLAGS}")
 
 set_target_properties(${MPGame} PROPERTIES INCLUDE_DIRECTORIES "${MPGameIncludeDirectories}")
 set_target_properties(${MPGame} PROPERTIES PROJECT_LABEL "MP Game Library")

--- a/codemp/rd-vanilla/CMakeLists.txt
+++ b/codemp/rd-vanilla/CMakeLists.txt
@@ -161,7 +161,7 @@ endif()
 set_target_properties(${MPVanillaRenderer} PROPERTIES COMPILE_DEFINITIONS "${SharedDefines}")
 
 # Hide symbols not explicitly marked public.
-set_property(TARGET ${MPVanillaRenderer} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+ojk_add_compile_options(${MPVanillaRenderer} "${OPENJK_VISIBILITY_FLAGS}")
 
 set_target_properties(${MPVanillaRenderer} PROPERTIES INCLUDE_DIRECTORIES "${MPVanillaRendererIncludeDirectories}")
 set_target_properties(${MPVanillaRenderer} PROPERTIES PROJECT_LABEL "MP Vanilla Renderer")

--- a/codemp/ui/CMakeLists.txt
+++ b/codemp/ui/CMakeLists.txt
@@ -135,7 +135,7 @@ endif()
 set_target_properties(${MPUI} PROPERTIES COMPILE_DEFINITIONS "${MPUIDefines}")
 
 # Hide symbols not explicitly marked public.
-set_property(TARGET ${MPUI} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
+ojk_add_compile_options(${MPUI} "${OPENJK_VISIBILITY_FLAGS}")
 
 set_target_properties(${MPUI} PROPERTIES INCLUDE_DIRECTORIES "${MPUIIncludeDirectories}")
 set_target_properties(${MPUI} PROPERTIES PROJECT_LABEL "MP UI Library")


### PR DESCRIPTION
This pull request is intended to fix #933 as well as its duplicates like #780.

As I have already described in #933, the root of this bug is that symbol visibility flags that had been set to fix the similar issue before were effectively (but apparently unintentionally) disabled by bace05c9b3 because of the use of build target properties that are not supported in CMake 2.8.9. The issue could have been fixed by using CMake 2.8.12 for the project builds and the corresponding update of the declared CMake minimum required version. Still, as I understand from the discussion on #933, such an upgrade is not currently acceptable because of the ensuing issues with the build server.

Considering that, I wrote a small function that resolves this problem in a way compatible with the used CMake 2.8.9 and allows to avoid using [deprecated CMake functionality](https://cmake.org/cmake/help/v3.10/prop_tgt/COMPILE_FLAGS.html) while using the latter CMake versions. This change is proposed in this pull request.

In case CMake version upgrade is done, this change can be reverted.