### PR TITLE
Fix hanging cutscenes on fast machines

### DIFF
--- a/code/server/sv_init.cpp
+++ b/code/server/sv_init.cpp
@@ -311,7 +311,7 @@ void SV_SpawnServer( const char *server, ForceReload_e eForceReload, qboolean bA
 	SV_InitGameProgs();
 
 	// run a few frames to allow everything to settle
-	for ( i = 0 ;i < 3 ; i++ ) {
+	for ( i = 0 ;i < 4 ; i++ ) {
 		ge->RunFrame( sv.time );
 		sv.time += 100;
 		re.G2API_SetTime(sv.time,G2T_SV_TIME);


### PR DESCRIPTION
On machines that can load levels faster than the hardcoded entity spawning delay, the Icarus sequencer could reference non-existing entities and therefore fail to chain events to progress cutscenes.

This change increases the number of warmup frames by 1 to push the possible client-server connection time to after all relevant entities have been spawned.

Fixes #1150 