### PR TITLE
can we use CMakePresets.json for some reasonable defaults?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ pip-log.txt
 #############
 [Bb]uild*/
 cmake-build-*
+CMakeUserPresets.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,59 @@
+{
+	"version": 6,
+	"cmakeMinimumRequired": {
+		"major": 3,
+		"minor": 20
+	},
+	"configurePresets": [
+		{
+			"name": "NOOP",
+			"hidden": true,
+			"cacheVariables": {
+				"BuildMPEngine": "OFF",
+				"BuildMPRdVanilla": "OFF",
+				"BuildMPDed": "OFF",
+				"BuildMPGame": "OFF",
+				"BuildMPCGame": "OFF",
+				"BuildMPUI": "OFF",
+				"BuildSPEngine": "OFF",
+				"BuildSPGame": "OFF",
+				"BuildSPRdVanilla": "OFF",
+				"BuildJK2SPEngine": "OFF",
+				"BuildJK2SPGame": "OFF",
+				"BuildJK2SPRdVanilla": "OFF"
+			}
+		},
+		{
+			"name": "JASP",
+			"cacheVariables": {
+				"BuildSPEngine": "ON",
+				"BuildSPGame": "ON",
+				"BuildSPRdVanilla": "ON"
+			}
+		},
+		{
+			"name": "JAMP",
+			"cacheVariables": {
+				"BuildMPEngine": "ON",
+				"BuildMPRdVanilla": "ON",
+				"BuildMPDed": "ON",
+				"BuildMPGame": "ON",
+				"BuildMPCGame": "ON",
+				"BuildMPUI": "ON"
+			}
+		},
+		{
+			"name": "JKA",
+			"inherits": [ "JASP", "JAMP", "NOOP" ]
+		},
+		{
+			"name": "JK2",
+			"inherits": [ "NOOP" ],
+			"cacheVariables": {
+				"BuildJK2SPEngine": "ON",
+				"BuildJK2SPGame": "ON",
+				"BuildJK2SPRdVanilla": "ON"
+			}
+		}
+	]
+}


### PR DESCRIPTION
# DO NOT MERGE

Just an experiment to see if we can make use of CMakePresets for some common, generic options.

It means I can do this:
```sh
cmake --preset=JK2 -DCMAKE_BUILD_TYPE=Release -DOpenGL_GL_PREFERENCE=GLVND ../
```
instead of:
```sh
cmake -DBuildMPEngine=OFF -DBuildMPRdVanilla=OFF -DBuildMPDed=OFF -DBuildMPGame=OFF -DBuildMPCGame=OFF -DBuildMPUI=OFF -DBuildSPEngine=OFF -DBuildSPGame=OFF -DBuildSPRdVanilla=OFF -DBuildJK2SPEngine=ON -DBuildJK2SPGame=ON -DBuildJK2SPRdVanilla=ON -DCMAKE_BUILD_TYPE=Release -DOpenGL_GL_PREFERENCE=GLVND ../
```

But CMake has stupid behavior when combining (inheriting) presets. It's not additive so you end up with combinatorial explosion and redefining explicit variables in each stanza.

We also (ideally) don't want our presets to contain _any_ IDE or toolchain specific details (ref #1089)

How can we make use of and improve this?