### PR TITLE
Draw stencil shadows in one drawcall when possible

### DIFF
--- a/code/rd-common/tr_types.h
+++ b/code/rd-common/tr_types.h
@@ -243,6 +243,8 @@ typedef struct glconfig_s {
 
 	int						displayFrequency;
 
+	qboolean				doStencilShadowsInOneDrawcall;
+
 	// synonymous with "does rendering consume the entire screen?", therefore
 	// a Voodoo or Voodoo2 will have this set to TRUE, as will a Win32 ICD that
 	// used CDS.

--- a/code/rd-vanilla/qgl.h
+++ b/code/rd-vanilla/qgl.h
@@ -386,6 +386,8 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define qglVertexPointer glVertexPointer
 #define qglViewport glViewport
 
+extern PFNGLSTENCILOPSEPARATEPROC qglStencilOpSeparate;
+
 extern PFNGLACTIVETEXTUREARBPROC qglActiveTextureARB;
 extern PFNGLCLIENTACTIVETEXTUREARBPROC qglClientActiveTextureARB;
 extern PFNGLMULTITEXCOORD2FARBPROC qglMultiTexCoord2fARB;

--- a/code/rd-vanilla/tr_init.cpp
+++ b/code/rd-vanilla/tr_init.cpp
@@ -185,6 +185,7 @@ cvar_t	*com_buildScript;
 cvar_t	*r_environmentMapping;
 cvar_t *r_screenshotJpegQuality;
 
+PFNGLSTENCILOPSEPARATEPROC qglStencilOpSeparate;
 
 PFNGLACTIVETEXTUREARBPROC qglActiveTextureARB;
 PFNGLCLIENTACTIVETEXTUREARBPROC qglClientActiveTextureARB;
@@ -668,6 +669,12 @@ static void GLimp_InitExtensions( void )
 	{
 		g_bDynamicGlowSupported = false;
 		ri.Cvar_Set( "r_DynamicGlow","0" );
+	}
+
+	qglStencilOpSeparate = (PFNGLSTENCILOPSEPARATEPROC)ri.GL_GetProcAddress("glStencilOpSeparate");
+	if (qglStencilOpSeparate)
+	{
+		glConfig.doStencilShadowsInOneDrawcall = qtrue;
 	}
 }
 

--- a/code/rd-vanilla/tr_shadows.cpp
+++ b/code/rd-vanilla/tr_shadows.cpp
@@ -350,15 +350,27 @@ void RB_DoShadowTessEnd( vec3_t lightPos )
 	qglDepthFunc(GL_LESS);
 
 	//now using the Carmack Reverse<tm> -rww
-	GL_Cull(CT_FRONT_SIDED);
-	qglStencilOp( GL_KEEP, GL_INCR, GL_KEEP );
+	if (glConfig.doStencilShadowsInOneDrawcall)
+	{
+		GL_Cull(CT_TWO_SIDED);
+		qglStencilOpSeparate(GL_FRONT, GL_KEEP, GL_INCR_WRAP, GL_KEEP);
+		qglStencilOpSeparate(GL_BACK, GL_KEEP, GL_DECR_WRAP, GL_KEEP);
 
-	R_RenderShadowEdges();
+		R_RenderShadowEdges();
+		qglDisable(GL_STENCIL_TEST);
+	}
+	else
+	{
+		GL_Cull(CT_FRONT_SIDED);
+		qglStencilOp(GL_KEEP, GL_INCR, GL_KEEP);
 
-	GL_Cull(CT_BACK_SIDED);
-	qglStencilOp( GL_KEEP, GL_DECR, GL_KEEP );
+		R_RenderShadowEdges();
 
-	R_RenderShadowEdges();
+		GL_Cull(CT_BACK_SIDED);
+		qglStencilOp(GL_KEEP, GL_DECR, GL_KEEP);
+
+		R_RenderShadowEdges();
+	}
 
 	qglDepthFunc(GL_LEQUAL);
 #else

--- a/codemp/rd-vanilla/qgl.h
+++ b/codemp/rd-vanilla/qgl.h
@@ -392,6 +392,8 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define qglVertexPointer glVertexPointer
 #define qglViewport glViewport
 
+extern PFNGLSTENCILOPSEPARATEPROC qglStencilOpSeparate;
+
 extern PFNGLACTIVETEXTUREARBPROC qglActiveTextureARB;
 extern PFNGLCLIENTACTIVETEXTUREARBPROC qglClientActiveTextureARB;
 extern PFNGLMULTITEXCOORD2FARBPROC qglMultiTexCoord2fARB;

--- a/codemp/rd-vanilla/tr_init.cpp
+++ b/codemp/rd-vanilla/tr_init.cpp
@@ -216,6 +216,8 @@ cvar_t *se_language;
 cvar_t *r_aviMotionJpegQuality;
 cvar_t *r_screenshotJpegQuality;
 
+PFNGLSTENCILOPSEPARATEPROC qglStencilOpSeparate;
+
 PFNGLACTIVETEXTUREARBPROC qglActiveTextureARB;
 PFNGLCLIENTACTIVETEXTUREARBPROC qglClientActiveTextureARB;
 PFNGLMULTITEXCOORD2FARBPROC qglMultiTexCoord2fARB;
@@ -724,6 +726,12 @@ static void GLimp_InitExtensions( void )
 	{
 		g_bDynamicGlowSupported = false;
 		ri.Cvar_Set( "r_DynamicGlow","0" );
+	}
+
+	qglStencilOpSeparate = (PFNGLSTENCILOPSEPARATEPROC)ri.GL_GetProcAddress("glStencilOpSeparate");
+	if ( qglStencilOpSeparate )
+	{
+		glConfigExt.doStencilShadowsInOneDrawcall = qtrue;
 	}
 }
 

--- a/codemp/rd-vanilla/tr_local.h
+++ b/codemp/rd-vanilla/tr_local.h
@@ -1063,6 +1063,7 @@ struct glconfigExt_t
 	glconfig_t *glConfig;
 
 	qboolean doGammaCorrectionWithShaders;
+	qboolean doStencilShadowsInOneDrawcall;
 	const char *originalExtensionString;
 };
 

--- a/codemp/rd-vanilla/tr_shadows.cpp
+++ b/codemp/rd-vanilla/tr_shadows.cpp
@@ -350,15 +350,27 @@ void RB_DoShadowTessEnd( vec3_t lightPos )
 	qglDepthFunc(GL_LESS);
 
 	//now using the Carmack Reverse<tm> -rww
-	GL_Cull(CT_FRONT_SIDED);
-	qglStencilOp( GL_KEEP, GL_INCR, GL_KEEP );
+	if ( glConfigExt.doStencilShadowsInOneDrawcall )
+	{
+		GL_Cull(CT_TWO_SIDED);
+		qglStencilOpSeparate(GL_FRONT, GL_KEEP, GL_INCR_WRAP, GL_KEEP);
+		qglStencilOpSeparate(GL_BACK, GL_KEEP, GL_DECR_WRAP, GL_KEEP);
 
-	R_RenderShadowEdges();
+		R_RenderShadowEdges();
+		qglDisable(GL_STENCIL_TEST);
+	}
+	else
+	{
+		GL_Cull(CT_FRONT_SIDED);
+		qglStencilOp(GL_KEEP, GL_INCR, GL_KEEP);
 
-	GL_Cull(CT_BACK_SIDED);
-	qglStencilOp( GL_KEEP, GL_DECR, GL_KEEP );
+		R_RenderShadowEdges();
 
-	R_RenderShadowEdges();
+		GL_Cull(CT_BACK_SIDED);
+		qglStencilOp(GL_KEEP, GL_DECR, GL_KEEP);
+
+		R_RenderShadowEdges();
+	}
 
 	qglDepthFunc(GL_LEQUAL);
 #else
@@ -388,7 +400,7 @@ void RB_DoShadowTessEnd( vec3_t lightPos )
 
 	// reenable writing to the color buffer
 	qglColorMask( GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE );
-
+	
 #ifdef _DEBUG_STENCIL_SHADOWS
 	qglPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
 #endif


### PR DESCRIPTION
When glStencilOpSeparate is available, the renderer tries to render stencil shadows in one draw call instead of two. It's a neat little performance booster.