### PR TITLE
[SP] "Give Force" limit changed from 100, uses playermodel's max forc…

### DIFF
--- a/code/game/g_cmds.cpp
+++ b/code/game/g_cmds.cpp
@@ -196,9 +196,9 @@ void G_Give( gentity_t *ent, const char *name, const char *args, int argc )
 	if ( give_all || !Q_stricmp( name, "force" ) )
 	{
 		if ( argc == 3 )
-			ent->client->ps.forcePower = Com_Clampi( 0, FORCE_POWER_MAX, atoi( args ) );
+			ent->client->ps.forcePower = Com_Clampi( 0, ent->client->ps.forcePowerMax, atoi( args ) );
 		else
-			ent->client->ps.forcePower = FORCE_POWER_MAX;
+			ent->client->ps.forcePower = ent->client->ps.forcePowerMax;
 
 		if ( !give_all )
 			return;


### PR DESCRIPTION
…e power now

Previously, the console command "give force" only allowed the amount of force power to go up to 100 and not the actual limit of the current playermodel, because it was set to go until FORCE_POWER_MAX, which is defined as 100. Now, if you are using a playermodel with an increased amount set, that amount will be used as the maximum.