### PR TITLE
Fixed bug with read hexadecimal number in codemp/botlib/l_script

### DIFF
--- a/codemp/botlib/l_script.cpp
+++ b/codemp/botlib/l_script.cpp
@@ -652,7 +652,7 @@ int PS_ReadNumber(script_t *script, token_t *token)
 		//hexadecimal
 		while((c >= '0' && c <= '9') ||
 					(c >= 'a' && c <= 'f') ||
-					(c >= 'A' && c <= 'A'))
+					(c >= 'A' && c <= 'F'))
 		{
 			token->string[len++] = *script->script_p++;
 			if (len >= MAX_TOKEN)


### PR DESCRIPTION
@ensiform, @dionrhys , HI my friends!
Take my bug fix to botlib module.
Problem is that it ignores example hexadecimal values `0xB` `0xC` `0xD` `0xE` `0xF`