### PR TITLE
[MP] fix off-by-one in TruncateGLExtensionsString

### DIFF
--- a/codemp/rd-vanilla/tr_init.cpp
+++ b/codemp/rd-vanilla/tr_init.cpp
@@ -751,7 +751,7 @@ static const char *TruncateGLExtensionsString (const char *extensionsString, int
 
 	char *truncatedExtensions;
 
-	while ( (q = strchr (p, ' ')) != NULL && numExtensions <= maxExtensions )
+	while ( (q = strchr (p, ' ')) != NULL && numExtensions < maxExtensions )
 	{
 		p = q + 1;
 		numExtensions++;


### PR DESCRIPTION
...which affects mods not derived from OJK.

`UI_DrawGLInfo` has an array of size 128, which was being filled from a GL extensions string of 129 words and displaying garbage in the UI.
Discovered by @Daggolin

![image](https://github.com/JACoders/OpenJK/assets/844370/639c0fed-9b15-4be0-a3a4-40ad8eb7df7b)

Ref #472