### PR TITLE
Multiplayer RoffSystem Fixes

### DIFF
--- a/codemp/qcommon/RoffSystem.cpp
+++ b/codemp/qcommon/RoffSystem.cpp
@@ -647,7 +647,7 @@ qboolean CROFFSystem::Play( int entID, int id, qboolean doTranslation, qboolean 
 
 	roffing_ent->mEntID			= entID;
 	roffing_ent->mROFFID		= id;
-	roffing_ent->mNextROFFTime	= svs.time;
+	roffing_ent->mNextROFFTime	= sv.time;
 	roffing_ent->mROFFFrame		= 0;
 	roffing_ent->mKill			= qfalse;
 	roffing_ent->mSignal		= qtrue; // TODO: hook up the real signal code
@@ -864,7 +864,7 @@ qboolean CROFFSystem::ApplyROFF( SROFFEntity *roff_ent, CROFFSystem::CROFF *roff
 	float			*origin = NULL, *angle = NULL;
 
 
-	if ( svs.time < roff_ent->mNextROFFTime )
+	if ( sv.time < roff_ent->mNextROFFTime )
 	{ // Not time to roff yet
 		return qtrue;
 	}
@@ -900,8 +900,8 @@ qboolean CROFFSystem::ApplyROFF( SROFFEntity *roff_ent, CROFFSystem::CROFF *roff
 
 	if ( roff_ent->mROFFFrame >= roff->mROFFEntries )
 	{ // we are done roffing, so stop moving and flag this ent to be removed
-		SetLerp( originTrajectory, TR_STATIONARY, origin, NULL, svs.time, roff->mLerp );
-		SetLerp( angleTrajectory, TR_STATIONARY, angle, NULL, svs.time, roff->mLerp );
+		SetLerp( originTrajectory, TR_STATIONARY, origin, NULL, sv.time, roff->mLerp );
+		SetLerp( angleTrajectory, TR_STATIONARY, angle, NULL, sv.time, roff->mLerp );
 		if (!roff_ent->mIsClient)
 		{
 			ent->r.mIsRoffing = qfalse;
@@ -922,11 +922,11 @@ qboolean CROFFSystem::ApplyROFF( SROFFEntity *roff_ent, CROFFSystem::CROFF *roff
 	}
 
 	// Set up our origin interpolation
-	SetLerp( originTrajectory, TR_LINEAR, origin, result, svs.time, roff->mLerp );
+	SetLerp( originTrajectory, TR_LINEAR, origin, result, sv.time, roff->mLerp );
 
 	// Set up our angle interpolation
 	SetLerp( angleTrajectory, TR_LINEAR, angle,
-				roff->mMoveRotateList[roff_ent->mROFFFrame].mRotateOffset, svs.time, roff->mLerp );
+				roff->mMoveRotateList[roff_ent->mROFFFrame].mRotateOffset, sv.time, roff->mLerp );
 
 	if (roff->mMoveRotateList[roff_ent->mROFFFrame].mStartNote >= 0)
 	{
@@ -940,7 +940,7 @@ qboolean CROFFSystem::ApplyROFF( SROFFEntity *roff_ent, CROFFSystem::CROFF *roff
 
 	// Advance ROFF frames and lock to a 10hz cycle
 	roff_ent->mROFFFrame++;
-	roff_ent->mNextROFFTime = svs.time + roff->mFrameTime;
+	roff_ent->mNextROFFTime = sv.time + roff->mFrameTime;
 
 	//rww - npcs need to know when they're getting roff'd
 	if ( !roff_ent->mIsClient )
@@ -1044,8 +1044,8 @@ qboolean CROFFSystem::ClearLerp( SROFFEntity *roff_ent )
 		angle = ent->r.currentAngles;
 	}
 
-	SetLerp( originTrajectory, TR_STATIONARY, origin, NULL, svs.time, ROFF_SAMPLE_RATE );
-	SetLerp( angleTrajectory, TR_STATIONARY, angle, NULL, svs.time, ROFF_SAMPLE_RATE );
+	SetLerp( originTrajectory, TR_STATIONARY, origin, NULL, sv.time, ROFF_SAMPLE_RATE );
+	SetLerp( angleTrajectory, TR_STATIONARY, angle, NULL, sv.time, ROFF_SAMPLE_RATE );
 
 	return qtrue;
 }

--- a/codemp/qcommon/RoffSystem.h
+++ b/codemp/qcommon/RoffSystem.h
@@ -64,7 +64,7 @@ private:
 	//-------------------------------
 	{
 		char	mHeader[4];				// should match roff_string defined above
-		long	mVersion;				// version num, supported version defined above
+		int		mVersion;				// version num, supported version defined above
 		float	mCount;					// I think this is a float because of a limitation of the roff exporter
 
 	} TROFFHeader;
@@ -81,7 +81,7 @@ private:
 	//-------------------------------
 	{
 		char	mHeader[4];				// should match roff_string defined above
-		long	mVersion;				// version num, supported version defined above
+		int		mVersion;				// version num, supported version defined above
 		int		mCount;					// I think this is a float because of a limitation of the roff exporter
 		int		mFrameRate;				// Frame rate the roff should be played at
 		int		mNumNotes;				// number of notes (null terminated strings) after the roff data


### PR DESCRIPTION
This pull request fixes two multiplayer bugs related to the RoffSystem:
 1. The RoffSystem used the wrong time value (engine time rather than module time) since the times were separated in 92e12a9e9b19525c1f589f1f6779e9397b6bfd26. This caused playback to be incorrect after the first mapchange. The same bug was also introduced by jk2mv and has been fixed the same way in https://github.com/mvdevs/jk2mv/commit/11a108ed4c495b0808f9f15f72f1668149cc4b49.
 2. The RoffSystem used `long` instead if `int` for the `mVersion` header field, causing 64-bit versions to be unable to parse roff files and playing them back.