### PR TITLE
Add SDL2 to macOS app bundle

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -401,6 +401,12 @@ if(BuildSPEngine OR BuildJK2SPEngine)
 		endif(WIN32)
 
 		if(MakeApplicationBundles)
+			install(CODE "
+				include(BundleUtilities)
+				set(BU_CHMOD_BUNDLE_ITEMS ON)
+				fixup_bundle(\"${CMAKE_BINARY_DIR}/${ProjectName}.app\" \"\" \"\")
+				"
+				COMPONENT Runtime)
 			install(TARGETS ${ProjectName}
 				BUNDLE
 				DESTINATION ${InstallDir}

--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -579,6 +579,12 @@ if(BuildMPEngine)
 	endif(WIN32)
 
 	if(MakeApplicationBundles)
+		install(CODE "
+			include(BundleUtilities)
+			set(BU_CHMOD_BUNDLE_ITEMS ON)
+			fixup_bundle(\"${CMAKE_BINARY_DIR}/${MPEngine}.app\" \"\" \"\")
+			"
+			COMPONENT Runtime)
 		install(TARGETS ${MPEngine}
 			BUNDLE
 			DESTINATION ${JKAInstallDir}


### PR DESCRIPTION
This will make the macOS app bundle completely self-contained (as it should be), i.e. the client will not need to install SDL2 separately.