### PR TITLE
game: fix overflow on too many spawnpoints

### DIFF
--- a/code/game/g_client.cpp
+++ b/code/game/g_client.cpp
@@ -239,6 +239,9 @@ gentity_t *SelectRandomDeathmatchSpawnPoint( team_t team ) {
 	spot = NULL;
 
 	while ((spot = G_Find (spot, FOFS(classname), "info_player_deathmatch")) != NULL) {
+		if (count >= MAX_SPAWN_POINTS) {
+			G_Error("too many spawnpoints in map, must not exceed %d", MAX_SPAWN_POINTS);
+		}
 		/*if ( team == TEAM_RED && ( spot->spawnflags & 2 ) ) {
 			continue;
 		}


### PR DESCRIPTION
Previously, the game would typically just crash due to stack corruption after a buffer overflow. Now, we detect the overflow, and show an error instead.

Can be tested using <https://mrwonko.de/jk3files/Jedi%20Academy/Maps/Free%20For%20All/82455/>.

Fixes #1137