### PR TITLE
Fixed bug in Clear() function SIntRange, mMax is never cleared.

### DIFF
--- a/code/rd-vanilla/tr_WorldEffects.cpp
+++ b/code/rd-vanilla/tr_WorldEffects.cpp
@@ -257,7 +257,7 @@ struct	SIntRange
 	inline void	Clear()
 	{
 		mMin = 0;
-		mMin = 0;
+		mMax = 0;
 	}
 	inline void Pick(int& V)
 	{

--- a/codemp/rd-vanilla/tr_WorldEffects.cpp
+++ b/codemp/rd-vanilla/tr_WorldEffects.cpp
@@ -229,7 +229,7 @@ struct	SIntRange
 	inline void	Clear()
 	{
 		mMin = 0;
-		mMin = 0;
+		mMax = 0;
 	}
 	inline void Pick(int& V)
 	{


### PR DESCRIPTION
This is also more likely a manifestation of inattention of developers.
Affects behavior:
- `CWindZone::mRDuration`
- `CWindZone::mRDeadTime`
- `CWeatherParticleCloud::mRotationChangeTimer`