### PR TITLE
Use s_khz with SDL sound backend

### DIFF
--- a/code/client/snd_dma.cpp
+++ b/code/client/snd_dma.cpp
@@ -30,6 +30,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
  *****************************************************************************/
 #include "../server/exe_headers.h"
 
+#include "sdl/sdl_sound.h"
 #include "snd_local.h"
 #include "cl_mp3.h"
 #include "snd_music.h"
@@ -619,7 +620,7 @@ void S_Init( void ) {
 	else
 	{
 #endif
-		r = SNDDMA_Init();
+		r = SNDDMA_Init(s_khz->integer);
 
 		if ( r ) {
 			s_soundStarted = 1;

--- a/code/client/snd_local.h
+++ b/code/client/snd_local.h
@@ -184,29 +184,6 @@ typedef struct {
 	int			dataofs;		// chunk starts this many bytes from file start
 } wavinfo_t;
 
-
-
-/*
-====================================================================
-
-  SYSTEM SPECIFIC FUNCTIONS
-
-====================================================================
-*/
-
-// initializes cycling through a DMA buffer and returns information on it
-qboolean SNDDMA_Init(void);
-
-// gets the current DMA position
-int		SNDDMA_GetDMAPos(void);
-
-// shutdown the DMA xfer.
-void	SNDDMA_Shutdown(void);
-
-void	SNDDMA_BeginPainting (void);
-
-void	SNDDMA_Submit(void);
-
 //====================================================================
 
 #define	MAX_CHANNELS			32

--- a/codemp/client/snd_dma.cpp
+++ b/codemp/client/snd_dma.cpp
@@ -28,6 +28,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
  *
  *
  *****************************************************************************/
+#include "sdl/sdl_sound.h"
 #include "snd_local.h"
 #include "snd_mp3.h"
 #include "snd_music.h"
@@ -436,8 +437,6 @@ void S_SoundInfo_f(void) {
 	Com_Printf("----------------------\n" );
 }
 
-
-
 /*
 ================
 S_Init
@@ -618,7 +617,7 @@ void S_Init( void ) {
 	else
 	{
 #endif
-		r = SNDDMA_Init();
+		r = SNDDMA_Init(s_khz->integer);
 
 		if ( r ) {
 			s_soundStarted = 1;

--- a/codemp/client/snd_local.h
+++ b/codemp/client/snd_local.h
@@ -180,29 +180,6 @@ typedef struct wavinfo_s {
 	int			dataofs;		// chunk starts this many bytes from file start
 } wavinfo_t;
 
-
-
-/*
-====================================================================
-
-  SYSTEM SPECIFIC FUNCTIONS
-
-====================================================================
-*/
-
-// initializes cycling through a DMA buffer and returns information on it
-qboolean SNDDMA_Init(void);
-
-// gets the current DMA position
-int		SNDDMA_GetDMAPos(void);
-
-// shutdown the DMA xfer.
-void	SNDDMA_Shutdown(void);
-
-void	SNDDMA_BeginPainting (void);
-
-void	SNDDMA_Submit(void);
-
 //====================================================================
 
 #define	MAX_CHANNELS			32

--- a/shared/sdl/sdl_sound.cpp
+++ b/shared/sdl/sdl_sound.cpp
@@ -132,12 +132,23 @@ static void SNDDMA_PrintAudiospec(const char *str, const SDL_AudioSpec *spec)
 	Com_Printf( "  Channels: %d\n", (int) spec->channels );
 }
 
+static int SNDDMA_ExpandSampleFrequencyKHzToHz(int khz)
+{
+	switch (khz)
+	{
+		default:
+		case 44: return 44100;
+		case 22: return 22050;
+		case 11: return 11025;
+	}
+}
+
 /*
 ===============
 SNDDMA_Init
 ===============
 */
-qboolean SNDDMA_Init(void)
+qboolean SNDDMA_Init(int sampleFrequencyInKHz)
 {
 	SDL_AudioSpec desired;
 	SDL_AudioSpec obtained;
@@ -148,7 +159,6 @@ qboolean SNDDMA_Init(void)
 
 	if (!s_sdlBits) {
 		s_sdlBits = Cvar_Get("s_sdlBits", "16", CVAR_ARCHIVE_ND);
-		s_sdlSpeed = Cvar_Get("s_sdlSpeed", "0", CVAR_ARCHIVE);
 		s_sdlChannels = Cvar_Get("s_sdlChannels", "2", CVAR_ARCHIVE_ND);
 		s_sdlDevSamps = Cvar_Get("s_sdlDevSamps", "0", CVAR_ARCHIVE_ND);
 		s_sdlMixSamps = Cvar_Get("s_sdlMixSamps", "0", CVAR_ARCHIVE_ND);
@@ -176,8 +186,7 @@ qboolean SNDDMA_Init(void)
 	if ((tmp != 16) && (tmp != 8))
 		tmp = 16;
 
-	desired.freq = (int) s_sdlSpeed->value;
-	if(!desired.freq) desired.freq = 44100;
+	desired.freq = SNDDMA_ExpandSampleFrequencyKHzToHz(sampleFrequencyInKHz);
 	desired.format = ((tmp == 16) ? AUDIO_S16SYS : AUDIO_U8);
 
 	// I dunno if this is the best idea, but I'll give it a try...

--- a/shared/sdl/sdl_sound.h
+++ b/shared/sdl/sdl_sound.h
@@ -1,0 +1,35 @@
+/*
+===========================================================================
+Copyright (C) 2013 - 2018, OpenJK contributors
+
+This file is part of the OpenJK source code.
+
+OpenJK is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <http://www.gnu.org/licenses/>.
+===========================================================================
+*/
+#pragma once
+
+#include "qcommon/q_shared.h"
+
+// initializes cycling through a DMA buffer and returns information on it
+qboolean SNDDMA_Init(int sampleFrequencyInKHz);
+
+// gets the current DMA position
+int		SNDDMA_GetDMAPos(void);
+
+// shutdown the DMA xfer.
+void	SNDDMA_Shutdown(void);
+
+void	SNDDMA_BeginPainting (void);
+
+void	SNDDMA_Submit(void);


### PR DESCRIPTION
And remove `s_sdlSpeed`. This lets the 'Sound Quality' option in the menu work again.