### PR TITLE
SP: Attempt to fix GetString() calls with cvars in ICARUS

### DIFF
--- a/code/game/Q3_Interface.cpp
+++ b/code/game/Q3_Interface.cpp
@@ -10570,11 +10570,14 @@ int		CQuake3GameInterface::GetString( int entID, const char *name, char **value 
 
 	if( strlen(name) > 5 && Q_stricmpn(name, "cvar_", 5) )
 	{
-		char cvarbuf[MAX_STRING_CHARS];
-
-		gi.Cvar_VariableStringBuffer(name+5, cvarbuf, sizeof(cvarbuf));
-		m_cvars[name+5] = cvarbuf;
-		*value = &m_cvars[name+5][0];
+		const char* cvar_name = name + 5;
+		// by allocating and then re-using the same sufficiently large buffer,
+		// we ensure that pointers to it never become invalid,
+		// so we can support expressions using the same cvar twice,
+		// e.g. if(get(cvar_x) == get(cvar_x))
+		std::array<char, MAX_STRING_CHARS>& buf = m_cvars[cvar_name];
+		gi.Cvar_VariableStringBuffer(cvar_name, buf.data(), buf.size());
+		*value = buf.data();
 		return true;
 	}
 

--- a/code/game/Q3_Interface.cpp
+++ b/code/game/Q3_Interface.cpp
@@ -7473,6 +7473,7 @@ CQuake3GameInterface::CQuake3GameInterface() : IGameInterface()
 {
 	m_ScriptList.clear();
 	m_EntityList.clear();
+	m_cvars.clear();
 
 	m_numVariables = 0;
 
@@ -7509,6 +7510,7 @@ CQuake3GameInterface::~CQuake3GameInterface()
 
 	m_ScriptList.clear();
 	m_EntityList.clear();
+	m_cvars.clear();
 }
 
 // Initialize an Entity by ID.
@@ -8230,8 +8232,7 @@ void	CQuake3GameInterface::Set( int taskID, int entID, const char *type_name, co
 	vec3_t		vector_data;
 
 	// eezstreet: Add support for cvars getting modified thru ICARUS script
-	if(!Q_stricmpn(type_name, "cvar_", 5) &&
-		strlen(type_name) > 5)
+	if(strlen(type_name) > 5 && !Q_stricmpn(type_name, "cvar_", 5))
 	{
 		gi.cvar_set(type_name+5, data);
 		return;
@@ -9867,8 +9868,7 @@ int		CQuake3GameInterface::GetFloat( int entID, const char *name, float *value )
 		return false;
 	}
 
-	if( !Q_stricmpn(name, "cvar_", 5) &&
-		strlen(name) > 5 )
+	if( strlen(name) > 5 &&!Q_stricmpn(name, "cvar_", 5) )
 	{
 		*value = (float)gi.Cvar_VariableIntegerValue(name+5);
 		return true;
@@ -10568,10 +10568,13 @@ int		CQuake3GameInterface::GetString( int entID, const char *name, char **value 
 		return false;
 	}
 
-	if( !Q_stricmpn(name, "cvar_", 5) &&
-		strlen(name) > 5 )
+	if( strlen(name) > 5 && Q_stricmpn(name, "cvar_", 5) )
 	{
-		gi.Cvar_VariableStringBuffer(name+5, *value, strlen(*value));
+		char cvarbuf[MAX_STRING_CHARS];
+
+		gi.Cvar_VariableStringBuffer(name+5, cvarbuf, sizeof(cvarbuf));
+		m_cvars[name+5] = cvarbuf;
+		*value = &m_cvars[name+5][0];
 		return true;
 	}
 

--- a/code/game/Q3_Interface.h
+++ b/code/game/Q3_Interface.h
@@ -577,6 +577,8 @@ private:
 	varString_m		m_varVectors;
 	int				m_numVariables;
 
+	varString_m		m_cvars;
+
 	int				m_entFilter;
 
 	// Register variables functions.

--- a/code/game/Q3_Interface.h
+++ b/code/game/Q3_Interface.h
@@ -23,6 +23,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #ifndef __Q3_INTERFACE__
 #define __Q3_INTERFACE__
 
+#include <array>
 #include "../icarus/IcarusInterface.h"
 #include "bg_public.h"
 #include "g_shared.h"
@@ -558,6 +559,8 @@ typedef std::map < std::string, pscript_t* >	scriptlist_t;
 // STL map type definitions for the variable containers.
 typedef std::map < std::string, std::string >		varString_m;
 typedef std::map < std::string, float >		varFloat_m;
+// For cases where we need to re-use a buffer without invalidating it
+typedef std::map < std::string, std::array< char, MAX_STRING_CHARS > >		varStringBuf_m;
 
 
 // The Quake 3 Game Interface Class for Quake3 and Icarus to use.
@@ -577,7 +580,7 @@ private:
 	varString_m		m_varVectors;
 	int				m_numVariables;
 
-	varString_m		m_cvars;
+	varStringBuf_m		m_cvars;
 
 	int				m_entFilter;
 

--- a/codeJK2/game/Q3_Interface.cpp
+++ b/codeJK2/game/Q3_Interface.cpp
@@ -8599,11 +8599,14 @@ static int Q3_GetString( int entID, int type, const char *name, char **value )
 
 	if( strlen(name) > 5 && Q_stricmpn(name, "cvar_", 5) )
 	{
-		char cvarbuf[MAX_STRING_CHARS];
-
-		gi.Cvar_VariableStringBuffer(name+5, cvarbuf, sizeof(cvarbuf));
-		ICARUS_CvarList[name+5] = cvarbuf;
-		*value = &ICARUS_CvarList[name+5][0];
+		const char* cvar_name = name + 5;
+		// by allocating and then re-using the same sufficiently large buffer,
+		// we ensure that pointers to it never become invalid,
+		// so we can support expressions using the same cvar twice,
+		// e.g. if(get(cvar_x) == get(cvar_x))
+		std::array<char, MAX_STRING_CHARS>& buf = m_cvars[cvar_name];
+		gi.Cvar_VariableStringBuffer(cvar_name, buf.data(), buf.size());
+		*value = buf.data();
 		return true;
 	}
 

--- a/codeJK2/game/Q3_Interface.cpp
+++ b/codeJK2/game/Q3_Interface.cpp
@@ -6533,11 +6533,10 @@ static void Q3_Set( int taskID, int entID, const char *type_name, const char *da
 	int			int_data, toSet;
 	vec3_t		vector_data;
 
-	// eezstreet: In response to issue #75 (Cvars being affected by set command)
-	if( !Q_stricmpn(type_name, "cvar_", 5) &&
-		strlen(type_name) > 5 )
+	// eezstreet: Add support for cvars getting modified thru ICARUS script
+	if(strlen(type_name) > 5 && !Q_stricmpn(type_name, "cvar_", 5))
 	{
-		cgi_Cvar_Set(type_name+5, data);
+		gi.cvar_set(type_name+5, data);
 		return;
 	}
 
@@ -7904,8 +7903,7 @@ static int Q3_GetFloat( int entID, int type, const char *name, float *value )
 		return false;
 	}
 
-	if( !Q_stricmpn(name, "cvar_", 5) &&
-		strlen(name) > 5 )
+	if( strlen(name) > 5 &&!Q_stricmpn(name, "cvar_", 5) )
 	{
 		*value = (float)gi.Cvar_VariableIntegerValue(name+5);
 		return true;
@@ -8599,10 +8597,13 @@ static int Q3_GetString( int entID, int type, const char *name, char **value )
 		return false;
 	}
 
-	if( !Q_stricmpn(name, "cvar_", 5) &&
-		strlen(name) > 5 )
+	if( strlen(name) > 5 && Q_stricmpn(name, "cvar_", 5) )
 	{
-		gi.Cvar_VariableStringBuffer(name+5, *value, strlen(*value));
+		char cvarbuf[MAX_STRING_CHARS];
+
+		gi.Cvar_VariableStringBuffer(name+5, cvarbuf, sizeof(cvarbuf));
+		ICARUS_CvarList[name+5] = cvarbuf;
+		*value = &ICARUS_CvarList[name+5][0];
 		return true;
 	}
 

--- a/codeJK2/game/Q3_Registers.h
+++ b/codeJK2/game/Q3_Registers.h
@@ -27,6 +27,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include <string>
 #include <map>
+#include <array>
 
 typedef std::map < std::string, std::string >		varString_m;
 typedef std::map < std::string, float >		varFloat_m;

--- a/codeJK2/game/Q3_Registers.h
+++ b/codeJK2/game/Q3_Registers.h
@@ -25,6 +25,9 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #define	MAX_VARIABLES	32
 
+#include <string>
+#include <map>
+
 typedef std::map < std::string, std::string >		varString_m;
 typedef std::map < std::string, float >		varFloat_m;
 

--- a/codeJK2/game/g_ICARUS.cpp
+++ b/codeJK2/game/g_ICARUS.cpp
@@ -34,6 +34,8 @@ ICARUS_Instance		*iICARUS;
 bufferlist_t		ICARUS_BufferList;
 entlist_t			ICARUS_EntList;
 
+cvarlist_t			ICARUS_CvarList;
+
 extern uint32_t Com_BlockChecksum (const void *buffer, int length);
 extern	void	Q3_DebugPrint( int level, const char *format, ... );
 
@@ -136,6 +138,8 @@ void ICARUS_Init( void )
 		Com_Error( ERR_DROP, "Unable to initialize ICARUS instance\n" );
 		return;
 	}
+
+	ICARUS_CvarList.clear();
 }
 
 /*
@@ -171,6 +175,8 @@ void ICARUS_Shutdown( void )
 
 	//Clear the name map
 	ICARUS_EntList.clear();
+
+	ICARUS_CvarList.clear();
 
 	//Free this instance
 	if ( iICARUS )

--- a/codeJK2/game/g_icarus.h
+++ b/codeJK2/game/g_icarus.h
@@ -35,6 +35,7 @@ extern	bool ICARUS_RegisterScript( const char *name, bool bCalledDuringInterroga
 extern ICARUS_Instance	*iICARUS;
 extern bufferlist_t		ICARUS_BufferList;
 extern entlist_t		ICARUS_EntList;
+extern cvarlist_t       ICARUS_CvarList;
 
 //
 //	g_ICARUS.cpp

--- a/codeJK2/game/g_local.h
+++ b/codeJK2/game/g_local.h
@@ -636,7 +636,7 @@ typedef struct pscript_s
 
 typedef std::map < std::string, int, std::less<std::string> >		entlist_t;
 typedef std::map < std::string, pscript_t*, std::less<std::string> >	bufferlist_t;
-typedef std::map < std::string, std::string >		cvarlist_t;
+typedef std::map < std::string, std::array<char, MAX_STRING_CHARS> >		cvarlist_t;
 
 
 extern char *G_NewString( const char *string );

--- a/codeJK2/game/g_local.h
+++ b/codeJK2/game/g_local.h
@@ -636,6 +636,7 @@ typedef struct pscript_s
 
 typedef std::map < std::string, int, std::less<std::string> >		entlist_t;
 typedef std::map < std::string, pscript_t*, std::less<std::string> >	bufferlist_t;
+typedef std::map < std::string, std::string >		cvarlist_t;
 
 
 extern char *G_NewString( const char *string );


### PR DESCRIPTION
Cvar_VariableStringBuffer() does not like unallocated buffers with strlen().

Uses a local variable and cache the result in a map<> that is then cleared upon shutdown.