### PR TITLE
ROFF2 bug fixes

### DIFF
--- a/code/game/g_roff.cpp
+++ b/code/game/g_roff.cpp
@@ -28,6 +28,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "g_functions.h"
 #include "qcommon/ojk_saved_game_helper.h"
 
+
 // The list of precached ROFFs
 roff_list_t	roffs[MAX_ROFFS];
 int			num_roffs = 0;
@@ -35,6 +36,7 @@ int			num_roffs = 0;
 qboolean g_bCollidableRoffs = qfalse;
 
 extern void	Q3_TaskIDComplete( gentity_t *ent, taskID_t taskType );
+
 
 static void G_RoffNotetrackCallback( gentity_t *ent, const char *notetrack)
 {
@@ -277,17 +279,21 @@ defaultoffsetposition:
 			useOrigin[1] += up[1]*parsedOffset[2];
 			useOrigin[2] += up[2]*parsedOffset[2];
 
-#if !NDEBUG
-			Com_Printf(S_COLOR_GREEN"NoteTrack:  \"%s\"\n", notetrack);
-#endif
+			if (g_developer->integer)
+			{
+				Com_Printf(S_COLOR_GREEN "NoteTrack:  \"%s\"\n", notetrack);
+			}
+
 			G_PlayEffect(objectID, useOrigin, useAngles);
 		}
 	}
 	else if (strcmp(type, "sound") == 0)
 	{
-#if !NDEBUG
-		Com_Printf(S_COLOR_GREEN"NoteTrack:  \"%s\"\n", notetrack);
-#endif
+		if (g_developer->integer)
+		{
+			Com_Printf(S_COLOR_GREEN "NoteTrack:  \"%s\"\n", notetrack);
+		}
+
 		//check for eType and play the sound
 		if (ent->s.eType == ET_MOVER)
 		{
@@ -304,9 +310,11 @@ defaultoffsetposition:
         //try to cache the script
         Quake3Game()->PrecacheScript(argument);
 
-#if !NDEBUG
-		Com_Printf(S_COLOR_GREEN"NoteTrack:  \"%s\"\n", notetrack);
-#endif
+		if (g_developer->integer)
+		{
+			Com_Printf(S_COLOR_GREEN "NoteTrack:  \"%s\"\n", notetrack);
+		}
+
         //run the IBI script
         Quake3Game()->RunScript(ent, argument);
     }
@@ -349,9 +357,11 @@ defaultoffsetposition:
 			//Re-link entity
 			gi.linkentity(ent);
 
-#if !NDEBUG
-			Com_Printf(S_COLOR_GREEN"NoteTrack:  \"%s\"\n", notetrack);
-#endif
+			if (g_developer->integer)
+			{
+				Com_Printf(S_COLOR_GREEN "NoteTrack:  \"%s\"\n", notetrack);
+			}
+
 			// Re-apply the ROFF
 			G_Roff(ent);
 		}
@@ -376,9 +386,10 @@ defaultoffsetposition:
 			if (r2 && strstr(teststr, "kill"))
 			{ // kill the looping sound
 				ent->s.loopSound = 0;
-#if !NDEBUG
-				Com_Printf(S_COLOR_GREEN"NoteTrack:  \"%s\"\n", notetrack);
-#endif
+				if (g_developer->integer)
+				{
+					Com_Printf(S_COLOR_GREEN "NoteTrack:  \"%s\"\n", notetrack);
+				}
 			}
 			else if (r2 && strstr(teststr, "sound"))
 			{ // OK... we should have a relative sound path
@@ -389,9 +400,10 @@ defaultoffsetposition:
 					if (objectID)
 					{
 						ent->s.loopSound = objectID;
-#if !NDEBUG
-						Com_Printf(S_COLOR_GREEN"NoteTrack:  \"%s\"\n", notetrack);
-#endif
+						if (g_developer->integer)
+						{
+							Com_Printf(S_COLOR_GREEN "NoteTrack:  \"%s\"\n", notetrack);
+						}
 					}
 					else
 					{
@@ -403,9 +415,10 @@ defaultoffsetposition:
 				else
 				{
 					ent->s.loopSound = G_SoundIndex(addlArg);
-#if !NDEBUG
-					Com_Printf(S_COLOR_GREEN"NoteTrack:  \"%s\"\n", notetrack);
-#endif
+					if (g_developer->integer)
+					{
+						Com_Printf(S_COLOR_GREEN "NoteTrack:  \"%s\"\n", notetrack);
+					}
 				}
 			}
 			else

--- a/code/game/g_roff.cpp
+++ b/code/game/g_roff.cpp
@@ -62,16 +62,19 @@ static void G_RoffNotetrackCallback( gentity_t *ent, const char *notetrack)
 	//Examples:
 	//effect notetrack format:		effect <relative_filepath.efx> [originOffset] [rotationOffset]
 	//					notetrack = "effect effects/explosion1.efx 0+0+64 0-0-1";
-	//the '+' and '-' are delimiters and not positive/negative signs. For example, negative origin offset would be: -10+-20+-10
-	//angles are expected to be from 0 to 360, i.e., no negative angles.
-	//optional additional argument for rotationOffset requires the originOffset preceding it.
+	//'effect' notes:
+	//		(1) the '+' and '-' are delimiters and not positive/negative signs. For example, negative origin offset would be: -10+-20+-10
+	//		(2) angles are expected to be from 0 to 360, i.e., no negative angles.
+	//		(3) optional additional argument for rotationOffset requires the originOffset preceding it.
 	//
 	//
 	//sound notetrack format:		sound <relative_soundfilepath.ext>
 	//					notetrack =	"sound sound/vehicles/tie/flyby2.mp3";
+	//'sound' notes:
+	//		(1) supported sound file formats are: .mp3, .wav
 	//
 	//
-	//USE notetrack format =	<USE> <IBI_ScriptName_noExt>
+	//USE notetrack format:			USE <IBI_ScriptName_noExt>
 	//					notetrack = "USE airborne";
 	//
 	//
@@ -82,11 +85,11 @@ static void G_RoffNotetrackCallback( gentity_t *ent, const char *notetrack)
 	//					notetrack = "loop sfx sound/vehicles/tie/loop.wav";
 	//					notetrack = "loop sfx kill";
 	//'loop rof' notes:  
-	//		absolute ==> reset rof to original delta position/rotation world location before looping.
-	//		relative ==> reset rof to original delta position/rotation at current location before looping.
+	//		(1) absolute ==> reset rof to original delta position/rotation world location before looping.
+	//		(2) relative ==> reset rof to original delta position/rotation at current location before looping.
 	//'loop sfx' notes:
-	//		adds a sound to be looped which gets assigned to the entitystate's loopSound parameter.
-	//		addlArg 'kill' -- kills the looping sound by setting entitystate's loopSound to zero.
+	//		(1) adds a sound to be looped which gets assigned to the entitystate's loopSound parameter.
+	//		(2) addlArg 'kill' -- kills the looping sound by setting entitystate's loopSound equal to zero.
 	//
 	//////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -411,24 +414,29 @@ defaultoffsetposition:
 				goto functionend;
 			}
 		}
+		else
+		{
+			sprintf(errMsg, "Invalid argument <%s> for type 'loop' notetrack.", argument);
+			goto functionend;
+		}
 	}
 	//else if ...
 	else
 	{
 		if (type[0])
 		{
-			Com_Printf("Warning: \"%s\" is an invalid ROFF NoteTrack function\n", type);
+			Com_Printf(S_COLOR_YELLOW"Warning: \"%s\" is an invalid ROFF NoteTrack function\n", type);
 		}
 		else
 		{
-			Com_Printf("Warning: NoteTrack is missing function and/or arguments\n");
+			Com_Printf(S_COLOR_YELLOW"Warning: NoteTrack is missing function and/or arguments\n");
 		}
 	}
 
 	return;
 
 functionend:
-	Com_Printf("Type-specific NoteTrack error: %s\n", errMsg);
+	Com_Printf(S_COLOR_RED"Type-specific NoteTrack error: %s\n", errMsg);
 	return;
 }
 
@@ -556,18 +564,18 @@ static void G_CacheRoffNoteTracks(const char *notetrack)
     {
         if (type[0])
         {
-            Com_Printf("Warning: \"%s\" is an invalid ROFF NoteTrack function\n", type);
+            Com_Printf(S_COLOR_YELLOW"Warning: \"%s\" is an invalid ROFF NoteTrack function\n", type);
         }
         else
         {
-            Com_Printf("Warning: NoteTrack is missing function and/or arguments\n");
+            Com_Printf(S_COLOR_YELLOW"Warning: NoteTrack is missing function and/or arguments\n");
         }
     }
 
     return;
 	
 functionend:
-	Com_Printf("Type-specific NoteTrack error: %s\n", errMsg);
+	Com_Printf(S_COLOR_RED"Type-specific NoteTrack error: %s\n", errMsg);
 	return;
 }
 

--- a/code/game/g_roff.cpp
+++ b/code/game/g_roff.cpp
@@ -24,7 +24,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "g_roff.h"
 #include "Q3_Interface.h"
 #include "../cgame/cg_local.h"
-#include "../cgame/cg_media.h" //needed for fixing ROFF2 sounds
+#include "../cgame/cg_media.h"
 #include "g_functions.h"
 #include "qcommon/ojk_saved_game_helper.h"
 
@@ -65,7 +65,7 @@ static void G_RoffNotetrackCallback( gentity_t *ent, const char *notetrack)
 	//effect notetrack format:		effect <relative_effectfilepath.efx> [originOffset] [rotationOffset]
 	//					notetrack = "effect effects/explosion1.efx 0+0+64 0-0-1";
 	//'effect' notes:
-	//		(1) the '+' and '-' are delimiters and not positive/negative signs. For example, negative origin offset would be: -10+-20+-10
+	//		(1) the '+' and '-' are delimiters and not positive/negative signs; e.g., negative origin offset would be: -10+-20+-10
 	//		(2) angles are expected to be from 0 to 360, i.e., no negative angles.
 	//		(3) optional additional argument for rotationOffset requires the originOffset preceding it.
 	//
@@ -305,19 +305,19 @@ defaultoffsetposition:
 			G_SoundOnEnt(ent, CHAN_BODY, argument);
 		}
 	}
-    else if (strcmp(type, "USE") == 0)
-    {	
-        //try to cache the script
-        Quake3Game()->PrecacheScript(argument);
+	else if (strcmp(type, "USE") == 0)
+	{
+		//try to cache the script
+		Quake3Game()->PrecacheScript(argument);
 
 		if (g_developer->integer)
 		{
 			Com_Printf(S_COLOR_GREEN "NoteTrack:  \"%s\"\n", notetrack);
 		}
 
-        //run the IBI script
-        Quake3Game()->RunScript(ent, argument);
-    }
+		//run the IBI script
+		Quake3Game()->RunScript(ent, argument);
+	}
 	else if (strcmp(type, "loop") == 0)
 	{
 		if (strcmp(argument, "rof") == 0)


### PR DESCRIPTION
Fixes for issues #1002 and #1003.  Additional ROFF2 Notetrack enhancements-- added support for new Notetrack types:  USE, loop


Supported notetrack types:    effect, sound, USE, loop

General notetrack format:        \<type\> \<argument\> [additionalArguments]
Note: <> denote required argument, [ ] denote optional argument, | denotes argument choices

Examples:
effect notetrack format:        effect <relative_effectfilepath.efx> [originOffset] [rotationOffset]
                    notetrack = "effect effects/explosion1.efx 0+0+64 0-0-1";
'effect' notes:
        (1) the '+' and '-' are delimiters and not positive/negative signs. For example, negative origin offset would be: -10+-20+-10
        (2) angles are expected to be from 0 to 360, i.e., no negative angles.
        (3) optional additional argument for rotationOffset requires the originOffset preceding it.

sound notetrack format:        sound <relative_soundfilepath.ext>
                    notetrack =    "sound sound/vehicles/tie/flyby2.mp3";
'sound' notes:
         (1) supported sound file formats are: .mp3, .wav

USE notetrack format:            USE <relative_scriptfilepath_noExt>
                    notetrack = "USE shuttlemap/shuttletakeoff";

loop notetrack format:        loop rof < absolute | relative >
                                          loop sfx < relative_soundfilepath.ext | kill >
                    notetrack = "loop rof absolute";
                    notetrack = "loop rof relative";
                    notetrack = "loop sfx sound/vehicles/tie/loop.wav";
                    notetrack = "loop sfx kill";
'loop rof' notes:  
        (1) absolute ==> reset rof to original delta position/rotation world location before looping.
        (2) relative ==> reset rof to original delta position/rotation at current location before looping.
'loop sfx' notes:
        (1) adds a sound to be looped which gets assigned to the entitystate's loopSound parameter.
        (2) addlArg 'kill' -- kills the looping sound by setting entitystate's loopSound equal to zero.

****Example Test Level****
[shuttlemap.zip](https://github.com/JACoders/OpenJK/files/3175127/shuttlemap.zip)