### PR TITLE
Steam Integration.

### DIFF
--- a/code/qcommon/common.cpp
+++ b/code/qcommon/common.cpp
@@ -1077,6 +1077,8 @@ void Com_Init( char *commandLine ) {
 		FS_InitFilesystem ();	//uses z_malloc
 		//re.R_InitWorldEffects();   // this doesn't do much but I want to be sure certain variables are intialized.
 
+		Sys_SteamInit();
+
 		Com_ExecuteCfg();
 
 		// override anything from the config files with command line args
@@ -1579,6 +1581,8 @@ void Com_Shutdown (void) {
 		FS_FCloseFile( com_journalFile );
 		com_journalFile = 0;
 	}
+
+	Sys_SteamShutdown();
 
 #ifdef JK2_MODE
 	JK2SP_Shutdown();

--- a/codemp/qcommon/common.cpp
+++ b/codemp/qcommon/common.cpp
@@ -1167,6 +1167,8 @@ void Com_Init( char *commandLine ) {
 
 		FS_InitFilesystem ();
 
+		Sys_SteamInit();
+
 		Com_InitJournaling();
 
 		// Add some commands here already so users can use them from config files
@@ -1675,6 +1677,8 @@ void Com_Shutdown (void)
 		FS_FCloseFile( com_journalFile );
 		com_journalFile = 0;
 	}
+
+	Sys_SteamShutdown();
 
 	MSG_shutdownHuffman();
 /*

--- a/shared/sys/sys_local.h
+++ b/shared/sys/sys_local.h
@@ -38,6 +38,10 @@ void		Sys_SigHandler( int signal );
 void		Sys_AnsiColorPrint( const char *msg );
 #endif
 
+// Steam integration
+void		Sys_SteamInit();
+void		Sys_SteamShutdown();
+
 struct UnpackDLLResult
 {
 	bool succeeded;

--- a/shared/sys/sys_unix.cpp
+++ b/shared/sys/sys_unix.cpp
@@ -608,3 +608,25 @@ void Sys_AnsiColorPrint( const char *msg )
 		fputs( buffer, stderr );
 	}
 }
+
+/*
+================
+Sys_SteamInit
+
+Only Windows has this feature at the moment.
+================
+*/
+void Sys_SteamInit()
+{
+}
+
+/*
+================
+Sys_SteamShutdown
+
+Only Windows has this feature at the moment.
+================
+*/
+void Sys_SteamShutdown()
+{
+}

--- a/shared/sys/sys_win32.cpp
+++ b/shared/sys/sys_win32.cpp
@@ -20,6 +20,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 */
 
 #include "sys_local.h"
+#include "sys_loadlib.h"
 #include <direct.h>
 #include <io.h>
 #include <shlobj.h>
@@ -589,4 +590,88 @@ void Sys_Sleep( int msec )
 
 	Sleep( msec );
 #endif
+}
+
+/*
+================
+Sys_SteamInit
+
+Steam initialization is done here.
+In order for Steam to work, two things are needed:
+- steam_api.dll (not included with retail Jedi Academy or Jedi Outcast!)
+- steam_appid.txt (likewise)
+steam_appid.txt is a text file containing either "6020" or "6030".
+These correspond to Jedi Academy and Jedi Outcast, respectively.
+
+Steamworks SDK is required to use the playtime tracking and overlay features
+without launching the app manually through Steam.
+Unfortunately, the SDK does not play nice with copyleft licenses.
+Fortunately! we can invoke the library directly and avoid this entirely,
+provided the end-user has the goods.
+Unfortunately! this is platform specific and so we have to do it here.
+================
+*/
+
+typedef bool(__stdcall* SteamAPIInit_Type)();
+typedef void(__stdcall* SteamAPIShutdown_Type)();
+static SteamAPIInit_Type SteamAPI_Init;
+static SteamAPIShutdown_Type SteamAPI_Shutdown;
+static void* gp_steamLibrary = nullptr;
+
+void Sys_SteamInit()
+{
+	if (!Cvar_VariableIntegerValue("com_steamIntegration"))
+	{
+		// Don't do anything if com_steamIntegration is disabled
+		return;
+	}
+
+	// Load the library
+	gp_steamLibrary = Sys_LoadLibrary("steam_api" DLL_EXT);
+	if (!gp_steamLibrary)
+	{
+		Com_Printf(S_COLOR_RED "Steam integration failed: Couldn't find steam_api" DLL_EXT "\n");
+		return;
+	}
+
+	// Load the functions
+	SteamAPI_Init = (SteamAPIInit_Type)Sys_LoadFunction(gp_steamLibrary, "SteamAPI_Init");
+	SteamAPI_Shutdown = (SteamAPIShutdown_Type)Sys_LoadFunction(gp_steamLibrary, "SteamAPI_Shutdown");
+
+	if (!SteamAPI_Shutdown || !SteamAPI_Init)
+	{
+		Com_Printf(S_COLOR_RED "Steam integration failed: Library invalid\n");
+		Sys_UnloadLibrary(gp_steamLibrary);
+		gp_steamLibrary = nullptr;
+		return;
+	}
+
+	// Finally, call the init function in Steam, which should pop up the overlay if everything went correctly
+	if (!SteamAPI_Init())
+	{
+		Com_Printf(S_COLOR_RED "Steam integration failed: Steam init failed. Ensure steam_appid.txt exists and is valid.\n");
+		Sys_UnloadLibrary(gp_steamLibrary);
+		gp_steamLibrary = nullptr;
+		return;
+	}
+}
+
+/*
+================
+Sys_SteamShutdown
+
+Platform-specific exit code
+================
+*/
+void Sys_SteamShutdown()
+{
+	if (!gp_steamLibrary)
+	{
+		Com_Printf("Skipping Steam integration shutdown...\n");
+		return;
+	}
+
+	SteamAPI_Shutdown();
+	Sys_UnloadLibrary(gp_steamLibrary);
+	gp_steamLibrary = nullptr;
 }


### PR DESCRIPTION
Only works on Windows. If com_steamIntegration is 1 on startup (maybe it can default to 1?), the game will look for a steam_api.dll and steam_appid.txt and attempt to initialize the Steam API. With an extra download of these two files, one can have the Steam Overlay and hours tracking without launching OpenJK through Steam itself.