### PR TITLE
[NPC behavior] reduce NPC_BSFlee random range

### DIFF
--- a/code/game/NPC_behavior.cpp
+++ b/code/game/NPC_behavior.cpp
@@ -1745,7 +1745,7 @@ qboolean NPC_BSFlee( void )
 			NPCInfo->goalEntity = foundWeap;	// Change Our Target Goal
 			NPCInfo->goalRadius	= 30.0f;		// 30 good enough?
 
-			TIMER_Set(NPC, "CheckForWeaponToPickup", Q_irand(10000, 50000));
+			TIMER_Set(NPC, "CheckForWeaponToPickup", Q_irand(1000, 5000));
 		}
 
 		// Look Again Soon

--- a/code/game/NPC_behavior.cpp
+++ b/code/game/NPC_behavior.cpp
@@ -1745,7 +1745,7 @@ qboolean NPC_BSFlee( void )
 			NPCInfo->goalEntity = foundWeap;	// Change Our Target Goal
 			NPCInfo->goalRadius	= 30.0f;		// 30 good enough?
 
-			TIMER_Set(NPC, "CheckForWeaponToPickup", Q_irand(1000, 5000));
+			TIMER_Set(NPC, "CheckForWeaponToPickup", Q_irand(1000, 5000) * 10);
 		}
 
 		// Look Again Soon


### PR DESCRIPTION
Irand fails when the requested random range is not below QRAND_MAX, which is 2^15 as it is right now. NPC_BSFlee calls irand (via Q_irand) by requesting the random range within [10000, 50000] which is of course below 2^15 and the game crashes.

Below is my stack trace in gdb:
```
    4  0x00007ffff784a486 in __assert_fail () from /usr/lib/libc.so.6
    5  0x00007fffd18e5b6c in irand (min=10000, max=50000) at /opt/games/git-openjk/shared/qcommon/q_math.c:252
    6  0x00007fffd18e5bcc in Q_irand (value1=10000, value2=50000) at /opt/games/git-openjk/shared/qcommon/q_math.c:264
    7  0x00007fffd177c34b in NPC_BSFlee () at /opt/games/git-openjk/code/game/NPC_behavior.cpp:1748
    8  0x00007fffd1776525 in NPC_RunBehavior (team=2, bState=10) at /opt/games/git-openjk/code/game/NPC.cpp:2055
    9  0x00007fffd1776837 in NPC_ExecuteBState (self=0x7fffd1a94ac8 <g_entities+94248>) at /opt/games/git-openjk/code/game/NPC.cpp:2185
    10 0x00007fffd1777472 in NPC_Think (self=0x7fffd1a94ac8 <g_entities+94248>) at /opt/games/git-openjk/code/game/NPC.cpp:2494
    11 0x00007fffd16d83ce in GEntity_ThinkFunc (self=0x7fffd1a94ac8 <g_entities+94248>) at /opt/games/git-openjk/code/game/g_functions.cpp:67
    12 0x00007fffd16e5ac4 in G_RunThink (ent=0x7fffd1a94ac8 <g_entities+94248>) at /opt/games/git-openjk/code/game/g_main.cpp:1075
    13 0x00007fffd16e84fa in G_RunFrame (levelTime=578050) at /opt/games/git-openjk/code/game/g_main.cpp:2055
    14 0x00005555555d9d91 in SV_Frame (msec=11, fractionMsec=0) at /opt/games/git-openjk/code/server/sv_main.cpp:513
    15 0x00005555555b0740 in Com_Frame () at /opt/games/git-openjk/code/qcommon/common.cpp:1418
    16 0x000055555562a897 in main (argc=1, argv=0x7fffffffe2c8) at /opt/games/git-openjk/shared/sys/sys_main.cpp:812
    (gdb) frame 5
    5  0x00007fffd18e5b6c in irand (min=10000, max=50000) at /opt/games/git-openjk/shared/qcommon/q_math.c:252
    252             assert((max - min) < QRAND_MAX);
```