### PR TITLE
Prevent segmentation fault when loading lightstyles

### DIFF
--- a/code/game/g_spawn.cpp
+++ b/code/game/g_spawn.cpp
@@ -1337,96 +1337,6 @@ static	const char *defaultStyles[LS_NUM_STYLES][3] =
 		"zyxwvutsrqmlkjihgfedcba",
 		"aammbbzzccllcckkffyyggp"
 	},
-	{	// 14
-		"",
-		"",
-		""
-	},
-	{	// 15
-		"",
-		"",
-		""
-	},
-	{	// 16
-		"",
-		"",
-		""
-	},
-	{	// 17
-		"",
-		"",
-		""
-	},
-	{	// 18
-		"",
-		"",
-		""
-	},
-	{	// 19
-		"",
-		"",
-		""
-	},
-	{	// 20
-		"",
-		"",
-		""
-	},
-	{	// 21
-		"",
-		"",
-		""
-	},
-	{	// 22
-		"",
-		"",
-		""
-	},
-	{	// 23
-		"",
-		"",
-		""
-	},
-	{	// 24
-		"",
-		"",
-		""
-	},
-	{	// 25
-		"",
-		"",
-		""
-	},
-	{	// 26
-		"",
-		"",
-		""
-	},
-	{	// 27
-		"",
-		"",
-		""
-	},
-	{	// 28
-		"",
-		"",
-		""
-	},
-	{	// 29
-		"",
-		"",
-		""
-	},
-	{	// 30
-		"",
-		"",
-		""
-	},
-	{	// 31
-		"",
-		"",
-		""
-	}
 };
 
 
@@ -1509,17 +1419,17 @@ void SP_worldspawn( void ) {
 		int		lengthRed, lengthBlue, lengthGreen;
 		Com_sprintf(temp, sizeof(temp), "ls_%dr", i);
 		G_SpawnString( temp, defaultStyles[i][0], &s );
-		lengthRed = strlen(s);
+		lengthRed = s ? strlen(s) : 0;
 		gi.SetConfigstring(CS_LIGHT_STYLES+((i+LS_STYLES_START)*3)+0, s);
 
 		Com_sprintf(temp, sizeof(temp), "ls_%dg", i);
 		G_SpawnString(temp, defaultStyles[i][1], &s);
-		lengthGreen = strlen(s);
+		lengthGreen = s ? strlen(s) : 0;
 		gi.SetConfigstring(CS_LIGHT_STYLES+((i+LS_STYLES_START)*3)+1, s);
 
 		Com_sprintf(temp, sizeof(temp), "ls_%db", i);
 		G_SpawnString(temp, defaultStyles[i][2], &s);
-		lengthBlue = strlen(s);
+		lengthBlue = s ? strlen(s) : 0;
 		gi.SetConfigstring(CS_LIGHT_STYLES+((i+LS_STYLES_START)*3)+2, s);
 
 		if (lengthRed != lengthGreen || lengthGreen != lengthBlue)

--- a/codeJK2/game/g_spawn.cpp
+++ b/codeJK2/game/g_spawn.cpp
@@ -1117,96 +1117,6 @@ static	char *defaultStyles[LS_NUM_STYLES][3] =
 		"zyxwvutsrqmlkjihgfedcba",
 		"aammbbzzccllcckkffyyggp"
 	},
-	{	// 14
-		"",
-		"",
-		""
-	},
-	{	// 15
-		"",
-		"",
-		""
-	},
-	{	// 16
-		"",
-		"",
-		""
-	},
-	{	// 17
-		"",
-		"",
-		""
-	},
-	{	// 18
-		"",
-		"",
-		""
-	},
-	{	// 19
-		"",
-		"",
-		""
-	},
-	{	// 20
-		"",
-		"",
-		""
-	},
-	{	// 21
-		"",
-		"",
-		""
-	},
-	{	// 22
-		"",
-		"",
-		""
-	},
-	{	// 23
-		"",
-		"",
-		""
-	},
-	{	// 24
-		"",
-		"",
-		""
-	},
-	{	// 25
-		"",
-		"",
-		""
-	},
-	{	// 26
-		"",
-		"",
-		""
-	},
-	{	// 27
-		"",
-		"",
-		""
-	},
-	{	// 28
-		"",
-		"",
-		""
-	},
-	{	// 29
-		"",
-		"",
-		""
-	},
-	{	// 30
-		"",
-		"",
-		""
-	},
-	{	// 31
-		"",
-		"",
-		""
-	}
 };
 
 
@@ -1279,17 +1189,17 @@ void SP_worldspawn( void ) {
 		int		lengthRed, lengthBlue, lengthGreen;
 		Com_sprintf(temp, sizeof(temp), "ls_%dr", i);
 		G_SpawnString( temp, defaultStyles[i][0], &s );
-		lengthRed = strlen(s);
+		lengthRed = s ? strlen(s) : 0;
 		gi.SetConfigstring(CS_LIGHT_STYLES+((i+LS_STYLES_START)*3)+0, s);
 
 		Com_sprintf(temp, sizeof(temp), "ls_%dg", i);
 		G_SpawnString(temp, defaultStyles[i][1], &s);
-		lengthGreen = strlen(s);
+		lengthGreen = s ? strlen(s) : 0;
 		gi.SetConfigstring(CS_LIGHT_STYLES+((i+LS_STYLES_START)*3)+1, s);
 
 		Com_sprintf(temp, sizeof(temp), "ls_%db", i);
 		G_SpawnString(temp, defaultStyles[i][2], &s);
-		lengthBlue = strlen(s);
+		lengthBlue = s ? strlen(s) : 0;
 		gi.SetConfigstring(CS_LIGHT_STYLES+((i+LS_STYLES_START)*3)+2, s);
 
 		if (lengthRed != lengthGreen || lengthGreen != lengthBlue)

--- a/codemp/game/g_spawn.c
+++ b/codemp/game/g_spawn.c
@@ -1267,96 +1267,6 @@ static	char *defaultStyles[32][3] =
 		"zyxwvutsrqmlkjihgfedcba",
 		"aammbbzzccllcckkffyyggp"
 	},
-	{	// 14
-		"",
-		"",
-		""
-	},
-	{	// 15
-		"",
-		"",
-		""
-	},
-	{	// 16
-		"",
-		"",
-		""
-	},
-	{	// 17
-		"",
-		"",
-		""
-	},
-	{	// 18
-		"",
-		"",
-		""
-	},
-	{	// 19
-		"",
-		"",
-		""
-	},
-	{	// 20
-		"",
-		"",
-		""
-	},
-	{	// 21
-		"",
-		"",
-		""
-	},
-	{	// 22
-		"",
-		"",
-		""
-	},
-	{	// 23
-		"",
-		"",
-		""
-	},
-	{	// 24
-		"",
-		"",
-		""
-	},
-	{	// 25
-		"",
-		"",
-		""
-	},
-	{	// 26
-		"",
-		"",
-		""
-	},
-	{	// 27
-		"",
-		"",
-		""
-	},
-	{	// 28
-		"",
-		"",
-		""
-	},
-	{	// 29
-		"",
-		"",
-		""
-	},
-	{	// 30
-		"",
-		"",
-		""
-	},
-	{	// 31
-		"",
-		"",
-		""
-	}
 };
 
 void *precachedKyle = 0;
@@ -1496,17 +1406,17 @@ void SP_worldspawn( void )
 	{
 		Com_sprintf(temp, sizeof(temp), "ls_%dr", i);
 		G_SpawnString(temp, defaultStyles[i][0], &text);
-		lengthRed = strlen(text);
+		lengthRed = text ? strlen(text) : 0;
 		trap->SetConfigstring(CS_LIGHT_STYLES+((i+LS_STYLES_START)*3)+0, text);
 
 		Com_sprintf(temp, sizeof(temp), "ls_%dg", i);
 		G_SpawnString(temp, defaultStyles[i][1], &text);
-		lengthGreen = strlen(text);
+		lengthGreen = text ? strlen(text) : 0;
 		trap->SetConfigstring(CS_LIGHT_STYLES+((i+LS_STYLES_START)*3)+1, text);
 
 		Com_sprintf(temp, sizeof(temp), "ls_%db", i);
 		G_SpawnString(temp, defaultStyles[i][2], &text);
-		lengthBlue = strlen(text);
+		lengthBlue = text ? strlen(text) : 0;
 		trap->SetConfigstring(CS_LIGHT_STYLES+((i+LS_STYLES_START)*3)+2, text);
 
 		if (lengthRed != lengthGreen || lengthGreen != lengthBlue)


### PR DESCRIPTION
The defaultStyle array only has 14 valid entries currently. When the
15th element is accessed, it returns a null-byte (not an empty string).
This commit prevents a segmentation fault by checking whether the
returned pointer from G_SpawnString is NULL before calling strlen.

Fixes: https://github.com/JACoders/OpenJK/issues/1021