### PR TITLE
JK2: Remove mismatched allocator from std::map typedefs

### DIFF
--- a/codeJK2/cgame/cg_main.cpp
+++ b/codeJK2/cgame/cg_main.cpp
@@ -31,7 +31,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "../code/qcommon/ojk_saved_game_helper.h"
 
 //NOTENOTE: Be sure to change the mirrored code in g_shared.h
-typedef std::map< sstring_t, unsigned char, std::less<sstring_t>, std::allocator< unsigned char >  >	namePrecache_m;
+typedef std::map< sstring_t, unsigned char, std::less<sstring_t> >	namePrecache_m;
 extern namePrecache_m	*as_preCacheMap;
 extern void CG_RegisterNPCCustomSounds( clientInfo_t *ci );
 extern qboolean G_AddSexToMunroString ( char *string, qboolean qDoBoth );

--- a/codeJK2/game/g_local.h
+++ b/codeJK2/game/g_local.h
@@ -634,8 +634,8 @@ typedef struct pscript_s
 	long	length;
 } pscript_t;
 
-typedef std::map < std::string, int, std::less<std::string>, std::allocator<int> >		entlist_t;
-typedef std::map < std::string, pscript_t*, std::less<std::string>, std::allocator<pscript_t*> >	bufferlist_t;
+typedef std::map < std::string, int, std::less<std::string> >		entlist_t;
+typedef std::map < std::string, pscript_t*, std::less<std::string> >	bufferlist_t;
 
 
 extern char *G_NewString( const char *string );

--- a/codeJK2/game/g_spawn.cpp
+++ b/codeJK2/game/g_spawn.cpp
@@ -39,7 +39,7 @@ char		spawnVarChars[MAX_SPAWN_VARS_CHARS];
 #include "../../code/qcommon/sstring.h"
 
 //NOTENOTE: Be sure to change the mirrored code in cgmain.cpp
-typedef std::map< sstring_t, unsigned char, std::less<sstring_t>, std::allocator< unsigned char >  >	namePrecache_m;
+typedef std::map< sstring_t, unsigned char, std::less<sstring_t> >	namePrecache_m;
 namePrecache_m	*as_preCacheMap;
 
 qboolean	G_SpawnString( const char *key, const char *defaultString, char **out ) {

--- a/scripts/travis/install.sh
+++ b/scripts/travis/install.sh
@@ -8,7 +8,8 @@ shift 1
 
 # macOS is special
 if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-	brew install libpng sdl2 --universal
+	brew upgrade
+	brew install --universal --verbose libpng sdl2
 	exit 0
 fi
 


### PR DESCRIPTION
The Allocator is meant to be one that is suitable for allocating
std::pair<key, value> instances, not value instances, and the
Standard C++ library provided by gcc 8 asserts that the types match.
The closest valid allocator here would be
std::allocator<std::pair<key, value>>, but that is the default for
this template anyway, so we can just omit it.

Closes: https://github.com/JACoders/OpenJK/issues/985  
Bug-Debian: https://bugs.debian.org/905477  
Signed-off-by: Simon McVittie <smcv@debian.org>