### PR TITLE
Add support for compiling on Apple m1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 #============================================================================
 
 cmake_minimum_required(VERSION 3.1)
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum OS X deployment version")
 
 set(InOpenJK ON)
 
@@ -112,7 +112,9 @@ if(WIN32)
 	endif()
 else()
 	set(X86 OFF)
-	if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
+	if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
+		set(Architecture "aarch64")
+	elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
 		set(Architecture "arm")
 	elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
 		set(X86 ON)

--- a/shared/qcommon/q_platform.h
+++ b/shared/qcommon/q_platform.h
@@ -108,7 +108,10 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 		#define idx64
 		#define ARCH_STRING "x86_64"
 		#define Q3_LITTLE_ENDIAN
-	#endif
+    #elif defined(__aarch64__)
+        #define ARCH_STRING "aarch64"
+        #define Q3_LITTLE_ENDIAN
+    #endif
 
     #define DLL_EXT ".dylib"
 


### PR DESCRIPTION
This adds support for compiling on Apple M1 processors. 

Apple also now requires all applications on M1 to be signed, so the following will need to be run on the bundle: 

`codesign --force --deep --sign - openjk.aarch64.app`