### PR TITLE
Also aspect correct the fov in skybox portals

### DIFF
--- a/codemp/cgame/cg_view.c
+++ b/codemp/cgame/cg_view.c
@@ -1780,6 +1780,16 @@ void CG_DrawSkyBoxPortal(const char *cstr)
 		}
 	}
 
+	if (cg_fovAspectAdjust.integer) {
+		// Based on LordHavoc's code for Darkplaces
+		// http://www.quakeworld.nu/forum/topic/53/what-does-your-qw-look-like/page/30
+		const float baseAspect = 0.75f; // 3/4
+		const float aspect = (float)cgs.glconfig.vidWidth / (float)cgs.glconfig.vidHeight;
+		const float desiredFov = fov_x;
+
+		fov_x = atan(tan(desiredFov*M_PI / 360.0f) * baseAspect*aspect)*360.0f / M_PI;
+	}
+
 	x = cg.refdef.width / tan( fov_x / 360 * M_PI );
 	fov_y = atan2( cg.refdef.height, x );
 	fov_y = fov_y * 360 / M_PI;


### PR DESCRIPTION
Was missing and created a visual break when using cg_fovAspectAdjust 1. Just copied the correction code from CG_CalcFov.