### PR TITLE
[Fix #757] Fix crash when user loads a saved game with console-spawned vehicles

### DIFF
--- a/code/game/g_savegame.cpp
+++ b/code/game/g_savegame.cpp
@@ -1147,6 +1147,9 @@ static void ReadGEntities(qboolean qbAutosave)
 		{
 			Vehicle_t tempVehicle;
 
+			// initialize the vehicle cache g_vehicleInfo
+			int vehicleIndex = BG_VehicleGetIndex(pEnt->NPC_type);
+
 			EvaluateFields(savefields_gVHIC, &tempVehicle,(byte *)pEntOriginal->m_pVehicle, INT_ID('V','H','I','C'));
 
 			// so can we pinch the original's one or do we have to alloc a new one?...


### PR DESCRIPTION
Steps to reproduce:

maptransition [any level]
helpusobi 1
npc spawn vehicle swoop
 -- save game --
load game