### PR TITLE
Fix glStencilOpSeparate usage for macOS

### DIFF
--- a/code/rd-vanilla/qgl.h
+++ b/code/rd-vanilla/qgl.h
@@ -306,6 +306,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define qglStencilFunc glStencilFunc
 #define qglStencilMask glStencilMask
 #define qglStencilOp glStencilOp
+#if defined(__APPLE__)
+#define qglStencilOpSeparate glStencilOpSeparate
+#endif
 #define qglTexCoord1d glTexCoord1d
 #define qglTexCoord1dv glTexCoord1dv
 #define qglTexCoord1f glTexCoord1f
@@ -386,7 +389,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define qglVertexPointer glVertexPointer
 #define qglViewport glViewport
 
+#if !defined(__APPLE__)
 extern PFNGLSTENCILOPSEPARATEPROC qglStencilOpSeparate;
+#endif
 
 extern PFNGLACTIVETEXTUREARBPROC qglActiveTextureARB;
 extern PFNGLCLIENTACTIVETEXTUREARBPROC qglClientActiveTextureARB;

--- a/code/rd-vanilla/tr_init.cpp
+++ b/code/rd-vanilla/tr_init.cpp
@@ -185,7 +185,9 @@ cvar_t	*com_buildScript;
 cvar_t	*r_environmentMapping;
 cvar_t *r_screenshotJpegQuality;
 
+#if !defined(__APPLE__)
 PFNGLSTENCILOPSEPARATEPROC qglStencilOpSeparate;
+#endif
 
 PFNGLACTIVETEXTUREARBPROC qglActiveTextureARB;
 PFNGLCLIENTACTIVETEXTUREARBPROC qglClientActiveTextureARB;
@@ -671,11 +673,15 @@ static void GLimp_InitExtensions( void )
 		ri.Cvar_Set( "r_DynamicGlow","0" );
 	}
 
+#if !defined(__APPLE__)
 	qglStencilOpSeparate = (PFNGLSTENCILOPSEPARATEPROC)ri.GL_GetProcAddress("glStencilOpSeparate");
 	if (qglStencilOpSeparate)
 	{
 		glConfig.doStencilShadowsInOneDrawcall = qtrue;
 	}
+#else
+	glConfig.doStencilShadowsInOneDrawcall = qtrue;
+#endif
 }
 
 /*

--- a/codemp/rd-vanilla/qgl.h
+++ b/codemp/rd-vanilla/qgl.h
@@ -306,6 +306,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define qglStencilFunc glStencilFunc
 #define qglStencilMask glStencilMask
 #define qglStencilOp glStencilOp
+#if defined(__APPLE__)
+#define qglStencilOpSeparate glStencilOpSeparate
+#endif
 #define qglTexCoord1d glTexCoord1d
 #define qglTexCoord1dv glTexCoord1dv
 #define qglTexCoord1f glTexCoord1f
@@ -392,7 +395,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define qglVertexPointer glVertexPointer
 #define qglViewport glViewport
 
+#if !defined(__APPLE__)
 extern PFNGLSTENCILOPSEPARATEPROC qglStencilOpSeparate;
+#endif
 
 extern PFNGLACTIVETEXTUREARBPROC qglActiveTextureARB;
 extern PFNGLCLIENTACTIVETEXTUREARBPROC qglClientActiveTextureARB;

--- a/codemp/rd-vanilla/tr_init.cpp
+++ b/codemp/rd-vanilla/tr_init.cpp
@@ -216,7 +216,9 @@ cvar_t *se_language;
 cvar_t *r_aviMotionJpegQuality;
 cvar_t *r_screenshotJpegQuality;
 
+#if !defined(__APPLE__)
 PFNGLSTENCILOPSEPARATEPROC qglStencilOpSeparate;
+#endif
 
 PFNGLACTIVETEXTUREARBPROC qglActiveTextureARB;
 PFNGLCLIENTACTIVETEXTUREARBPROC qglClientActiveTextureARB;
@@ -728,11 +730,15 @@ static void GLimp_InitExtensions( void )
 		ri.Cvar_Set( "r_DynamicGlow","0" );
 	}
 
+#if !defined(__APPLE__)
 	qglStencilOpSeparate = (PFNGLSTENCILOPSEPARATEPROC)ri.GL_GetProcAddress("glStencilOpSeparate");
 	if ( qglStencilOpSeparate )
 	{
 		glConfigExt.doStencilShadowsInOneDrawcall = qtrue;
 	}
+#else
+	glConfigExt.doStencilShadowsInOneDrawcall = qtrue;
+#endif
 }
 
 // Truncates the GL extensions string by only allowing up to 'maxExtensions' extensions in the string.


### PR DESCRIPTION
This PR fixes compile issues on macOS - macOS handles OpenGL functions differently from other operating systems. The GL symbols corresponding to the chosen GL version (either legacy GL 2.1, or core GL 4.2) are linked at link time so the respective functions are guaranteed to exist once the code is compiled. Therefore we can simply define `qglStencilOpSeparate` to be `glStencilOpSeparate` and avoid looking up the function.