### PR TITLE
[SP] Fix vid_restart crash

### DIFF
--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -382,12 +382,14 @@ void CL_Vid_Restart_f( void ) {
 	//rww - sof2mp does this here, but it seems to cause problems in this codebase.
 //	CM_ClearMap();
 
-	CL_InitRef();
-
 	cls.rendererStarted = qfalse;
 	cls.uiStarted = qfalse;
 	cls.cgameStarted = qfalse;
 	cls.soundRegistered = qfalse;
+
+	CL_InitRef();
+
+	CL_StartHunkUsers();
 
 	// unpause so the cgame definately gets a snapshot and renders a frame
 	Cvar_Set( "cl_paused", "0" );


### PR DESCRIPTION
The renderer isn't initialized until the first frame after the restart. The game frame can run before this happens which will try to do some operations with the renderer, causing the process to crash.

Fix this by ensuring renderer is initialised immediately after being shutdown.