### PR TITLE
Fixed issue with toolchain not being detected in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . /usr/src/openjk
 # Build i386 arch
 RUN mkdir /usr/src/openjk/build.i386 &&\
 	cd /usr/src/openjk/build.i386 &&\
-	cmake -DCMAKE_TOOLCHAIN_FILE=$(realpath ../cmake/toolchains/linux-i686.cmake) \
+	cmake -DCMAKE_TOOLCHAIN_FILE=/usr/src/openjk/cmake/Toolchains/linux-i686.cmake \
 		-DCMAKE_INSTALL_PREFIX=/opt \
 		-DBuildMPCGame=OFF -DBuildMPEngine=OFF -DBuildMPRdVanilla=OFF -DBuildMPUI=OFF \
 		-DBuildSPEngine=OFF -DBuildSPGame=OFF -DBuildSPRdVanilla=OFF \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . /usr/src/openjk
 # Build i386 arch
 RUN mkdir /usr/src/openjk/build.i386 &&\
 	cd /usr/src/openjk/build.i386 &&\
-	cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/linux-i686.cmake \
+	cmake -DCMAKE_TOOLCHAIN_FILE=$(realpath ../cmake/toolchains/linux-i686.cmake) \
 		-DCMAKE_INSTALL_PREFIX=/opt \
 		-DBuildMPCGame=OFF -DBuildMPEngine=OFF -DBuildMPRdVanilla=OFF -DBuildMPUI=OFF \
 		-DBuildSPEngine=OFF -DBuildSPGame=OFF -DBuildSPRdVanilla=OFF \


### PR DESCRIPTION
Fixes an issue with CMake not resolving the correct path, it isn't clear why this isn't working.
Replacing it with an absolute path (via realpath) allows this to compile.