### PR TITLE
Improved OOB packet rate limiter

### DIFF
--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -818,6 +818,46 @@ fileHandle_t FS_SV_FOpenFileWrite( const char *filename ) {
 
 /*
 ===========
+FS_SV_FOpenFileAppend
+
+===========
+*/
+fileHandle_t FS_SV_FOpenFileAppend( const char *filename ) {
+	char			*ospath;
+	fileHandle_t	f;
+
+	FS_AssertInitialised();
+
+	f = FS_HandleForFile();
+	fsh[f].zipFile = qfalse;
+
+	Q_strncpyz( fsh[f].name, filename, sizeof( fsh[f].name ) );
+
+	ospath = FS_BuildOSPath( fs_homepath->string, filename, "" );
+	ospath[strlen(ospath)-1] = '\0';
+
+	if ( fs_debug->integer ) {
+		Com_Printf( "FS_SV_FOpenFileAppend: %s\n", ospath );
+	}
+
+	FS_CheckFilenameIsMutable( ospath, __func__ );
+
+	if( FS_CreatePath( ospath ) ) {
+		return 0;
+	}
+
+	fsh[f].handleFiles.file.o = fopen( ospath, "ab" );
+	fsh[f].handleSync = qfalse;
+
+	if (!fsh[f].handleFiles.file.o) {
+		f = 0;
+	}
+
+	return f;
+}
+
+/*
+===========
 FS_SV_FOpenFileRead
 search for a file somewhere below the home path, base path or cd path
 we search in that order, matching FS_SV_FOpenFileRead order

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -610,6 +610,7 @@ fileHandle_t	FS_FOpenFileWrite( const char *qpath, qboolean safe=qtrue );
 
 int		FS_filelength( fileHandle_t f );
 fileHandle_t FS_SV_FOpenFileWrite( const char *filename );
+fileHandle_t FS_SV_FOpenFileAppend( const char *filename );
 int		FS_SV_FOpenFileRead( const char *filename, fileHandle_t *fp );
 void	FS_SV_Rename( const char *from, const char *to, qboolean safe );
 long		FS_FOpenFileRead( const char *qpath, fileHandle_t *file, qboolean uniqueFILE );

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -284,18 +284,8 @@ extern	int serverBansCount;
 //
 typedef struct leakyBucket_s leakyBucket_t;
 struct leakyBucket_s {
-	netadrtype_t	type;
-
-	union {
-		byte	_4[4];
-	} ipv;
-
 	int					lastTime;
-	signed char			burst;
-
-	long				hash;
-
-	leakyBucket_t *prev, *next;
+	unsigned short		burst;
 };
 
 extern leakyBucket_t outboundLeakyBucket;

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -292,8 +292,8 @@ struct leakyBucket_s {
 
 extern leakyBucket_t outboundLeakyBucket;
 
-qboolean SVC_RateLimit( leakyBucket_t *bucket, int burst, int period );
-qboolean SVC_RateLimitAddress( netadr_t from, int burst, int period );
+qboolean SVC_RateLimit( leakyBucket_t *bucket, int burst, int period, int now );
+qboolean SVC_RateLimitAddress( netadr_t from, int burst, int period, int now );
 void SV_FinalMessage (char *message);
 void QDECL SV_SendServerCommand( client_t *cl, const char *fmt, ...);
 

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -275,6 +275,7 @@ extern	cvar_t	*sv_legacyFixes;
 extern	cvar_t	*sv_banFile;
 extern	cvar_t	*sv_maxOOBRate;
 extern	cvar_t	*sv_maxOOBRateIP;
+extern	cvar_t	*sv_autoWhitelist;
 
 extern	serverBan_t serverBans[SERVER_MAXBANS];
 extern	int serverBansCount;
@@ -294,6 +295,8 @@ extern leakyBucket_t outboundLeakyBucket;
 
 qboolean SVC_RateLimit( leakyBucket_t *bucket, int burst, int period, int now );
 qboolean SVC_RateLimitAddress( netadr_t from, int burst, int period, int now );
+void SVC_LoadWhitelist( void );
+void SVC_WhitelistAdr( netadr_t adr );
 void SV_FinalMessage (char *message);
 void QDECL SV_SendServerCommand( client_t *cl, const char *fmt, ...);
 

--- a/codemp/server/server.h
+++ b/codemp/server/server.h
@@ -273,6 +273,8 @@ extern	cvar_t	*sv_autoDemoBots;
 extern	cvar_t	*sv_autoDemoMaxMaps;
 extern	cvar_t	*sv_legacyFixes;
 extern	cvar_t	*sv_banFile;
+extern	cvar_t	*sv_maxOOBRate;
+extern	cvar_t	*sv_maxOOBRateIP;
 
 extern	serverBan_t serverBans[SERVER_MAXBANS];
 extern	int serverBansCount;

--- a/codemp/server/sv_ccmds.cpp
+++ b/codemp/server/sv_ccmds.cpp
@@ -1906,6 +1906,29 @@ static void SV_Record_f( void ) {
 	SV_RecordDemo( cl, demoName );
 }
 
+/*
+=================
+SV_WhitelistIP_f
+=================
+*/
+static void SV_WhitelistIP_f( void ) {
+	if ( Cmd_Argc() < 2 ) {
+		Com_Printf ("Usage: whitelistip <ip>...\n");
+		return;
+	}
+
+	for ( int i = 1; i < Cmd_Argc(); i++ ) {
+		netadr_t	adr;
+
+		if ( NET_StringToAdr( Cmd_Argv(i), &adr ) ) {
+			SVC_WhitelistAdr( adr );
+			Com_Printf("Added %s to the IP whitelist\n", NET_AdrToString(adr));
+		} else {
+			Com_Printf("Incorrect IP address: %s\n", Cmd_Argv(i));
+		}
+	}
+}
+
 //===========================================================
 
 /*
@@ -1966,6 +1989,7 @@ void SV_AddOperatorCommands( void ) {
 	Cmd_AddCommand ("sv_bandel", SV_BanDel_f, "Removes a ban" );
 	Cmd_AddCommand ("sv_exceptdel", SV_ExceptDel_f, "Removes a ban exception" );
 	Cmd_AddCommand ("sv_flushbans", SV_FlushBans_f, "Removes all bans and exceptions" );
+	Cmd_AddCommand ("whitelistip", SV_WhitelistIP_f, "Add IP to the whitelist" );
 }
 
 /*

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -74,15 +74,6 @@ void SV_GetChallenge( netadr_t from ) {
 		return;
 	}
 
-	// Prevent using getchallenge as an amplifier
-	if ( SVC_RateLimitAddress( from, 10, 1000 ) ) {
-		if ( com_developer->integer ) {
-			Com_Printf( "SV_GetChallenge: rate limit from %s exceeded, dropping request\n",
-				NET_AdrToString( from ) );
-		}
-		return;
-	}
-
 	// Create a unique challenge for this client without storing state on the server
 	challenge = SV_CreateChallenge(from);
 

--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -552,6 +552,10 @@ void SV_ClientEnterWorld( client_t *client, usercmd_t *cmd ) {
 	Com_DPrintf( "Going from CS_PRIMED to CS_ACTIVE for %s\n", client->name );
 	client->state = CS_ACTIVE;
 
+	if (sv_autoWhitelist->integer) {
+		SVC_WhitelistAdr( client->netchan.remoteAddress );
+	}
+
 	// resend all configstrings using the cs commands since these are
 	// no longer sent when the client is CS_PRIMED
 	SV_UpdateConfigstrings( client );

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -1010,6 +1010,9 @@ void SV_Init (void) {
 
 	sv_banFile = Cvar_Get( "sv_banFile", "serverbans.dat", CVAR_ARCHIVE, "File to use to store bans and exceptions" );
 
+	sv_maxOOBRate = Cvar_Get("sv_maxOOBRate", "1000", CVAR_ARCHIVE, "Maximum rate of handling incoming server commands" );
+	sv_maxOOBRateIP = Cvar_Get("sv_maxOOBRateIP", "1", CVAR_ARCHIVE, "Maximum rate of handling incoming server commands per IP address" );
+
 	// initialize bot cvars so they are listed and can be set before loading the botlib
 	SV_BotInitCvars();
 

--- a/codemp/server/sv_init.cpp
+++ b/codemp/server/sv_init.cpp
@@ -1012,6 +1012,7 @@ void SV_Init (void) {
 
 	sv_maxOOBRate = Cvar_Get("sv_maxOOBRate", "1000", CVAR_ARCHIVE, "Maximum rate of handling incoming server commands" );
 	sv_maxOOBRateIP = Cvar_Get("sv_maxOOBRateIP", "1", CVAR_ARCHIVE, "Maximum rate of handling incoming server commands per IP address" );
+	sv_autoWhitelist = Cvar_Get("sv_autoWhitelist", "1", CVAR_ARCHIVE, "Save player IPs to allow them using server during DOS attack" );
 
 	// initialize bot cvars so they are listed and can be set before loading the botlib
 	SV_BotInitCvars();
@@ -1021,6 +1022,9 @@ void SV_Init (void) {
 
 	// Load saved bans
 	Cbuf_AddText("sv_rehashbans\n");
+
+	// Load IP whitelist
+	SVC_LoadWhitelist();
 
 	// Only allocated once, no point in moving it around and fragmenting
 	// create a heap for Ghoul2 to use for game side model vertex transforms used in collision detection

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -704,8 +704,9 @@ void SV_ConnectionlessPacket( netadr_t from, msg_t *msg ) {
 	if (sv_maxOOBRateIP->integer) {
 		int rate = Com_Clampi(1, 1000, sv_maxOOBRateIP->integer);
 		int period = 1000 / rate;
+		int burst = 10 * rate;
 
-		if (SVC_RateLimitAddress(from, rate, period, now)) {
+		if (SVC_RateLimitAddress(from, burst, period, now)) {
 			if (com_developer && com_developer->integer) {
 				Com_Printf("SV_ConnectionlessPacket: Rate limit from %s exceeded, dropping request\n", NET_AdrToString(from));
 			}

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -311,8 +311,6 @@ CONNECTIONLESS COMMANDS
 ==============================================================================
 */
 
-leakyBucket_t outboundLeakyBucket;
-
 /*
 ================
 SVC_BucketForAddress
@@ -419,22 +417,6 @@ void SVC_Status( netadr_t from ) {
 	}
 	*/
 
-	// Prevent using getstatus as an amplifier
-	if ( SVC_RateLimitAddress( from, 10, 1000 ) ) {
-		if ( com_developer->integer ) {
-			Com_Printf( "SVC_Status: rate limit from %s exceeded, dropping request\n",
-				NET_AdrToString( from ) );
-		}
-		return;
-	}
-
-	// Allow getstatus to be DoSed relatively easily, but prevent
-	// excess outbound bandwidth usage when being flooded inbound
-	if ( SVC_RateLimit( &outboundLeakyBucket, 10, 100 ) ) {
-		Com_DPrintf( "SVC_Status: rate limit exceeded, dropping request\n" );
-		return;
-	}
-
 	// A maximum challenge length of 128 should be more than plenty.
 	if(strlen(Cmd_Argv(1)) > 128)
 		return;
@@ -488,22 +470,6 @@ void SVC_Info( netadr_t from ) {
 
 	if (Cvar_VariableValue("ui_singlePlayerActive"))
 	{
-		return;
-	}
-
-	// Prevent using getinfo as an amplifier
-	if ( SVC_RateLimitAddress( from, 10, 1000 ) ) {
-		if ( com_developer->integer ) {
-			Com_Printf( "SVC_Info: rate limit from %s exceeded, dropping request\n",
-				NET_AdrToString( from ) );
-		}
-		return;
-	}
-
-	// Allow getinfo to be DoSed relatively easily, but prevent
-	// excess outbound bandwidth usage when being flooded inbound
-	if ( SVC_RateLimit( &outboundLeakyBucket, 10, 100 ) ) {
-		Com_DPrintf( "SVC_Info: rate limit exceeded, dropping request\n" );
 		return;
 	}
 
@@ -598,25 +564,8 @@ void SVC_RemoteCommand( netadr_t from, msg_t *msg ) {
 	char		sv_outputbuf[SV_OUTPUTBUF_LENGTH];
 	char		*cmd_aux;
 
-	// Prevent using rcon as an amplifier and make dictionary attacks impractical
-	if ( SVC_RateLimitAddress( from, 10, 1000 ) ) {
-		if ( com_developer->integer ) {
-			Com_Printf( "SVC_RemoteCommand: rate limit from %s exceeded, dropping request\n",
-				NET_AdrToString( from ) );
-		}
-		return;
-	}
-
 	if ( !strlen( sv_rconPassword->string ) ||
 		strcmp (Cmd_Argv(1), sv_rconPassword->string) ) {
-		static leakyBucket_t bucket;
-
-		// Make DoS via rcon impractical
-		if ( SVC_RateLimit( &bucket, 10, 1000 ) ) {
-			Com_DPrintf( "SVC_RemoteCommand: rate limit exceeded, dropping request\n" );
-			return;
-		}
-
 		valid = qfalse;
 		Com_Printf ("Bad rcon from %s: %s\n", NET_AdrToString (from), Cmd_ArgsFrom(2) );
 	} else {

--- a/codemp/server/sv_main.cpp
+++ b/codemp/server/sv_main.cpp
@@ -320,10 +320,9 @@ Find or allocate a bucket for an address
 */
 #include <map>
 
-static leakyBucket_t *SVC_BucketForAddress( netadr_t address, int burst, int period ) {
+static leakyBucket_t *SVC_BucketForAddress( netadr_t address, int burst, int period, int now ) {
 	static std::map<int, leakyBucket_t> bucketMap;
 	static unsigned int	callCounter = 0;
-	int	now = Sys_Milliseconds();
 
 	if (address.type != NA_IP) {
 		return NULL;
@@ -353,9 +352,8 @@ static leakyBucket_t *SVC_BucketForAddress( netadr_t address, int burst, int per
 SVC_RateLimit
 ================
 */
-qboolean SVC_RateLimit( leakyBucket_t *bucket, int burst, int period ) {
+qboolean SVC_RateLimit( leakyBucket_t *bucket, int burst, int period, int now ) {
 	if ( bucket != NULL ) {
-		int now = Sys_Milliseconds();
 		int interval = now - bucket->lastTime;
 		int expired = interval / period;
 		int expiredRemainder = interval % period;
@@ -385,10 +383,10 @@ SVC_RateLimitAddress
 Rate limit for a particular address
 ================
 */
-qboolean SVC_RateLimitAddress( netadr_t from, int burst, int period ) {
-	leakyBucket_t *bucket = SVC_BucketForAddress( from, burst, period );
+qboolean SVC_RateLimitAddress( netadr_t from, int burst, int period, int now ) {
+	leakyBucket_t *bucket = SVC_BucketForAddress( from, burst, period, now );
 
-	return SVC_RateLimit( bucket, burst, period );
+	return SVC_RateLimit( bucket, burst, period, now );
 }
 
 /*
@@ -617,6 +615,7 @@ connectionless packets.
 */
 void SV_ConnectionlessPacket( netadr_t from, msg_t *msg ) {
 	static leakyBucket_t	bucket;
+	int		now = Sys_Milliseconds();
 	char	*s;
 	char	*c;
 
@@ -624,7 +623,7 @@ void SV_ConnectionlessPacket( netadr_t from, msg_t *msg ) {
 		int rate = Com_Clampi(1, 1000, sv_maxOOBRateIP->integer);
 		int period = 1000 / rate;
 
-		if (SVC_RateLimitAddress(from, rate, period)) {
+		if (SVC_RateLimitAddress(from, rate, period, now)) {
 			return;
 		}
 	}
@@ -633,7 +632,7 @@ void SV_ConnectionlessPacket( netadr_t from, msg_t *msg ) {
 		int rate = Com_Clampi(1, 1000, sv_maxOOBRate->integer);
 		int period = 1000 / rate;
 
-		if (SVC_RateLimit(&bucket, rate, period)) {
+		if (SVC_RateLimit(&bucket, rate, period, now)) {
 			return;
 		}
 	}

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -37,8 +37,10 @@ typedef enum netadrtype_s
 typedef struct netadr_s
 {
 	netadrtype_t	type;
-
-	byte		ip[4];
+	union {
+		byte		ip[4];
+		int32_t		ipi;
+	};
 	uint16_t	port;
 } netadr_t;
 


### PR DESCRIPTION
This is an redesigned server rate limiter for incoming Out Of Bounds (Connectionless) packets.

The purpose of these patches is to mitigate spoofed IP OOB DOS attacks. This is achieved by two changes:

1. Fixing issue with original q3a rate limiter that was causing very high CPU usage when under such attack, up to the point of rendering server unusable.
2. Allowing "whitelisted" players to fully access OOB server protocol when server is under such attack.

There are 3 new cvars:
- `sv_autoWhitelist` – Enable automatically adding connected players to whitelist
- `sv_maxOOBRate` – Max. incoming OOB packet rate per second. 1000 is default, raising it even more would require code changes.
- `sv_maxOOBRateIP` – Max. incoming OOB packet rate per second for a single IP. 1 is default but there is a burst of 10 times the cvar value and it appears to be enough.

Known issues:
1. Lack of whitelist.dat file access synchronization. Rudimentary version of this was implemented in jk2mv.
2. Concerns have been raised about storing IP in the whitelist.dat file being against the GDPR or other privacy laws. If this is a problem, there is a cvar `sv_autoWhitelist`, or IP could be stored as its digest.

I can explain the attacks addressed by this PR and how they are mitigated in depth, on a private communication channel.

These patches have been tested on actual servers by @Yberion and they managed to mitigate few real attacks that would have crippled the server without them. Also a slightly different version has been part of JK2MV 1.4.1 for over a year.