### PR TITLE
Fix typo that causes comparison to always evaluate to false.

### DIFF
--- a/code/game/g_active.cpp
+++ b/code/game/g_active.cpp
@@ -2905,7 +2905,7 @@ qboolean G_CheckClampUcmd( gentity_t *ent, usercmd_t *ucmd )
 						}
 					}
 					if ( ent->client->ps.legsAnimTimer <= 1150
-						&& ent->client->ps.legsAnimTimer > 10500 )
+						&& ent->client->ps.legsAnimTimer > 1050 )
 					{
 						TIMER_Set( ent, "grappleDamageDebounce", 150 );
 						if ( ent->s.number < MAX_CLIENTS )


### PR DESCRIPTION
Looking at the other checks in this code I think it is safe to assume that this was meant to be 1050.