### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @JACoders/openjk-maintainers


### PR DESCRIPTION
Does what it says on the tin.
May want to expand this in future for delegating maintenance (e.g. renderers).