### PR TITLE
Removed superfluous code to determine the number of compressed bones.

### DIFF
--- a/code/rd-common/mdx_format.h
+++ b/code/rd-common/mdx_format.h
@@ -432,10 +432,11 @@ typedef struct {
 	//
 	// (iFrameNum * mdxaHeader_t->numBones * 3) + (iBoneNum * 3)
 	//
-	//  then read the int at that location and AND it with 0x00FFFFFF. I use the struct below simply for easy searches
+	// Then convert the three byte int at that location.
+	// This struct is used for easy searches.
 	typedef struct
 	{
-		int iIndex;	// this struct for pointing purposes, need to and with 0x00FFFFFF to be meaningful
+		byte    iIndex[3];
 	} mdxaIndex_t;
 	//
 	// (note that there's then an alignement-pad here to get the next struct back onto 32-bit alignement)

--- a/code/rd-vanilla/tr_ghoul2.cpp
+++ b/code/rd-vanilla/tr_ghoul2.cpp
@@ -3909,26 +3909,10 @@ qboolean R_LoadMDXA( model_t *mod, void *buffer, const char *mod_name, qboolean 
 		}
 	}
 
-	// find the largest index, since the actual number of compressed bone pools is not stored anywhere
-	for ( i = 0 ; i < mdxa->numFrames ; i++ )
-	{
-		for ( j = 0 ; j < mdxa->numBones ; j++ )
-		{
-			k = (i * mdxa->numBones * 3) + (j * 3); // iOffsetToIndex
-			pIndex = (mdxaIndex_t *) ((byte*) mdxa + mdxa->ofsFrames + k);
-
-			// 3 byte ints, yeah...
-			int tmp = pIndex->iIndex & 0xFFFFFF00;
-			LL(tmp);
-
-			if (maxBoneIndex < tmp)
-				maxBoneIndex = tmp;
-		}
-	}
-
 	// swap the compressed bones
-	pCompBonePool = (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
-	for ( i = 0 ; i <= maxBoneIndex ; i++ )
+	maxBoneIndex	= (mdxa->ofsEnd - mdxa->ofsCompBonePool) / sizeof(mdxaCompQuatBone_t);
+	pCompBonePool	= (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
+	for ( i = 0 ; i < maxBoneIndex ; i++ )
 	{
 		pwIn = (unsigned short *) pCompBonePool[i].Comp;
 

--- a/code/rd-vanilla/tr_ghoul2.cpp
+++ b/code/rd-vanilla/tr_ghoul2.cpp
@@ -3820,7 +3820,6 @@ qboolean R_LoadMDXA( model_t *mod, void *buffer, const char *mod_name, qboolean 
 	int					maxBoneIndex = 0;
 	mdxaCompQuatBone_t	*pCompBonePool;
 	unsigned short		*pwIn;
-	mdxaIndex_t			*pIndex;
 #endif
 
  	pinmodel = (mdxaHeader_t *)buffer;
@@ -3909,9 +3908,35 @@ qboolean R_LoadMDXA( model_t *mod, void *buffer, const char *mod_name, qboolean 
 		}
 	}
 
-	// swap the compressed bones
-	maxBoneIndex	= (mdxa->ofsEnd - mdxa->ofsCompBonePool) / sizeof(mdxaCompQuatBone_t);
-	pCompBonePool	= (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
+	// Determine the amount of compressed bones.
+	if(mdxa->version == 6){
+		// Official MDXA version. The compressed bone pool always resides
+		// at the end of the file.
+		maxBoneIndex = (mdxa->ofsEnd - mdxa->ofsCompBonePool) / sizeof(mdxaCompQuatBone_t);
+	}else{
+		// Find the largest index by iterating through all frames.
+		// It is not guaranteed that the compressed bone pool still resides
+		// at the end of the file for any future MDXA version.
+		byte    *pIndex;
+		int     tmp;
+
+		for(i = 0; i < mdxa->numFrames; i++){
+			for(j = 0; j < mdxa->numBones; j++){
+				k       = (i * mdxa->numBones * 3) + (j * 3);	// iOffsetToIndex
+				pIndex  = ((byte *)mdxa + mdxa->ofsFrames + k);
+				tmp     = (pIndex[2] << 16) + (pIndex[1] << 8) + (pIndex[0]);
+
+				if(maxBoneIndex < tmp){
+					maxBoneIndex = tmp;
+				}
+			}
+		}
+
+		maxBoneIndex++;
+	}
+
+	// Swap the compressed bones.
+	pCompBonePool = (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
 	for ( i = 0 ; i < maxBoneIndex ; i++ )
 	{
 		pwIn = (unsigned short *) pCompBonePool[i].Comp;

--- a/code/rd-vanilla/tr_ghoul2.cpp
+++ b/code/rd-vanilla/tr_ghoul2.cpp
@@ -925,21 +925,15 @@ void Multiply_3x4Matrix(mdxaBone_t *out,const  mdxaBone_t *in2,const mdxaBone_t 
 	out->matrix[2][3] = (in2->matrix[2][0] * in->matrix[0][3]) + (in2->matrix[2][1] * in->matrix[1][3]) + (in2->matrix[2][2] * in->matrix[2][3]) + in2->matrix[2][3];
 }
 
-static int G2_GetBonePoolIndex(	const mdxaHeader_t *pMDXAHeader, int iFrame, int iBone)
+static int G2_GetBonePoolIndex(const mdxaHeader_t *pMDXAHeader, int iFrame, int iBone)
 {
 	assert(iFrame>=0&&iFrame<pMDXAHeader->numFrames);
 	assert(iBone>=0&&iBone<pMDXAHeader->numBones);
-	const int iOffsetToIndex = (iFrame * pMDXAHeader->numBones * 3) + (iBone * 3);
 
-	mdxaIndex_t *pIndex = (mdxaIndex_t *) ((byte*) pMDXAHeader + pMDXAHeader->ofsFrames + iOffsetToIndex);
+	const int iOffsetToIndex	= (iFrame * pMDXAHeader->numBones * 3) + (iBone * 3);
+	mdxaIndex_t *pIndex			= (mdxaIndex_t *)((byte*)pMDXAHeader + pMDXAHeader->ofsFrames + iOffsetToIndex);
 
-#ifdef Q3_BIG_ENDIAN
-	int tmp = pIndex->iIndex & 0xFFFFFF00;
-	LL(tmp);
-	return tmp;
-#else
-	return pIndex->iIndex & 0x00FFFFFF;
-#endif
+	return (pIndex->iIndex[2] << 16) + (pIndex->iIndex[1] << 8) + (pIndex->iIndex[0]);
 }
 
 
@@ -3820,6 +3814,8 @@ qboolean R_LoadMDXA( model_t *mod, void *buffer, const char *mod_name, qboolean 
 	int					maxBoneIndex = 0;
 	mdxaCompQuatBone_t	*pCompBonePool;
 	unsigned short		*pwIn;
+	mdxaIndex_t			*pIndex;
+	int					tmp;
 #endif
 
  	pinmodel = (mdxaHeader_t *)buffer;
@@ -3909,35 +3905,25 @@ qboolean R_LoadMDXA( model_t *mod, void *buffer, const char *mod_name, qboolean 
 	}
 
 	// Determine the amount of compressed bones.
-	if(mdxa->version == 6){
-		// Official MDXA version. The compressed bone pool always resides
-		// at the end of the file.
-		maxBoneIndex = (mdxa->ofsEnd - mdxa->ofsCompBonePool) / sizeof(mdxaCompQuatBone_t);
-	}else{
-		// Find the largest index by iterating through all frames.
-		// It is not guaranteed that the compressed bone pool still resides
-		// at the end of the file for any future MDXA version.
-		byte    *pIndex;
-		int     tmp;
 
-		for(i = 0; i < mdxa->numFrames; i++){
-			for(j = 0; j < mdxa->numBones; j++){
-				k       = (i * mdxa->numBones * 3) + (j * 3);	// iOffsetToIndex
-				pIndex  = ((byte *)mdxa + mdxa->ofsFrames + k);
-				tmp     = (pIndex[2] << 16) + (pIndex[1] << 8) + (pIndex[0]);
+	// Find the largest index by iterating through all frames.
+	// It is not guaranteed that the compressed bone pool resides
+	// at the end of the file.
+	for(i = 0; i < mdxa->numFrames; i++){
+		for(j = 0; j < mdxa->numBones; j++){
+			k		= (i * mdxa->numBones * 3) + (j * 3);	// iOffsetToIndex
+			pIndex	= (mdxaIndex_t *) ((byte *)mdxa + mdxa->ofsFrames + k);
+			tmp		= (pIndex->iIndex[2] << 16) + (pIndex->iIndex[1] << 8) + (pIndex->iIndex[0]);
 
-				if(maxBoneIndex < tmp){
-					maxBoneIndex = tmp;
-				}
+			if(maxBoneIndex < tmp){
+				maxBoneIndex = tmp;
 			}
 		}
-
-		maxBoneIndex++;
 	}
 
 	// Swap the compressed bones.
 	pCompBonePool = (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
-	for ( i = 0 ; i < maxBoneIndex ; i++ )
+	for ( i = 0 ; i <= maxBoneIndex ; i++ )
 	{
 		pwIn = (unsigned short *) pCompBonePool[i].Comp;
 

--- a/codemp/rd-common/mdx_format.h
+++ b/codemp/rd-common/mdx_format.h
@@ -417,10 +417,11 @@ typedef struct mdxaHeader_s {
 	//
 	// (iFrameNum * mdxaHeader_t->numBones * 3) + (iBoneNum * 3)
 	//
-	//  then read the int at that location and AND it with 0x00FFFFFF. I use the struct below simply for easy searches
+	// Then convert the three byte int at that location.
+	// This struct is used for easy searches.
 	typedef struct
 	{
-		int iIndex;	// this struct for pointing purposes, need to and with 0x00FFFFFF to be meaningful
+		byte    iIndex[3];
 	} mdxaIndex_t;
 	//
 	// (note that there's then an alignement-pad here to get the next struct back onto 32-bit alignement)

--- a/codemp/rd-dedicated/tr_ghoul2.cpp
+++ b/codemp/rd-dedicated/tr_ghoul2.cpp
@@ -915,13 +915,12 @@ void Multiply_3x4Matrix(mdxaBone_t *out, mdxaBone_t *in2, mdxaBone_t *in)
 }
 
 
-static int G2_GetBonePoolIndex(	const mdxaHeader_t *pMDXAHeader, int iFrame, int iBone)
+static int G2_GetBonePoolIndex(const mdxaHeader_t *pMDXAHeader, int iFrame, int iBone)
 {
-	const int iOffsetToIndex = (iFrame * pMDXAHeader->numBones * 3) + (iBone * 3);
+	const int iOffsetToIndex	= (iFrame * pMDXAHeader->numBones * 3) + (iBone * 3);
+	mdxaIndex_t *pIndex			= (mdxaIndex_t *)((byte*)pMDXAHeader + pMDXAHeader->ofsFrames + iOffsetToIndex);
 
-	mdxaIndex_t *pIndex = (mdxaIndex_t *) ((byte*) pMDXAHeader + pMDXAHeader->ofsFrames + iOffsetToIndex);
-
-	return pIndex->iIndex & 0x00FFFFFF;	// this will cause problems for big-endian machines... ;-)
+	return (pIndex->iIndex[2] << 16) + (pIndex->iIndex[1] << 8) + (pIndex->iIndex[0]);
 }
 
 

--- a/codemp/rd-vanilla/tr_ghoul2.cpp
+++ b/codemp/rd-vanilla/tr_ghoul2.cpp
@@ -4875,26 +4875,10 @@ qboolean R_LoadMDXA( model_t *mod, void *buffer, const char *mod_name, qboolean 
 		}
 	}
 
-	// find the largest index, since the actual number of compressed bone pools is not stored anywhere
-	for ( i = 0 ; i < mdxa->numFrames ; i++ )
-	{
-		for ( j = 0 ; j < mdxa->numBones ; j++ )
-		{
-			k = (i * mdxa->numBones * 3) + (j * 3); // iOffsetToIndex
-			pIndex = (mdxaIndex_t *) ((byte*) mdxa + mdxa->ofsFrames + k);
-
-			// 3 byte ints, yeah...
-			int tmp = pIndex->iIndex & 0xFFFFFF00;
-			LL(tmp);
-
-			if (maxBoneIndex < tmp)
-				maxBoneIndex = tmp;
-		}
-	}
-
 	// swap the compressed bones
-	pCompBonePool = (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
-	for ( i = 0 ; i <= maxBoneIndex ; i++ )
+	maxBoneIndex	= (mdxa->ofsEnd - mdxa->ofsCompBonePool) / sizeof(mdxaCompQuatBone_t);
+	pCompBonePool	= (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
+	for ( i = 0 ; i < maxBoneIndex ; i++ )
 	{
 		pwIn = (unsigned short *) pCompBonePool[i].Comp;
 

--- a/codemp/rd-vanilla/tr_model.cpp
+++ b/codemp/rd-vanilla/tr_model.cpp
@@ -767,26 +767,10 @@ qboolean ServerLoadMDXA( model_t *mod, void *buffer, const char *mod_name, qbool
 		}
 	}
 
-	// find the largest index, since the actual number of compressed bone pools is not stored anywhere
-	for ( i = 0 ; i < mdxa->numFrames ; i++ )
-	{
-		for ( j = 0 ; j < mdxa->numBones ; j++ )
-		{
-			k = (i * mdxa->numBones * 3) + (j * 3); // iOffsetToIndex
-			pIndex = (mdxaIndex_t *) ((byte*) mdxa + mdxa->ofsFrames + k);
-
-			// 3 byte ints, yeah...
-			int tmp = pIndex->iIndex & 0xFFFFFF00;
-			LL(tmp);
-
-			if (maxBoneIndex < tmp)
-				maxBoneIndex = tmp;
-		}
-	}
-
 	// swap the compressed bones
-	pCompBonePool = (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
-	for ( i = 0 ; i <= maxBoneIndex ; i++ )
+	maxBoneIndex	= (mdxa->ofsEnd - mdxa->ofsCompBonePool) / sizeof(mdxaCompQuatBone_t);
+	pCompBonePool	= (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
+	for ( i = 0 ; i < maxBoneIndex ; i++ )
 	{
 		pwIn = (unsigned short *) pCompBonePool[i].Comp;
 

--- a/codemp/rd-vanilla/tr_model.cpp
+++ b/codemp/rd-vanilla/tr_model.cpp
@@ -681,7 +681,6 @@ qboolean ServerLoadMDXA( model_t *mod, void *buffer, const char *mod_name, qbool
 	int					maxBoneIndex = 0;
 	mdxaCompQuatBone_t	*pCompBonePool;
 	unsigned short		*pwIn;
-	mdxaIndex_t			*pIndex;
 #endif
 
  	pinmodel = (mdxaHeader_t *)buffer;
@@ -767,9 +766,35 @@ qboolean ServerLoadMDXA( model_t *mod, void *buffer, const char *mod_name, qbool
 		}
 	}
 
-	// swap the compressed bones
-	maxBoneIndex	= (mdxa->ofsEnd - mdxa->ofsCompBonePool) / sizeof(mdxaCompQuatBone_t);
-	pCompBonePool	= (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
+	// Determine the amount of compressed bones.
+	if(mdxa->version == 6){
+		// Official MDXA version. The compressed bone pool always resides
+		// at the end of the file.
+		maxBoneIndex = (mdxa->ofsEnd - mdxa->ofsCompBonePool) / sizeof(mdxaCompQuatBone_t);
+	}else{
+		// Find the largest index by iterating through all frames.
+		// It is not guaranteed that the compressed bone pool still resides
+		// at the end of the file for any future MDXA version.
+		byte    *pIndex;
+		int     tmp;
+
+		for(i = 0; i < mdxa->numFrames; i++){
+			for(j = 0; j < mdxa->numBones; j++){
+				k       = (i * mdxa->numBones * 3) + (j * 3);	// iOffsetToIndex
+				pIndex  = ((byte *)mdxa + mdxa->ofsFrames + k);
+				tmp     = (pIndex[2] << 16) + (pIndex[1] << 8) + (pIndex[0]);
+
+				if(maxBoneIndex < tmp){
+					maxBoneIndex = tmp;
+				}
+			}
+		}
+
+		maxBoneIndex++;
+	}
+
+	// Swap the compressed bones.
+	pCompBonePool = (mdxaCompQuatBone_t *) ((byte *)mdxa + mdxa->ofsCompBonePool);
 	for ( i = 0 ; i < maxBoneIndex ; i++ )
 	{
 		pwIn = (unsigned short *) pCompBonePool[i].Comp;


### PR DESCRIPTION
The compressed bone pool of a Ghoul II animation file (MDXA, .gla) is always
stored at the end of the file. It is unnecessary to iterate through all frames
to determine the number of compressed bones present on big-endian machines.

This change is applied to the vanilla renderers of the single- and multiplayer
code of JK:JA.