### PR TITLE
Hack to fix singleplayer crashing when toggling fullscreen.

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -46,6 +46,14 @@ if(BuildSPEngine OR BuildJK2SPEngine)
 		"${GSLIncludeDirectory}")
 
 	#    Dependencies
+
+	if (NOT WIN32)
+		# OpenGL
+		find_package(OpenGL REQUIRED)
+		set(SPEngineIncludeDirectories ${SPEngineIncludeDirectories} ${OPENGL_INCLUDE_DIR})
+		set(SPEngineLibraries ${SPEngineLibraries} ${OPENGL_LIBRARIES})
+	endif()
+
 	# OpenAL (is optionally included for Windows)
 	if(MSVC AND NOT WIN64)
 		if(UseInternalOpenAL)


### PR DESCRIPTION
glConfig is a global variable visible to tr_{model,init}.cpp and not
visible to cl_main.cpp, which has its own global cls.glconfig. When
RE_BeginRegistration is being called while the video subsystem is
restarting, explicitly memset glConfig to 0. InitOpenGL depends on
glConfig.vidWidth == 0.

In the codemp/ version, Sys_UnloadDll (dlclose) is sufficient to
remove glConfig, which gets reset to 0 later on. In the code/ version,
even after Sys_UnloadDll (dlclose), the old glConfig and vidWidth
remain, so InitOpenGL fails.