### PR TITLE
Add bounds check to resolve buffer over-read

### DIFF
--- a/codemp/client/snd_mix.cpp
+++ b/codemp/client/snd_mix.cpp
@@ -281,6 +281,9 @@ static void S_PaintChannelFrom16( channel_t *ch, const sfx_t *sfx, int count, in
 
 	for ( int i=0 ; i<count ; i++ )
 	{
+		// have we run off the end?
+		if ((int)ofst >= sfx->iSoundLengthInSamples)
+			break;
 		iData = sfx->pSoundData[ (int)ofst ];
 
 		pSamplesDest[i].left  += (iData * iLeftVol )>>8;

--- a/codemp/client/snd_mix.cpp
+++ b/codemp/client/snd_mix.cpp
@@ -281,9 +281,6 @@ static void S_PaintChannelFrom16( channel_t *ch, const sfx_t *sfx, int count, in
 
 	for ( int i=0 ; i<count ; i++ )
 	{
-		// have we run off the end?
-		if ((int)ofst >= sfx->iSoundLengthInSamples)
-			break;
 		iData = sfx->pSoundData[ (int)ofst ];
 
 		pSamplesDest[i].left  += (iData * iLeftVol )>>8;
@@ -446,8 +443,20 @@ void S_PaintChannels( int endtime ) {
 				}
 
 				count = end - ltime;
-				if ( sampleOffset + count > sc->iSoundLengthInSamples ) {
-					count = sc->iSoundLengthInSamples - sampleOffset;
+				if ( ch->doppler && ch->dopplerScale > 1 ) {
+					if ( sampleOffset + (count * ch->dopplerScale) > sc->iSoundLengthInSamples ) {
+						count = (sc->iSoundLengthInSamples - sampleOffset) / ch->dopplerScale;
+
+						// avoid infinite loop once length of remaining pSoundData (numerator)
+						//	is smaller than dopplerScale (denominator), resulting in 0.
+						if ( count == 0 ) {
+							break;
+						}
+					}
+				} else {
+					if ( sampleOffset + count > sc->iSoundLengthInSamples ) {
+						count = sc->iSoundLengthInSamples - sampleOffset;
+					}
 				}
 
 				if ( count > 0 ) {


### PR DESCRIPTION
Fixes https://github.com/JACoders/OpenJK/issues/1038

ofst over-reads past the end of the pSoundData buffer. Add a bounds check
similar to S_CheckAmplitude() in codemp/client/snd_dma.cpp.

https://github.com/JACoders/OpenJK/commit/69800e894dff5ea9fcad22c26cc41c9bbf250216