### PR TITLE
[Shared] Add cl_mouseAspectScaling to correct UI mouse sensitivity for your resolution

### DIFF
--- a/code/client/cl_input.cpp
+++ b/code/client/cl_input.cpp
@@ -447,7 +447,13 @@ CL_MouseEvent
 */
 void CL_MouseEvent( int dx, int dy, int time ) {
 	if ( Key_GetCatcher( ) & KEYCATCH_UI ) {
-		_UI_MouseEvent( dx, dy );
+		float dxScaled = dx;
+		float dyScaled = dy;
+		if ( cl_mouseAspectScaling->integer ) {
+			dxScaled *= (SCREEN_WIDTH / (float)cls.glconfig.vidWidth);
+			dyScaled *= (SCREEN_HEIGHT / (float)cls.glconfig.vidHeight);
+		}
+		_UI_MouseEvent( dxScaled, dyScaled );
 	}
 	else {
 		cl.mouseDx[cl.mouseIndex] += dx;

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -61,6 +61,7 @@ cvar_t	*cl_freelook;
 cvar_t	*cl_sensitivity;
 
 cvar_t	*cl_mouseAccel;
+cvar_t	*cl_mouseAspectScaling;
 cvar_t	*cl_showMouseRate;
 cvar_t	*cl_framerate;
 
@@ -1258,6 +1259,7 @@ void CL_Init( void ) {
 	cl_run = Cvar_Get ("cl_run", "1", CVAR_ARCHIVE_ND);
 	cl_sensitivity = Cvar_Get ("sensitivity", "5", CVAR_ARCHIVE);
 	cl_mouseAccel = Cvar_Get ("cl_mouseAccel", "0", CVAR_ARCHIVE_ND);
+	cl_mouseAspectScaling = Cvar_Get ("cl_mouseAspectScaling", "1", CVAR_ARCHIVE_ND);
 	cl_freelook = Cvar_Get( "cl_freelook", "1", CVAR_ARCHIVE_ND );
 
 	cl_showMouseRate = Cvar_Get ("cl_showmouserate", "0", 0);

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -1259,7 +1259,7 @@ void CL_Init( void ) {
 	cl_run = Cvar_Get ("cl_run", "1", CVAR_ARCHIVE_ND);
 	cl_sensitivity = Cvar_Get ("sensitivity", "5", CVAR_ARCHIVE);
 	cl_mouseAccel = Cvar_Get ("cl_mouseAccel", "0", CVAR_ARCHIVE_ND);
-	cl_mouseAspectScaling = Cvar_Get ("cl_mouseAspectScaling", "1", CVAR_ARCHIVE_ND);
+	cl_mouseAspectScaling = Cvar_Get ("cl_mouseAspectScaling", "0", CVAR_ARCHIVE_ND);
 	cl_freelook = Cvar_Get( "cl_freelook", "1", CVAR_ARCHIVE_ND );
 
 	cl_showMouseRate = Cvar_Get ("cl_showmouserate", "0", 0);

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -263,6 +263,7 @@ extern	cvar_t	*cl_sensitivity;
 extern	cvar_t	*cl_freelook;
 
 extern	cvar_t	*cl_mouseAccel;
+extern	cvar_t	*cl_mouseAspectScaling;
 extern	cvar_t	*cl_showMouseRate;
 
 extern	cvar_t	*cl_allowAltEnter;

--- a/codemp/client/cl_input.cpp
+++ b/codemp/client/cl_input.cpp
@@ -922,12 +922,18 @@ CL_MouseEvent
 =================
 */
 void CL_MouseEvent( int dx, int dy, int time ) {
+	float dxScaled = dx;
+	float dyScaled = dy;
+	if ( cl_mouseAspectScaling->integer ) {
+		dxScaled *= (SCREEN_WIDTH / (float)cls.glconfig.vidWidth);
+		dyScaled *= (SCREEN_HEIGHT / (float)cls.glconfig.vidHeight);
+	}
 	if (g_clAutoMapMode && cls.cgameStarted)
 	{ //automap input
 		autoMapInput_t *data = (autoMapInput_t *)cl.mSharedMemory;
 
-		g_clAutoMapInput.yaw = dx;
-		g_clAutoMapInput.pitch = dy;
+		g_clAutoMapInput.yaw = dxScaled;
+		g_clAutoMapInput.pitch = dyScaled;
 		memcpy(data, &g_clAutoMapInput, sizeof(autoMapInput_t));
 		CGVM_AutomapInput();
 
@@ -935,9 +941,9 @@ void CL_MouseEvent( int dx, int dy, int time ) {
 		g_clAutoMapInput.pitch = 0.0f;
 	}
 	else if ( Key_GetCatcher( ) & KEYCATCH_UI ) {
-		UIVM_MouseEvent( dx, dy );
+		UIVM_MouseEvent( dxScaled, dyScaled );
 	} else if ( Key_GetCatcher( ) & KEYCATCH_CGAME ) {
-		CGVM_MouseEvent( dx, dy );
+		CGVM_MouseEvent( dxScaled, dyScaled );
 	} else {
 		cl.mouseDx[cl.mouseIndex] += dx;
 		cl.mouseDy[cl.mouseIndex] += dy;

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -2731,7 +2731,7 @@ void CL_Init( void ) {
 	// this should be set to the max rate value
 	cl_mouseAccelOffset = Cvar_Get( "cl_mouseAccelOffset", "5", CVAR_ARCHIVE_ND, "Mouse acceleration offset for style 1" );
 
-	cl_mouseAspectScaling = Cvar_Get( "cl_mouseAspectScaling", "1", CVAR_ARCHIVE_ND, "Scale mouse movement correctly in menus based on your desktop aspect ratio" );
+	cl_mouseAspectScaling = Cvar_Get( "cl_mouseAspectScaling", "0", CVAR_ARCHIVE_ND, "Scale mouse movement correctly in menus based on your desktop aspect ratio" );
 
 	cl_showMouseRate = Cvar_Get ("cl_showmouserate", "0", 0);
 	cl_framerate	= Cvar_Get ("cl_framerate", "0", CVAR_TEMP);

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -70,6 +70,7 @@ cvar_t	*cl_sensitivity;
 cvar_t	*cl_mouseAccel;
 cvar_t	*cl_mouseAccelOffset;
 cvar_t	*cl_mouseAccelStyle;
+cvar_t	*cl_mouseAspectScaling;
 cvar_t	*cl_showMouseRate;
 
 cvar_t	*m_pitchVeh;
@@ -2729,6 +2730,8 @@ void CL_Init( void ) {
 	// offset for the power function (for style 1, ignored otherwise)
 	// this should be set to the max rate value
 	cl_mouseAccelOffset = Cvar_Get( "cl_mouseAccelOffset", "5", CVAR_ARCHIVE_ND, "Mouse acceleration offset for style 1" );
+
+	cl_mouseAspectScaling = Cvar_Get( "cl_mouseAspectScaling", "1", CVAR_ARCHIVE_ND, "Scale mouse movement correctly in menus based on your desktop aspect ratio" );
 
 	cl_showMouseRate = Cvar_Get ("cl_showmouserate", "0", 0);
 	cl_framerate	= Cvar_Get ("cl_framerate", "0", CVAR_TEMP);

--- a/codemp/client/client.h
+++ b/codemp/client/client.h
@@ -385,6 +385,7 @@ extern	cvar_t	*cl_freelook;
 extern	cvar_t	*cl_mouseAccel;
 extern	cvar_t	*cl_mouseAccelOffset;
 extern	cvar_t	*cl_mouseAccelStyle;
+extern	cvar_t	*cl_mouseAspectScaling;
 extern	cvar_t	*cl_showMouseRate;
 
 extern	cvar_t	*m_pitchVeh;


### PR DESCRIPTION
With this enabled, the cursor moves about the same rate as my desktop cursor.
Without this, horizontal movement is too sensitive on e.g. 1920x1080 windowed.

It's optional behind a cvar because without a breaking API change[1] or a more complex solution[2], small (sub-pixel) movements are completely discarded by being truncated.

[1] `int` -> `float` for `UI_MOUSE_EVENT` / `CG_MOUSE_EVENT`
[2] e.g. floating point accumulation buffer that emits movement events when it exceeds a whole number