### PR TITLE
Fix crash or freeze when there is too much text visible in the console

### DIFF
--- a/codemp/client/cl_console.cpp
+++ b/codemp/client/cl_console.cpp
@@ -743,6 +743,8 @@ void Con_DrawSolidConsole( float frac ) {
 			(lines-(SMALLCHAR_HEIGHT+SMALLCHAR_HEIGHT/2)), JK_VERSION[x] );
 	}
 
+	// draw the input prompt, user text, and cursor if desired
+	Con_DrawInput ();
 
 	// draw the text
 	con.vislines = lines;
@@ -830,9 +832,6 @@ void Con_DrawSolidConsole( float frac ) {
 			}
 		}
 	}
-
-	// draw the input prompt, user text, and cursor if desired
-	Con_DrawInput ();
 
 	re->SetColor( NULL );
 }


### PR DESCRIPTION
Game was freezing or crashing when there were too many characters visible at the same time in the console. Easy to reproduce with high resolution display.
Commit messages describe what was causing crashes and what had to be done.

After changes excessive characters are not printed but at least client remains functional, console prompt and latest console lines are visible:

![obraz](https://user-images.githubusercontent.com/4474909/139779679-5d864f71-e5fb-4dc7-9c5a-b7059163e44f.png)

Tested by @withRhodes