### PR TITLE
Unix: Fix argv[0] getting overwritten on launch

### DIFF
--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -141,8 +141,8 @@ char    *Sys_DefaultAppPath(void);
 #endif
 
 char	*Sys_DefaultHomePath(void);
-const char *Sys_Dirname( char *path );
-const char *Sys_Basename( char *path );
+const char *Sys_Dirname( const char *path );
+const char *Sys_Basename( const char *path );
 
 bool Sys_PathCmp( const char *path1, const char *path2 );
 

--- a/shared/sys/sys_unix.cpp
+++ b/shared/sys/sys_unix.cpp
@@ -164,9 +164,11 @@ qboolean Sys_LowPhysicalMemory( void )
 Sys_Basename
 ==================
 */
-const char *Sys_Basename( char *path )
+const char *Sys_Basename( const char *path )
 {
-	return basename( path );
+	static char buf[ MAX_OSPATH ];
+	Q_strncpyz( buf, path, sizeof(buf) );
+	return basename( buf );
 }
 
 /*
@@ -174,9 +176,11 @@ const char *Sys_Basename( char *path )
 Sys_Dirname
 ==================
 */
-const char *Sys_Dirname( char *path )
+const char *Sys_Dirname( const char *path )
 {
-	return dirname( path );
+	static char buf[ MAX_OSPATH ];
+	Q_strncpyz( buf, path, sizeof(buf) );
+	return dirname( buf );
 }
 
 /*

--- a/shared/sys/sys_win32.cpp
+++ b/shared/sys/sys_win32.cpp
@@ -38,7 +38,7 @@ static UINT timerResolution = 0;
 Sys_Basename
 ==============
 */
-const char *Sys_Basename( char *path )
+const char *Sys_Basename( const char *path )
 {
 	static char base[ MAX_OSPATH ] = { 0 };
 	int length;
@@ -68,7 +68,7 @@ const char *Sys_Basename( char *path )
 Sys_Dirname
 ==============
 */
-const char *Sys_Dirname( char *path )
+const char *Sys_Dirname( const char *path )
 {
 	static char dir[ MAX_OSPATH ] = { 0 };
 	int length;


### PR DESCRIPTION
Calling `Sys_Dirname` on `argv[0]` lead to slashes in `argv[0]` getting overwritten on Linux (and potentially other non-Windows platforms), causing some external script to fail sending signals to the right process, because the path changed.

This pull request adjusts `Sys_Dirname` and `Sys_Basename` to work with a copy of the given string instead of the original. This makes the behavior of both functions more consistent between Windows and other platforms.