### PR TITLE
Fix stencil shadows in mirrors

### DIFF
--- a/code/rd-vanilla/tr_shadows.cpp
+++ b/code/rd-vanilla/tr_shadows.cpp
@@ -350,31 +350,15 @@ void RB_DoShadowTessEnd( vec3_t lightPos )
 	qglDepthFunc(GL_LESS);
 
 	//now using the Carmack Reverse<tm> -rww
-	if ( backEnd.viewParms.isMirror ) {
-		//qglCullFace( GL_BACK );
-		GL_Cull(CT_BACK_SIDED);
-		qglStencilOp( GL_KEEP, GL_INCR, GL_KEEP );
+	GL_Cull(CT_FRONT_SIDED);
+	qglStencilOp( GL_KEEP, GL_INCR, GL_KEEP );
 
-		R_RenderShadowEdges();
+	R_RenderShadowEdges();
 
-		//qglCullFace( GL_FRONT );
-		GL_Cull(CT_FRONT_SIDED);
-		qglStencilOp( GL_KEEP, GL_DECR, GL_KEEP );
+	GL_Cull(CT_BACK_SIDED);
+	qglStencilOp( GL_KEEP, GL_DECR, GL_KEEP );
 
-		R_RenderShadowEdges();
-	} else {
-		//qglCullFace( GL_FRONT );
-		GL_Cull(CT_FRONT_SIDED);
-		qglStencilOp( GL_KEEP, GL_INCR, GL_KEEP );
-
-		R_RenderShadowEdges();
-
-		//qglCullFace( GL_BACK );
-		GL_Cull(CT_BACK_SIDED);
-		qglStencilOp( GL_KEEP, GL_DECR, GL_KEEP );
-
-		R_RenderShadowEdges();
-	}
+	R_RenderShadowEdges();
 
 	qglDepthFunc(GL_LEQUAL);
 #else

--- a/codemp/rd-vanilla/tr_shadows.cpp
+++ b/codemp/rd-vanilla/tr_shadows.cpp
@@ -350,31 +350,15 @@ void RB_DoShadowTessEnd( vec3_t lightPos )
 	qglDepthFunc(GL_LESS);
 
 	//now using the Carmack Reverse<tm> -rww
-	if ( backEnd.viewParms.isMirror ) {
-		//qglCullFace( GL_BACK );
-		GL_Cull(CT_BACK_SIDED);
-		qglStencilOp( GL_KEEP, GL_INCR, GL_KEEP );
+	GL_Cull(CT_FRONT_SIDED);
+	qglStencilOp( GL_KEEP, GL_INCR, GL_KEEP );
 
-		R_RenderShadowEdges();
+	R_RenderShadowEdges();
 
-		//qglCullFace( GL_FRONT );
-		GL_Cull(CT_FRONT_SIDED);
-		qglStencilOp( GL_KEEP, GL_DECR, GL_KEEP );
+	GL_Cull(CT_BACK_SIDED);
+	qglStencilOp( GL_KEEP, GL_DECR, GL_KEEP );
 
-		R_RenderShadowEdges();
-	} else {
-		//qglCullFace( GL_FRONT );
-		GL_Cull(CT_FRONT_SIDED);
-		qglStencilOp( GL_KEEP, GL_INCR, GL_KEEP );
-
-		R_RenderShadowEdges();
-
-		//qglCullFace( GL_BACK );
-		GL_Cull(CT_BACK_SIDED);
-		qglStencilOp( GL_KEEP, GL_DECR, GL_KEEP );
-
-		R_RenderShadowEdges();
-	}
+	R_RenderShadowEdges();
 
 	qglDepthFunc(GL_LEQUAL);
 #else


### PR DESCRIPTION
GL_Cull already handles if the view is a mirror or not. By also handling
it in RB_DoShadowTessEnd it renders the wrong side of the shadow
geometry. This is fixed by simply removing the mirror handling in
RB_DoShadowTessEnd.