### PR TITLE
[Shared] add a custom CMake target to copy compilation DB from build dir to source dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,7 @@ pip-log.txt
 ## clangd
 #############
 .clangd
+compile_commands.json
 
 #############
 ## CLion

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,14 @@ endif()
 #=============================================================================
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
+if(CMAKE_EXPORT_COMPILE_COMMANDS)
+	add_custom_target(
+		copy-compile-commands ALL
+		${CMAKE_COMMAND} -E copy_if_different
+		${CMAKE_BINARY_DIR}/compile_commands.json
+		${CMAKE_CURRENT_LIST_DIR})
+endif()
+
 #=============================================================================
 #
 # Architecture/OS defines


### PR DESCRIPTION
Configure with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to generate the compilation DB.
This PR will additionally copy this from the build directory to the source directory.
For example, this will provide better VSCodium support when using clangd instead of MS' C++ extension.

see links for further details:

- <https://clang.llvm.org/docs/JSONCompilationDatabase.html>
- <https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html>