### PR TITLE
GCC 10 Compliance

### DIFF
--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -26,6 +26,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "cg_local.h"
 
 #include "ui/ui_shared.h"
+
+NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
+void (*Com_Printf)( const char *msg, ... );
+
 // display context for new ui stuff
 displayContextDef_t cgDC;
 

--- a/codemp/game/g_main.c
+++ b/codemp/game/g_main.c
@@ -29,6 +29,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "bg_saga.h"
 #include "b_local.h"
 
+NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
+void (*Com_Printf)( const char *msg, ... );
+
 level_locals_t	level;
 
 int		eventClearTime = 0;

--- a/codemp/qcommon/q_shared.h
+++ b/codemp/qcommon/q_shared.h
@@ -687,8 +687,8 @@ qboolean Info_NextPair( const char **s, char *key, char *value );
 
 // this is only here so the functions in q_shared.c and bg_*.c can link
 #if defined( _GAME ) || defined( _CGAME ) || defined( UI_BUILD )
-	NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
-	void (*Com_Printf)( const char *msg, ... );
+	extern NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
+	extern void (*Com_Printf)( const char *msg, ... );
 #else
 	void NORETURN QDECL Com_Error( int level, const char *error, ... );
 	void QDECL Com_Printf( const char *msg, ... );

--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -44,6 +44,9 @@ USER INTERFACE MAIN
 #include "game/bg_saga.h"
 #include "ui_shared.h"
 
+NORETURN_PTR void (*Com_Error)( int level, const char *error, ... );
+void (*Com_Printf)( const char *msg, ... );
+
 extern void UI_SaberAttachToChar( itemDef_t *item );
 
 const char *forcepowerDesc[NUM_FORCE_POWERS] =


### PR DESCRIPTION
1. GCC 10 forbids multiple declarations of global variables, Com_Printf and Com_Error throw compiler errors as a result.
2. Fixes #1034 