### PR TITLE
Improve console and font handling

### DIFF
--- a/code/client/cl_console.cpp
+++ b/code/client/cl_console.cpp
@@ -39,8 +39,20 @@ cvar_t		*con_notifytime;
 cvar_t		*con_opacity; // background alpha multiplier
 cvar_t		*con_autoclear;
 cvar_t		*con_height;
+cvar_t		*con_scale;
+cvar_t		*con_timestamps;
 
 #define	DEFAULT_CONSOLE_WIDTH	78
+
+#define CON_BLANK_CHAR			' '
+#define CON_SCROLL_L_CHAR		'$'
+#define CON_SCROLL_R_CHAR		'$'
+#define CON_TIMESTAMP_LEN		11 // "[13:37:00] "
+#define CON_MIN_WIDTH			20
+
+
+static const conChar_t CON_WRAP = { { ColorIndex(COLOR_GREY), '\\' } };
+static const conChar_t CON_BLANK = { { ColorIndex(COLOR_WHITE), CON_BLANK_CHAR } };
 
 vec4_t	console_color = {0.509f, 0.609f, 0.847f, 1.0f};
 
@@ -83,7 +95,7 @@ void Con_Clear_f (void) {
 	int		i;
 
 	for ( i = 0 ; i < CON_TEXTSIZE ; i++ ) {
-		con.text[i] = (ColorIndex(COLOR_WHITE)<<8) | ' ';
+		con.text[i] = CON_BLANK;
 	}
 
 	Con_Bottom();		// go to end
@@ -98,12 +110,17 @@ Save the console contents out to a file
 */
 void Con_Dump_f (void)
 {
-	int		l, x, i;
-	short	*line;
+	char			filename[MAX_QPATH];
+	qboolean		empty;
+	int				l, i, j;
+	int				line;
+	int				lineLen;
 	fileHandle_t	f;
-	int		bufferlen;
-	char	*buffer;
-	char	filename[MAX_QPATH];
+#ifdef WIN32
+	char			buffer[CON_TIMESTAMP_LEN + MAXPRINTMSG + 2];
+#else
+	char			buffer[CON_TIMESTAMP_LEN + MAXPRINTMSG + 1];
+#endif
 
 	if (Cmd_Argc() != 2)
 	{
@@ -130,47 +147,59 @@ void Con_Dump_f (void)
 	Com_Printf ("Dumped console text to %s.\n", filename );
 
 	// skip empty lines
-	for (l = con.current - con.totallines + 1 ; l <= con.current ; l++)
+	for (l = 1, empty = qtrue ; l < con.totallines && empty ; l++)
 	{
-		line = con.text + (l%con.totallines)*con.linewidth;
-		for (x=0 ; x<con.linewidth ; x++)
-			if ((line[x] & 0xff) != ' ')
-				break;
-		if (x != con.linewidth)
-			break;
+		line = ((con.current + l) % con.totallines) * con.rowwidth;
+
+		for (j = CON_TIMESTAMP_LEN ; j < con.rowwidth - 1 ; j++)
+			if (con.text[line + j].f.character != CON_BLANK_CHAR)
+				empty = qfalse;
 	}
 
-#ifdef _WIN32
-	bufferlen = con.linewidth + 3 * sizeof ( char );
-#else
-	bufferlen = con.linewidth + 2 * sizeof ( char );
-#endif
-
-	buffer = (char *)Z_Malloc( bufferlen, TAG_TEMP_WORKSPACE, qfalse );
-
-	// write the remaining lines
-	buffer[bufferlen-1] = 0;
-	for ( ; l <= con.current ; l++)
+	for ( ; l < con.totallines ; l++)
 	{
-		line = con.text + (l%con.totallines)*con.linewidth;
-		for(i=0; i<con.linewidth; i++)
-			buffer[i] = (char) (line[i] & 0xff);
-		for (x=con.linewidth-1 ; x>=0 ; x--)
+		lineLen = 0;
+		i = 0;
+
+		// Print timestamp
+		if (con_timestamps->integer) {
+			line = ((con.current + l) % con.totallines) * con.rowwidth;
+
+			for (i = 0; i < CON_TIMESTAMP_LEN; i++)
+				buffer[i] = con.text[line + i].f.character;
+
+			lineLen = CON_TIMESTAMP_LEN;
+		}
+
+		// Concatenate wrapped lines
+		for ( ; l < con.totallines ; l++)
 		{
-			if (buffer[x] == ' ')
-				buffer[x] = 0;
-			else
+			line = ((con.current + l) % con.totallines) * con.rowwidth;
+
+			for (j = CON_TIMESTAMP_LEN; j < con.rowwidth - 1 && i < (int)sizeof(buffer) - 1; j++, i++) {
+				buffer[i] = con.text[line + j].f.character;
+
+				if (con.text[line + j].f.character != CON_BLANK_CHAR)
+					lineLen = i + 1;
+			}
+
+			if (i == sizeof(buffer) - 1)
+				break;
+
+			if (con.text[line + j].compare != CON_WRAP.compare)
 				break;
 		}
-#ifdef _WIN32
-		Q_strcat(buffer, bufferlen, "\r\n");
+
+#ifdef WIN32 // I really don't like this inconsistency, but OpenJK has been doing this since April 2013
+		buffer[lineLen] = '\r';
+		buffer[lineLen+1] = '\n';
+		FS_Write(buffer, lineLen + 2, f);
 #else
-		Q_strcat(buffer, bufferlen, "\n");
+		buffer[lineLen] = '\n';
+		FS_Write(buffer, lineLen + 1, f);
 #endif
-		FS_Write(buffer, strlen(buffer), f);
 	}
 
-	Z_Free( buffer );
 	FS_FCloseFile( f );
 }
 
@@ -188,7 +217,132 @@ void Con_ClearNotify( void ) {
 	}
 }
 
+/*
+================
+Con_Initialize
 
+Initialize console for the first time.
+================
+*/
+void Con_Initialize(void)
+{
+	int	i;
+
+	VectorCopy4(colorWhite, con.color);
+	con.charWidth = SMALLCHAR_WIDTH;
+	con.charHeight = SMALLCHAR_HEIGHT;
+	con.linewidth = DEFAULT_CONSOLE_WIDTH;
+	con.rowwidth = CON_TIMESTAMP_LEN + con.linewidth + 1;
+	con.totallines = CON_TEXTSIZE / con.rowwidth;
+	con.current = con.totallines - 1;
+	con.display = con.current;
+	con.xadjust = 1.0f;
+	con.yadjust = 1.0f;
+	for(i=0; i<CON_TEXTSIZE; i++)
+	{
+		con.text[i] = CON_BLANK;
+	}
+
+	con.initialized = qtrue;
+}
+
+
+
+/*
+================
+Con_Resize
+
+Reformat the buffer for new row width
+================
+*/
+static void Con_Resize(int rowwidth)
+{
+	static conChar_t tbuf[CON_TEXTSIZE];
+	int		i, j;
+	int		oldrowwidth;
+	int		oldtotallines;
+
+	oldrowwidth = con.rowwidth;
+	oldtotallines = con.totallines;
+
+	con.rowwidth = rowwidth;
+	con.totallines = CON_TEXTSIZE / rowwidth;
+
+	memcpy (tbuf, con.text, sizeof(tbuf));
+	for(i=0; i<CON_TEXTSIZE; i++)
+		con.text[i] = CON_BLANK;
+
+	int oi = 0;
+	int ni = 0;
+
+	while (oi < oldtotallines)
+		{
+			conChar_t	line[MAXPRINTMSG];
+			conChar_t	timestamp[CON_TIMESTAMP_LEN];
+			int		lineLen = 0;
+			int		oldline = ((con.current + oi) % oldtotallines) * oldrowwidth;
+			int		newline = (ni % con.totallines) * con.rowwidth;
+
+			// Store timestamp
+			for (i = 0; i < CON_TIMESTAMP_LEN; i++)
+				timestamp[i] = tbuf[oldline + i];
+
+			// Store whole line concatenating on CON_WRAP
+			for (i = 0; oi < oldtotallines; oi++)
+				{
+					oldline = ((con.current + oi) % oldtotallines) * oldrowwidth;
+
+					for (j = CON_TIMESTAMP_LEN; j < oldrowwidth - 1 && i < (int)ARRAY_LEN(line); j++, i++) {
+						line[i] = tbuf[oldline + j];
+
+						if (line[i].f.character != CON_BLANK_CHAR)
+							lineLen = i + 1;
+					}
+
+					if (i == ARRAY_LEN(line))
+						break;
+
+					if (tbuf[oldline + j].compare != CON_WRAP.compare)
+						break;
+				}
+
+			oi++;
+
+			// Print stored line to a new text buffer
+			for (i = 0; ; ni++) {
+				newline = (ni % con.totallines) * con.rowwidth;
+
+				// Print timestamp at the begining of each line
+				for (j = 0; j < CON_TIMESTAMP_LEN; j++)
+					con.text[newline + j] = timestamp[j];
+
+				for (j = CON_TIMESTAMP_LEN; j < con.rowwidth - 1 && i < lineLen; j++, i++)
+					con.text[newline + j] = line[i];
+
+				if (i == lineLen) {
+					// Erase remaining chars in case newline wrapped
+					for (; j < con.rowwidth - 1; j++)
+						con.text[newline + j] = CON_BLANK;
+
+					ni++;
+					break;
+				}
+
+				con.text[newline + j] = CON_WRAP;
+			}
+		}
+
+	con.current = ni;
+
+	// Erase con.current line for next CL_ConsolePrint
+	int newline = (con.current % con.totallines) * con.rowwidth;
+	for (j = 0; j < con.rowwidth; j++)
+		con.text[newline + j] = CON_BLANK;
+
+	Con_ClearNotify ();
+
+	con.display = con.current;
+}
 
 /*
 ================
@@ -199,68 +353,44 @@ If the line width has changed, reformat the buffer.
 */
 void Con_CheckResize (void)
 {
-	int		i, j, width, oldwidth, oldtotallines, numlines, numchars;
-	short	tbuf[CON_TEXTSIZE];
+	int		charWidth, rowwidth, width;
+	float	scale;
 
-	//width = (SCREEN_WIDTH / SMALLCHAR_WIDTH) - 2;
-	width = (cls.glconfig.vidWidth / SMALLCHAR_WIDTH) - 2;
+	assert(SMALLCHAR_HEIGHT >= SMALLCHAR_WIDTH);
 
-	if (width == con.linewidth)
-		return;
+	scale = ((con_scale->value > 0.0f) ? con_scale->value : 1.0f);
+	charWidth = scale * SMALLCHAR_WIDTH;
 
-	if (width < 1)			// video hasn't been initialized yet
-	{
-		con.xadjust = 1;
-		con.yadjust = 1;
-		width = DEFAULT_CONSOLE_WIDTH;
-		con.linewidth = width;
-		con.totallines = CON_TEXTSIZE / con.linewidth;
-		for(i=0; i<CON_TEXTSIZE; i++)
-		{
-			con.text[i] = (ColorIndex(COLOR_WHITE)<<8) | ' ';
-		}
-	}
-	else
-	{
-		// on wide screens, we will center the text
-		con.xadjust = 640.0f / cls.glconfig.vidWidth;
-		con.yadjust = 480.0f / cls.glconfig.vidHeight;
-
-		oldwidth = con.linewidth;
-		con.linewidth = width;
-		oldtotallines = con.totallines;
-		con.totallines = CON_TEXTSIZE / con.linewidth;
-		numlines = oldtotallines;
-
-		if (con.totallines < numlines)
-			numlines = con.totallines;
-
-		numchars = oldwidth;
-
-		if (con.linewidth < numchars)
-			numchars = con.linewidth;
-
-		memcpy (tbuf, con.text, CON_TEXTSIZE * sizeof(short));
-		for(i=0; i<CON_TEXTSIZE; i++)
-
-			con.text[i] = (ColorIndex(COLOR_WHITE)<<8) | ' ';
-
-
-		for (i=0 ; i<numlines ; i++)
-		{
-			for (j=0 ; j<numchars ; j++)
-			{
-				con.text[(con.totallines - 1 - i) * con.linewidth + j] =
-						tbuf[((con.current - i + oldtotallines) %
-							  oldtotallines) * oldwidth + j];
-			}
-		}
-
-		Con_ClearNotify ();
+	if (charWidth < 1) {
+		charWidth = 1;
+		scale = (float)charWidth / SMALLCHAR_WIDTH;
 	}
 
-	con.current = con.totallines - 1;
-	con.display = con.current;
+	width = (cls.glconfig.vidWidth / charWidth) - 2;
+
+	if (width < 20) {
+		width = 20;
+		charWidth = cls.glconfig.vidWidth / 22;
+		scale = (float)charWidth / SMALLCHAR_WIDTH;
+	}
+
+	if (charWidth < 1) {
+		Com_Error(ERR_FATAL, "Con_CheckResize: Window too small to draw a console");
+	}
+
+	rowwidth = width + 1 + (con_timestamps->integer ? 0 : CON_TIMESTAMP_LEN);
+
+	con.charWidth = charWidth;
+	con.charHeight = scale * SMALLCHAR_HEIGHT;
+	con.linewidth = width;
+	con.xadjust = ((float)SCREEN_WIDTH) / cls.glconfig.vidWidth;
+	con.yadjust = ((float)SCREEN_HEIGHT) / cls.glconfig.vidHeight;
+	g_consoleField.widthInChars = width - 1; // Command prompt
+
+	if (con.rowwidth != rowwidth)
+	{
+		Con_Resize(rowwidth);
+	}
 }
 
 
@@ -290,6 +420,9 @@ void Con_Init (void) {
 	con_autoclear = Cvar_Get ("con_autoclear", "1", CVAR_ARCHIVE_ND);
 	con_height = Cvar_Get ("con_height", "0.5", CVAR_ARCHIVE_ND);
 
+	con_scale = Cvar_Get ("con_scale", "1", CVAR_ARCHIVE_ND);
+	con_timestamps = Cvar_Get ("con_timestamps", "0", CVAR_ARCHIVE_ND);
+
 	Field_Clear( &g_consoleField );
 	g_consoleField.widthInChars = g_console_field_width;
 	for ( i = 0 ; i < COMMAND_HISTORY ; i++ ) {
@@ -302,6 +435,9 @@ void Con_Init (void) {
 	Cmd_AddCommand ("clear", Con_Clear_f);
 	Cmd_AddCommand ("condump", Con_Dump_f);
 	Cmd_SetCommandCompletionFunc( "condump", Cmd_CompleteTxtName );
+
+	//Initialize values on first print
+	con.initialized = qfalse;
 }
 
 
@@ -313,17 +449,37 @@ Con_Linefeed
 void Con_Linefeed (void)
 {
 	int		i;
+	int		line = (con.current % con.totallines) * con.rowwidth;
+
+	// print timestamp on the PREVIOUS line
+	{
+		time_t t = time( NULL );
+		struct tm *tms = localtime( &t );
+		char timestamp[CON_TIMESTAMP_LEN + 1];
+		const unsigned char color = ColorIndex(COLOR_GREY);
+
+		Com_sprintf(timestamp, sizeof(timestamp), "[%02d:%02d:%02d] ",
+			tms->tm_hour, tms->tm_min, tms->tm_sec);
+
+		for ( i = 0; i < CON_TIMESTAMP_LEN; i++ ) {
+			con.text[line + i].f = { color, timestamp[i] };
+		}
+	}
 
 	// mark time for transparent overlay
 	if (con.current >= 0)
 		con.times[con.current % NUM_CON_TIMES] = cls.realtime;
 
 	con.x = 0;
+
 	if (con.display == con.current)
 		con.display++;
 	con.current++;
-	for(i=0; i<con.linewidth; i++)
-		con.text[(con.current%con.totallines)*con.linewidth+i] = (ColorIndex(COLOR_WHITE)<<8) | ' ';
+
+	line = (con.current % con.totallines) * con.rowwidth;
+
+	for ( i = 0; i < con.rowwidth; i++ )
+		con.text[line + i] = CON_BLANK;
 }
 
 /*
@@ -335,10 +491,10 @@ All console printing must go through this in order to be logged to disk
 If no console is visible, the text will appear at the top of the game window
 ================
 */
-void CL_ConsolePrint( char *txt ) {
+void CL_ConsolePrint( const char *txt) {
 	int		y;
-	int		c, l;
-	int		color;
+	char			c;
+	unsigned char	color;
 
 	// for some demos we don't want to ever show anything on the console
 	if ( cl_noprint && cl_noprint->integer ) {
@@ -346,36 +502,16 @@ void CL_ConsolePrint( char *txt ) {
 	}
 
 	if (!con.initialized) {
-		con.color[0] =
-		con.color[1] =
-		con.color[2] =
-		con.color[3] = 1.0f;
-		con.linewidth = -1;
-		Con_CheckResize ();
-		con.initialized = qtrue;
+		Con_Initialize();
 	}
 
 	color = ColorIndex(COLOR_WHITE);
 
-	while ( (c = (unsigned char )*txt) != 0 ) {
+	while ( (c = (unsigned char) *txt) != 0 ) {
 		if ( Q_IsColorString( (unsigned char*) txt ) ) {
 			color = ColorIndex( *(txt+1) );
 			txt += 2;
 			continue;
-		}
-
-		// count word length
-		for (l=0 ; l< con.linewidth ; l++) {
-			if ( txt[l] <= ' ') {
-				break;
-			}
-
-		}
-
-		// word wrap
-		if (l != con.linewidth && (con.x + l >= con.linewidth) ) {
-			Con_Linefeed();
-
 		}
 
 		txt++;
@@ -390,13 +526,15 @@ void CL_ConsolePrint( char *txt ) {
 			break;
 		default:	// display character and advance
 			y = con.current % con.totallines;
-			con.text[y*con.linewidth+con.x] = (color << 8) | c;
-			con.x++;
-			if (con.x >= con.linewidth) {
 
+			if (con.x == con.rowwidth - CON_TIMESTAMP_LEN - 1) {
+				con.text[y * con.rowwidth + CON_TIMESTAMP_LEN + con.x] = CON_WRAP;
 				Con_Linefeed();
-				con.x = 0;
+				y = con.current % con.totallines;
 			}
+
+			con.text[y * con.rowwidth + CON_TIMESTAMP_LEN + con.x].f = { color, c };
+			con.x++;
 			break;
 		}
 	}
@@ -432,14 +570,23 @@ void Con_DrawInput (void) {
 		return;
 	}
 
-	y = con.vislines - ( SMALLCHAR_HEIGHT * (re.Language_IsAsian() ? 1.5 : 2) );
+	y = con.vislines - ( con.charHeight * (re.Language_IsAsian() ? 1.5 : 2) );
 
 	re.SetColor( con.color );
 
-	SCR_DrawSmallChar( con.xadjust + 1 * SMALLCHAR_WIDTH, y, CONSOLE_PROMPT_CHAR );
+	Field_Draw( &g_consoleField, 2 * con.charWidth, y, qtrue, qtrue );
 
-	Field_Draw( &g_consoleField, con.xadjust + 2 * SMALLCHAR_WIDTH, y,
-		SCREEN_WIDTH - 3 * SMALLCHAR_WIDTH, qtrue, qtrue );
+	SCR_DrawSmallChar( con.charWidth, y, CONSOLE_PROMPT_CHAR );
+
+	re.SetColor( g_color_table[ColorIndex(COLOR_GREY)] );
+
+	if ( g_consoleField.scroll > 0 )
+		SCR_DrawSmallChar( 0, y, CON_SCROLL_L_CHAR );
+
+	int len = Q_PrintStrlen( g_consoleField.buffer );
+	int pos = Q_PrintStrLenTo( g_consoleField.buffer, g_consoleField.scroll, NULL );
+	if ( pos + g_consoleField.widthInChars < len )
+		SCR_DrawSmallChar( cls.glconfig.vidWidth - con.charWidth, y, CON_SCROLL_R_CHAR );
 }
 
 
@@ -453,13 +600,24 @@ Draws the last few lines of output transparently over the game top
 void Con_DrawNotify (void)
 {
 	int		x, v;
-	short	*text;
+	conChar_t		*text;
 	int		i;
 	int		time;
 	int		currentColor;
 
 	currentColor = 7;
 	re.SetColor( g_color_table[currentColor] );
+
+	static int iFontIndex = re.RegisterFont("ocr_a");
+	float fFontScale = 1.0f;
+	int iPixelHeightToAdvance = 0;
+	if (re.Language_IsAsian())
+	{
+		fFontScale = con.charWidth * 10.0f /
+			re.Font_StrLenPixels("aaaaaaaaaa", iFontIndex, 1.0f);
+		fFontScale *= con.yadjust;
+		iPixelHeightToAdvance = 2+(1.3/con.yadjust) * re.Font_HeightPixels(iFontIndex, fFontScale);
+	}
 
 	v = 0;
 	for (i= con.current-NUM_CON_TIMES+1 ; i<=con.current ; i++)
@@ -472,7 +630,9 @@ void Con_DrawNotify (void)
 		time = cls.realtime - time;
 		if (time > con_notifytime->value*1000)
 			continue;
-		text = con.text + (i % con.totallines)*con.linewidth;
+		text = con.text + (i % con.totallines)*con.rowwidth;
+		if (!con_timestamps->integer)
+			text += CON_TIMESTAMP_LEN;
 
 		// asian language needs to use the new font system to print glyphs...
 		//
@@ -480,41 +640,40 @@ void Con_DrawNotify (void)
 		//
 		if (re.Language_IsAsian())
 		{
-			int iFontIndex = re.RegisterFont("ocr_a");	// this seems naughty
-			const float fFontScale = 0.75f*con.yadjust;
-			const int iPixelHeightToAdvance =   2+(1.3/con.yadjust) * re.Font_HeightPixels(iFontIndex, fFontScale);	// for asian spacing, since we don't want glyphs to touch.
-
 			// concat the text to be printed...
 			//
-			char sTemp[4096]={0};	// ott
+			char sTemp[4096];	// ott
+			sTemp[0] = '\0';
 			for (x = 0 ; x < con.linewidth ; x++)
 			{
-				if ( ( (text[x]>>8)&Q_COLOR_BITS ) != currentColor ) {
-					currentColor = (text[x]>>8)&Q_COLOR_BITS;
-					strcat(sTemp,va("^%i", (text[x]>>8)&Q_COLOR_BITS) );
+				if ( text[x].f.color != currentColor ) {
+					currentColor = text[x].f.color;
+					strcat(sTemp,va("^%i", currentColor ));
 				}
-				strcat(sTemp,va("%c",text[x] & 0xFF));
+				strcat(sTemp,va("%c",text[x].f.character));
 			}
 			//
 			// and print...
 			//
-			re.Font_DrawString(con.xadjust*(con.xadjust + (1*SMALLCHAR_WIDTH/*aesthetics*/)), con.yadjust*(v), sTemp, g_color_table[currentColor], iFontIndex, -1, fFontScale);
+			re.Font_DrawString(con.xadjust * (con.xadjust + con.charWidth), con.yadjust * v, sTemp,
+				g_color_table[currentColor], iFontIndex, -1, fFontScale);
 
 			v +=  iPixelHeightToAdvance;
 		}
 		else
 		{
 			for (x = 0 ; x < con.linewidth ; x++) {
-				if ( ( text[x] & 0xff ) == ' ' ) {
+				if ( text[x].f.character == ' ' ) {
 					continue;
 				}
-				if ( ( (text[x]>>8)&Q_COLOR_BITS ) != currentColor ) {
-					currentColor = (text[x]>>8)&Q_COLOR_BITS;
+				if ( text[x].f.color != currentColor ) {
+					currentColor = text[x].f.color;
 					re.SetColor( g_color_table[currentColor] );
 				}
-				SCR_DrawSmallChar( con.xadjust + (x+1)*SMALLCHAR_WIDTH, v, text[x] & 0xff );
+				SCR_DrawSmallChar( (x+1)*con.charWidth, v, text[x].f.character );
 			}
-			v += SMALLCHAR_HEIGHT;
+
+			v += con.charHeight;
 		}
 	}
 
@@ -532,9 +691,10 @@ void Con_DrawSolidConsole( float frac )
 {
 	int				i, x, y;
 	int				rows;
-	short			*text;
+	conChar_t		*text;
 	int				row;
 	int				lines;
+//	qhandle_t		conShader;
 	int				currentColor;
 
 	lines = cls.glconfig.vidHeight * frac;
@@ -561,7 +721,7 @@ void Con_DrawSolidConsole( float frac )
 		{
 			re.SetColor(NULL);
 		}
-		SCR_DrawPic( 0, 0, SCREEN_WIDTH, y, cls.consoleShader);
+		SCR_DrawPic( 0, 0, SCREEN_WIDTH, y, cls.consoleShader );
 	}
 
 	// draw the bottom bar and version number
@@ -572,8 +732,8 @@ void Con_DrawSolidConsole( float frac )
 	i = strlen( Q3_VERSION );
 
 	for (x=0 ; x<i ; x++) {
-		SCR_DrawSmallChar( cls.glconfig.vidWidth - ( i - x + 1 ) * SMALLCHAR_WIDTH,
-			(lines-(SMALLCHAR_HEIGHT+SMALLCHAR_HEIGHT/2)), Q3_VERSION[x] );
+		SCR_DrawSmallChar( cls.glconfig.vidWidth - ( i - x + 1 ) * con.charWidth,
+			(lines-(con.charHeight+con.charHeight/2)), Q3_VERSION[x] );
 	}
 
 	// draw the input prompt, user text, and cursor if desired
@@ -581,9 +741,9 @@ void Con_DrawSolidConsole( float frac )
 
 	// draw the text
 	con.vislines = lines;
-	rows = (lines-SMALLCHAR_WIDTH)/SMALLCHAR_WIDTH;		// rows of text to draw
+	rows = (lines-con.charHeight)/con.charHeight;		// rows of text to draw
 
-	y = lines - (SMALLCHAR_HEIGHT*3);
+	y = lines - (con.charHeight*3);
 
 	// draw from the bottom up
 	if (con.display != con.current)
@@ -591,8 +751,8 @@ void Con_DrawSolidConsole( float frac )
 	// draw arrows to show the buffer is backscrolled
 		re.SetColor( console_color );
 		for (x=0 ; x<con.linewidth ; x+=4)
-			SCR_DrawSmallChar( con.xadjust + (x+1)*SMALLCHAR_WIDTH, y, '^' );
-		y -= SMALLCHAR_HEIGHT;
+			SCR_DrawSmallChar( (x+1)*con.charWidth, y, '^' );
+		y -= con.charHeight;
 		rows--;
 	}
 
@@ -605,17 +765,15 @@ void Con_DrawSolidConsole( float frac )
 	currentColor = 7;
 	re.SetColor( g_color_table[currentColor] );
 
-
-	int iFontIndexForAsian = 0;	// kinda tacky, this just gets the first registered font, since Asian stuff ignores the contents anyway
-	const float fFontScaleForAsian = 0.75f*con.yadjust;
-	int iPixelHeightToAdvance = SMALLCHAR_HEIGHT;
+	static int iFontIndex = re.RegisterFont("ocr_a");
+	float fFontScale = 1.0f;
+	int iPixelHeightToAdvance = con.charHeight;
 	if (re.Language_IsAsian())
 	{
-		if (!iFontIndexForAsian)
-		{
-			iFontIndexForAsian = re.RegisterFont("ocr_a");	// must be a font that's used elsewhere
-		}
-		iPixelHeightToAdvance =   (1.3/con.yadjust) * re.Font_HeightPixels(iFontIndexForAsian, fFontScaleForAsian);	// for asian spacing, since we don't want glyphs to touch.
+		fFontScale = con.charWidth * 10.0f /
+			re.Font_StrLenPixels("aaaaaaaaaa", iFontIndex, 1.0f);
+		fFontScale *= con.yadjust;
+		iPixelHeightToAdvance = 2+(1.3/con.yadjust) * re.Font_HeightPixels(iFontIndex, fFontScale);
 	}
 
 	for (i=0 ; i<rows ; i++, y -= iPixelHeightToAdvance, row--)
@@ -627,8 +785,9 @@ void Con_DrawSolidConsole( float frac )
 			continue;
 		}
 
-		text = con.text + (row % con.totallines)*con.linewidth;
-
+		text = con.text + (row % con.totallines)*con.rowwidth;
+		if (!con_timestamps->integer)
+			text += CON_TIMESTAMP_LEN;
 
 		// asian language needs to use the new font system to print glyphs...
 		//
@@ -638,32 +797,34 @@ void Con_DrawSolidConsole( float frac )
 		{
 			// concat the text to be printed...
 			//
-			char sTemp[4096]={0};	// ott
-			for (x = 0 ; x < con.linewidth ; x++)
+			char sTemp[4096];	// ott
+			sTemp[0] = '\0';
+			for (x = 0 ; x < con.linewidth + 1 ; x++)
 			{
-				if ( ( (text[x]>>8)&Q_COLOR_BITS ) != currentColor ) {
-					currentColor = (text[x]>>8)&Q_COLOR_BITS;
-					strcat(sTemp,va("^%i", (text[x]>>8)&Q_COLOR_BITS) );
+				if ( text[x].f.color != currentColor ) {
+					currentColor = text[x].f.color;
+					strcat(sTemp,va("^%i", currentColor ));
 				}
-				strcat(sTemp,va("%c",text[x] & 0xFF));
+				strcat(sTemp,va("%c",text[x].f.character));
 			}
 			//
 			// and print...
 			//
-			re.Font_DrawString(con.xadjust*(con.xadjust + (1*SMALLCHAR_WIDTH/*(aesthetics)*/)), con.yadjust*(y), sTemp, g_color_table[currentColor], iFontIndexForAsian, -1, fFontScaleForAsian);
+			re.Font_DrawString(con.xadjust*(con.xadjust + con.charWidth), con.yadjust * y, sTemp, g_color_table[currentColor],
+				iFontIndex, -1, fFontScale);
 		}
 		else
 		{
-			for (x=0 ; x<con.linewidth ; x++) {
-				if ( ( text[x] & 0xff ) == ' ' ) {
+			for (x = 0; x < con.linewidth + 1 ; x++) {
+				if ( text[x].f.character == ' ' ) {
 					continue;
 				}
 
-				if ( ( (text[x]>>8)&Q_COLOR_BITS ) != currentColor ) {
-					currentColor = (text[x]>>8)&Q_COLOR_BITS;
+				if ( text[x].f.color != currentColor ) {
+					currentColor = text[x].f.color;
 					re.SetColor( g_color_table[currentColor] );
 				}
-				SCR_DrawSmallChar(  con.xadjust + (x+1)*SMALLCHAR_WIDTH, y, text[x] & 0xff );
+				SCR_DrawSmallChar( (x+1)*con.charWidth, y, text[x].f.character );
 			}
 		}
 	}

--- a/code/client/cl_console.cpp
+++ b/code/client/cl_console.cpp
@@ -38,6 +38,7 @@ cvar_t		*con_conspeed;
 cvar_t		*con_notifytime;
 cvar_t		*con_opacity; // background alpha multiplier
 cvar_t		*con_autoclear;
+cvar_t		*con_height;
 
 #define	DEFAULT_CONSOLE_WIDTH	78
 
@@ -287,6 +288,7 @@ void Con_Init (void) {
 
 	con_opacity = Cvar_Get ("con_opacity", "0.8", CVAR_ARCHIVE_ND);
 	con_autoclear = Cvar_Get ("con_autoclear", "1", CVAR_ARCHIVE_ND);
+	con_height = Cvar_Get ("con_height", "0.5", CVAR_ARCHIVE_ND);
 
 	Field_Clear( &g_consoleField );
 	g_consoleField.widthInChars = g_console_field_width;
@@ -710,7 +712,7 @@ Scroll it up or down
 void Con_RunConsole (void) {
 	// decide on the destination height of the console
 	if ( Key_GetCatcher( ) & KEYCATCH_CONSOLE )
-		con.finalFrac = 0.5;		// half screen
+		con.finalFrac = con_height->value;
 	else
 		con.finalFrac = 0;				// none visible
 

--- a/code/client/cl_console.cpp
+++ b/code/client/cl_console.cpp
@@ -576,6 +576,9 @@ void Con_DrawSolidConsole( float frac )
 			(lines-(SMALLCHAR_HEIGHT+SMALLCHAR_HEIGHT/2)), Q3_VERSION[x] );
 	}
 
+	// draw the input prompt, user text, and cursor if desired
+	Con_DrawInput ();
+
 	// draw the text
 	con.vislines = lines;
 	rows = (lines-SMALLCHAR_WIDTH)/SMALLCHAR_WIDTH;		// rows of text to draw
@@ -664,9 +667,6 @@ void Con_DrawSolidConsole( float frac )
 			}
 		}
 	}
-
-	// draw the input prompt, user text, and cursor if desired
-	Con_DrawInput ();
 
 	re.SetColor( NULL );
 }

--- a/code/client/cl_console.cpp
+++ b/code/client/cl_console.cpp
@@ -608,7 +608,7 @@ void Con_DrawNotify (void)
 	currentColor = 7;
 	re.SetColor( g_color_table[currentColor] );
 
-	static int iFontIndex = re.RegisterFont("ocr_a");
+	int iFontIndex = cls.consoleFont;
 	float fFontScale = 1.0f;
 	int iPixelHeightToAdvance = 0;
 	if (re.Language_IsAsian())
@@ -765,7 +765,7 @@ void Con_DrawSolidConsole( float frac )
 	currentColor = 7;
 	re.SetColor( g_color_table[currentColor] );
 
-	static int iFontIndex = re.RegisterFont("ocr_a");
+	int iFontIndex = cls.consoleFont;
 	float fFontScale = 1.0f;
 	int iPixelHeightToAdvance = con.charHeight;
 	if (re.Language_IsAsian())

--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -398,7 +398,8 @@ Handles horizontal scrolling and cursor blinking
 x, y, amd width are in pixels
 ===================
 */
-void Field_VariableSizeDraw( field_t *edit, int x, int y, int width, int size, qboolean showCursor, qboolean noColorEscape ) {
+extern console_t con;
+void Field_VariableSizeDraw( field_t *edit, int x, int y, int size, qboolean showCursor, qboolean noColorEscape ) {
 	int		len;
 	int		drawLen;
 	int		prestep;
@@ -434,7 +435,7 @@ void Field_VariableSizeDraw( field_t *edit, int x, int y, int width, int size, q
 	str[ drawLen ] = 0;
 
 	// draw it
-	if ( size == SMALLCHAR_WIDTH ) {
+	if ( size == con.charWidth ) {
 		float	color[4];
 
 		color[0] = color[1] = color[2] = color[3] = 1.0;
@@ -458,7 +459,7 @@ void Field_VariableSizeDraw( field_t *edit, int x, int y, int width, int size, q
 
 		i = drawLen - strlen( str );
 
-		if ( size == SMALLCHAR_WIDTH ) {
+		if ( size == con.charWidth ) {
 			SCR_DrawSmallChar( x + ( edit->cursor - prestep - i ) * size, y, cursorChar );
 		} else {
 			str[0] = cursorChar;
@@ -468,14 +469,14 @@ void Field_VariableSizeDraw( field_t *edit, int x, int y, int width, int size, q
 	}
 }
 
-void Field_Draw( field_t *edit, int x, int y, int width, qboolean showCursor, qboolean noColorEscape )
+void Field_Draw( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape )
 {
-	Field_VariableSizeDraw( edit, x, y, width, SMALLCHAR_WIDTH, showCursor, noColorEscape );
+	Field_VariableSizeDraw( edit, x, y, con.charWidth, showCursor, noColorEscape );
 }
 
-void Field_BigDraw( field_t *edit, int x, int y, int width, qboolean showCursor, qboolean noColorEscape )
+void Field_BigDraw( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape )
 {
-	Field_VariableSizeDraw( edit, x, y, width, BIGCHAR_WIDTH, showCursor, noColorEscape );
+	Field_VariableSizeDraw( edit, x, y, BIGCHAR_WIDTH, showCursor, noColorEscape );
 }
 
 /*

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -935,6 +935,7 @@ void CL_InitRenderer( void ) {
 
 	// load character sets
 	cls.charSetShader = re.RegisterShaderNoMip("gfx/2d/charsgrid_med");
+	cls.consoleFont = re.RegisterFont( "ocr_a" );
 	cls.whiteShader = re.RegisterShader( "white" );
 	cls.consoleShader = re.RegisterShader( "console" );
 	g_console_field_width = cls.glconfig.vidWidth / SMALLCHAR_WIDTH - 2;

--- a/code/client/cl_main.cpp
+++ b/code/client/cl_main.cpp
@@ -78,6 +78,7 @@ cvar_t	*cl_inGameVideo;
 
 cvar_t	*cl_consoleKeys;
 cvar_t	*cl_consoleUseScanCode;
+cvar_t	*cl_consoleShiftRequirement;
 
 clientActive_t		cl;
 clientConnection_t	clc;
@@ -1279,6 +1280,7 @@ void CL_Init( void ) {
 	// ~ and `, as keys and characters
 	cl_consoleKeys = Cvar_Get( "cl_consoleKeys", "~ ` 0x7e 0x60 0xb2", CVAR_ARCHIVE);
 	cl_consoleUseScanCode = Cvar_Get( "cl_consoleUseScanCode", "1", CVAR_ARCHIVE );
+	cl_consoleShiftRequirement = Cvar_Get( "cl_consoleShiftRequirement", "0", CVAR_ARCHIVE );
 
 	// userinfo
 #ifdef JK2_MODE

--- a/code/client/cl_scrn.cpp
+++ b/code/client/cl_scrn.cpp
@@ -151,7 +151,7 @@ void SCR_DrawSmallChar( int x, int y, int ch ) {
 		return;
 	}
 
-	if ( y < -SMALLCHAR_HEIGHT ) {
+	if ( y < -con.charHeight ) {
 		return;
 	}
 
@@ -162,7 +162,7 @@ void SCR_DrawSmallChar( int x, int y, int ch ) {
 	fcol = col*0.0625;
 	size = 0.0625;
 
-	re.DrawStretchPic( x, y, SMALLCHAR_WIDTH, SMALLCHAR_HEIGHT,
+	re.DrawStretchPic( x, y, con.charWidth, con.charHeight,
 					   fcol, frow,
 					   fcol + size, frow + size,
 					   cls.charSetShader );
@@ -176,7 +176,7 @@ void SCR_DrawSmallChar( int x, int y, int ch ) {
 	size2 = 0.0625;
 
 	re.DrawStretchPic( x * con.xadjust, y * con.yadjust,
-						SMALLCHAR_WIDTH * con.xadjust, SMALLCHAR_HEIGHT * con.yadjust,
+						con.charWidth * con.xadjust, con.charHeight * con.yadjust,
 		fcol, frow,
 		fcol + size, frow + size2,
 		cls.charSetShader );
@@ -284,7 +284,7 @@ void SCR_DrawSmallStringExt( int x, int y, const char *string, float *setColor, 
 			}
 		}
 		SCR_DrawSmallChar( xx, y, *s );
-		xx += SMALLCHAR_WIDTH;
+		xx += con.charWidth;
 		s++;
 	}
 	re.SetColor( NULL );

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -279,6 +279,7 @@ extern	cvar_t	*cl_activeAction;
 
 extern	cvar_t	*cl_consoleKeys;
 extern	cvar_t	*cl_consoleUseScanCode;
+extern	cvar_t	*cl_consoleShiftRequirement;
 
 //=================================================
 

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -211,16 +211,28 @@ typedef struct {
 #define	CON_TEXTSIZE	0x30000 //was 32768
 #define	NUM_CON_TIMES	4
 
+typedef union {
+	struct {
+		unsigned char	color;
+		char			character;
+	} f;
+	unsigned short	compare;
+} conChar_t;
+
 typedef struct {
 	qboolean	initialized;
 
-	short	text[CON_TEXTSIZE];
+	conChar_t	text[CON_TEXTSIZE];
 	int		current;		// line where next message will be printed
 	int		x;				// offset in current line for next print
 	int		display;		// bottom of console displays this line
 
 	int 	linewidth;		// characters across screen
+	int		rowwidth;		// timestamp, text and line wrap character
 	int		totallines;		// total lines in console scrollback
+
+	int		charWidth;		// Scaled console character width
+	int		charHeight;		// Scaled console character height
 
 	float	xadjust;		// for wide aspect screens
 	float	yadjust;

--- a/code/client/client.h
+++ b/code/client/client.h
@@ -206,6 +206,7 @@ typedef struct {
 	qhandle_t	charSetShader;
 	qhandle_t	whiteShader;
 	qhandle_t	consoleShader;
+	int			consoleFont;
 } clientStatic_t;
 
 #define	CON_TEXTSIZE	0x30000 //was 32768

--- a/code/client/keys.h
+++ b/code/client/keys.h
@@ -55,8 +55,8 @@ extern field_t		historyEditLines[COMMAND_HISTORY];
 
 void	Field_KeyDownEvent	( field_t *edit, int key );
 void	Field_CharEvent		( field_t *edit, int ch );
-void	Field_Draw			( field_t *edit, int x, int y, int width, qboolean showCursor, qboolean noColorEscape );
-void	Field_BigDraw		( field_t *edit, int x, int y, int width, qboolean showCursor, qboolean noColorEscape );
+void	Field_Draw			( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape );
+void	Field_BigDraw		( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape );
 
 void		Key_SetBinding			( int keynum, const char *binding );
 const char *Key_GetBinding			( int keynum );

--- a/code/qcommon/common.cpp
+++ b/code/qcommon/common.cpp
@@ -73,6 +73,8 @@ cvar_t	*com_G2Report;
 
 cvar_t *com_affinity;
 
+cvar_t	*com_timestamps;
+
 // com_speeds times
 int		time_game;
 int		time_frontend;		// renderer frontend time
@@ -137,6 +139,7 @@ A raw string should NEVER be passed as fmt, because of "%f" type crashers.
 void QDECL Com_Printf( const char *fmt, ... ) {
 	va_list		argptr;
 	char		msg[MAXPRINTMSG];
+	const char *p;
 
 	va_start (argptr,fmt);
 	Q_vsnprintf (msg, sizeof(msg), fmt, argptr);
@@ -153,26 +156,53 @@ void QDECL Com_Printf( const char *fmt, ... ) {
 
 	CL_ConsolePrint( msg );
 
-	// echo to dedicated console and early console
-	Sys_Print( msg );
+	p = msg;
+	while (*p) {
+		static qboolean	newLine = qtrue;
+		char			line[MAXPRINTMSG];
+		size_t			lineLen;
+
+		if (newLine && com_timestamps && com_timestamps->integer) {
+			time_t t = time( NULL );
+			struct tm *tms = localtime( &t );
+			Com_sprintf(line, sizeof(line), "%04i-%02i-%02i %02i:%02i:%02i ",
+				1900 + tms->tm_year, 1 + tms->tm_mon, tms->tm_mday, tms->tm_hour, tms->tm_min, tms->tm_sec);
+			lineLen = strlen(line);
+			newLine = qfalse;
+		} else {
+			if (const char *s = strchr(p, '\n')) {
+				lineLen = (size_t)(s - p + 1);
+				newLine = qtrue;
+			} else {
+				lineLen = strlen(p);
+			}
+
+			Com_Memcpy(line, p, lineLen);
+			line[lineLen] = '\0';
+			p += lineLen;
+		}
+
+		// echo to dedicated console and early console
+		Sys_Print( line );
 
 
 #ifdef OUTPUT_TO_BUILD_WINDOW
-	OutputDebugString(msg);
+		OutputDebugString(line);
 #endif
 
-	// logfile
-	if ( com_logfile && com_logfile->integer ) {
-		if ( !logfile && FS_Initialized() ) {
-			logfile = FS_FOpenFileWrite( "qconsole.log" );
-			if ( com_logfile->integer > 1 ) {
-				// force it to not buffer so we get valid
-				// data even if we are crashing
-				FS_ForceFlush(logfile);
+		// logfile
+		if ( com_logfile && com_logfile->integer ) {
+			if ( !logfile && FS_Initialized() ) {
+				logfile = FS_FOpenFileWrite( "qconsole.log" );
+				if ( com_logfile->integer > 1 ) {
+					// force it to not buffer so we get valid
+					// data even if we are crashing
+					FS_ForceFlush(logfile);
+				}
 			}
-		}
-		if ( logfile ) {
-			FS_Write(msg, strlen(msg), logfile);
+			if ( logfile ) {
+				FS_Write(line, strlen(line), logfile);
+			}
 		}
 	}
 }
@@ -1120,6 +1150,8 @@ void Com_Init( char *commandLine ) {
 		com_busyWait = Cvar_Get( "com_busyWait", "0", CVAR_ARCHIVE_ND );
 
 		com_bootlogo = Cvar_Get( "com_bootlogo", "1", CVAR_ARCHIVE_ND );
+
+		com_timestamps = Cvar_Get( "com_timestamps", "1", CVAR_ARCHIVE_ND );
 
 		if ( com_developer && com_developer->integer ) {
 			Cmd_AddCommand ("error", Com_Error_f);

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -739,7 +739,7 @@ void CL_JoystickEvent( int axis, int value, int time );
 
 void CL_PacketEvent( netadr_t from, msg_t *msg );
 
-void CL_ConsolePrint( char *text );
+void CL_ConsolePrint( const char *text );
 
 void CL_MapLoading( void );
 // do a screen update before starting to load a map

--- a/code/rd-common/tr_font.cpp
+++ b/code/rd-common/tr_font.cpp
@@ -34,6 +34,8 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #include "../qcommon/strippublic.h"
 #endif
 
+cvar_t *r_fontSharpness;
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // This file is shared in the single and multiplayer codebases, so be CAREFUL WHAT YOU ADD/CHANGE!!!!!
@@ -218,6 +220,8 @@ struct ThaiCodes_t
 #define GLYPH_MAX_THAI_SHADERS		3
 #define GLYPH_MAX_ASIAN_SHADERS		4	// this MUST equal the larger of the above defines
 
+#define MAX_FONT_VARIANTS 8
+
 class CFontInfo
 {
 private:
@@ -260,6 +264,11 @@ public:
 #endif
 	bool			m_bIsFakeAlienLanguage;	// ... if true, don't process as MBCS or override as SBCS etc
 
+	CFontInfo		*m_variants[MAX_FONT_VARIANTS];
+	int				m_numVariants;
+	int				m_handle;
+	qboolean		m_isVariant;
+
 	CFontInfo(const char *fontName);
 //	CFontInfo(int fill) { memset(this, fill, sizeof(*this)); }	// wtf?
 	~CFontInfo(void) {}
@@ -284,6 +293,12 @@ public:
 	bool AsianGlyphsAvailable(void) const { return !!(m_hAsianShaders[0]); }
 
 	void UpdateAsianIfNeeded( bool bForceReEval = false);
+
+	int GetHandle();
+
+	void AddVariant(CFontInfo *variant);
+	int GetNumVariants();
+	CFontInfo *GetVariant(int index);
 };
 
 //================================================
@@ -979,6 +994,11 @@ qboolean Language_UsesSpaces(void)
 //  If path present, it's a special language hack for SBCS override languages, eg: "lcd/russian", which means
 //	  just treat the file as "russian", but with the "lcd" part ensuring we don't find a different registered russian font
 //
+static const char *FontDatPath( const char *_fontName ) {
+	static char fontName[MAX_QPATH];
+	sprintf( fontName,"fonts/%s.fontdat",COM_SkipPath(const_cast<char*>(_fontName)) );	// COM_SkipPath should take a const char *, but it's just possible people use it as a char * I guess, so I have to hack around like this <groan>
+	return fontName;
+}
 CFontInfo::CFontInfo(const char *_fontName)
 {
 	int			len, i;
@@ -987,8 +1007,7 @@ CFontInfo::CFontInfo(const char *_fontName)
 
 	// remove any special hack name insertions...
 	//
-	char fontName[MAX_QPATH];
-	sprintf(fontName,"fonts/%s.fontdat",COM_SkipPath(const_cast<char*>(_fontName)));	// COM_SkipPath should take a const char *, but it's just possible people use it as a char * I guess, so I have to hack around like this <groan>
+	const char *fontName = FontDatPath( _fontName );
 
 	// clear some general things...
 	//
@@ -1056,6 +1075,7 @@ CFontInfo::CFontInfo(const char *_fontName)
 
 	// finished...
 	g_vFontArray.resize(g_iCurrentFontIndex + 1);
+	m_handle = g_iCurrentFontIndex;
 	g_vFontArray[g_iCurrentFontIndex++] = this;
 
 
@@ -1137,6 +1157,24 @@ CFontInfo::CFontInfo(const char *_fontName)
 			}
 		}
 	}
+
+	m_numVariants = 0;
+}
+
+int CFontInfo::GetHandle() {
+	return m_handle;
+}
+
+void CFontInfo::AddVariant(CFontInfo * replacer) {
+	m_variants[m_numVariants++] = replacer;
+}
+
+int CFontInfo::GetNumVariants() {
+	return m_numVariants;
+}
+
+CFontInfo *CFontInfo::GetVariant(int index) {
+	return m_variants[index];
 }
 
 void CFontInfo::UpdateAsianIfNeeded( bool bForceReEval /* = false */ )
@@ -1287,6 +1325,30 @@ static CFontInfo *GetFont_Actual(int index)
 	return(NULL);
 }
 
+static CFontInfo *RE_Font_GetVariant(CFontInfo *font, float *scale) {
+	int variants = font->GetNumVariants();
+
+	if (variants > 0) {
+		CFontInfo *variant;
+		int requestedSize = font->GetPointSize() * *scale *
+			r_fontSharpness->value * (glConfig.vidHeight / SCREEN_HEIGHT);
+
+		if (requestedSize <= font->GetPointSize())
+			return font;
+
+		for (int i = 0; i < variants; i++) {
+			variant = font->GetVariant(i);
+
+			if (requestedSize <= variant->GetPointSize())
+				break;
+		}
+
+		*scale *= (float)font->GetPointSize() / variant->GetPointSize();
+		return variant;
+	}
+
+	return font;
+}
 
 // needed to add *piShader param because of multiple TPs,
 //	if not passed in, then I also skip S,T calculations for re-usable static asian glyphinfo struct...
@@ -1534,8 +1596,9 @@ CFontInfo *GetFont(int index)
 }
 
 
-int RE_Font_StrLenPixels(const char *psText, const int iFontHandle, const float fScale)
+int RE_Font_StrLenPixels(const char *psText, const int iFontHandle, const float fScaleIn)
 {
+	float fScale = fScaleIn;
 #ifdef JK2_MODE
 	// Yes..even this func is a little different, to the point where it doesn't work. --eez
 	float		fMaxWidth = 0.0f;
@@ -1547,6 +1610,7 @@ int RE_Font_StrLenPixels(const char *psText, const int iFontHandle, const float 
 	{
 		return(0);
 	}
+	curfont = RE_Font_GetVariant(curfont, &fScale);
 
 	float fScaleAsian = fScale;
 	if (Language_IsAsian() && fScale > 0.7f )
@@ -1586,6 +1650,7 @@ int RE_Font_StrLenPixels(const char *psText, const int iFontHandle, const float 
 	{
 		return(0);
 	}
+	curfont = RE_Font_GetVariant(curfont, &fScale);
 
 	float fScaleAsian = fScale;
 	if (Language_IsAsian() && fScale > 0.7f )
@@ -1673,14 +1738,17 @@ int RE_Font_StrLenChars(const char *psText)
 	return iCharCount;
 }
 
-int RE_Font_HeightPixels(const int iFontHandle, const float fScale)
+int RE_Font_HeightPixels(const int iFontHandle, const float fScaleIn)
 {
+	float fScale = fScaleIn;
 	CFontInfo	*curfont;
 
 	curfont = GetFont(iFontHandle);
 	if(curfont)
 	{
-		float fValue = curfont->GetPointSize() * fScale;
+		float fValue;
+		curfont = RE_Font_GetVariant(curfont, &fScale);
+		fValue = curfont->GetPointSize() * fScale;
 		return curfont->mbRoundCalcs ? Round(fValue) : fValue;
 	}
 	return(0);
@@ -1688,8 +1756,10 @@ int RE_Font_HeightPixels(const int iFontHandle, const float fScale)
 
 // iMaxPixelWidth is -1 for "all of string", else pixel display count...
 //
-void RE_Font_DrawString(int ox, int oy, const char *psText, const float *rgba, const int iFontHandle, int iMaxPixelWidth, const float fScale)
+void RE_Font_DrawString(int ox, int oy, const char *psText, const float *rgba, const int iFontHandleIn, int iMaxPixelWidth, const float fScaleIn)
 {
+	int iFontHandle = iFontHandleIn;
+	float fScale = fScaleIn;
 	// HAAAAAAAAAAAAAAAX..fix me please --eez
 #ifdef JK2_MODE
 	static qboolean gbInShadow = qfalse;	// MUST default to this
@@ -1732,6 +1802,8 @@ void RE_Font_DrawString(int ox, int oy, const char *psText, const float *rgba, c
 	{
 		return;
 	}
+	curfont = RE_Font_GetVariant(curfont, &fScale);
+	iFontHandle = curfont->GetHandle() | (iFontHandle & ~SET_MASK);
 
 	float fScaleAsian = fScale;
 	float fAsianYAdjust = 0.0f;
@@ -1904,6 +1976,8 @@ void RE_Font_DrawString(int ox, int oy, const char *psText, const float *rgba, c
 	{
 		return;
 	}
+	curfont = RE_Font_GetVariant(curfont, &fScale);
+	iFontHandle = curfont->GetHandle() | (iFontHandle & ~SET_MASK);
 
 	float fScaleAsian = fScale;
 	float fAsianYAdjust = 0.0f;
@@ -2032,7 +2106,7 @@ void RE_Font_DrawString(int ox, int oy, const char *psText, const float *rgba, c
 #endif
 }
 
-int RE_RegisterFont(const char *psName)
+int RE_RegisterFont_Real(const char *psName)
 {
 	FontIndexMap_t::iterator it = g_mapFontIndexes.find(psName);
 	if (it != g_mapFontIndexes.end() )
@@ -2063,10 +2137,42 @@ int RE_RegisterFont(const char *psName)
 	return 0;
 }
 
+int RE_RegisterFont(const char *psName) {
+	int oriFontHandle = RE_RegisterFont_Real(psName);
+	if (oriFontHandle) {
+		CFontInfo *oriFont = GetFont_Actual(oriFontHandle);
+
+		if (oriFont->GetNumVariants() == 0) {
+			for (int i = 0; i < MAX_FONT_VARIANTS; i++) {
+				const char *variantName = va( "%s_sharp%i", psName, i + 1 );
+				const char *fontDatPath = FontDatPath( variantName );
+				if ( ri.FS_ReadFile(fontDatPath, NULL) > 0 ) {
+					int replacerFontHandle = RE_RegisterFont_Real(variantName);
+					if (replacerFontHandle) {
+						CFontInfo *replacerFont = GetFont_Actual(replacerFontHandle);
+						replacerFont->m_isVariant = qtrue;
+						oriFont->AddVariant(replacerFont);
+					} else {
+						break;
+					}
+				} else {
+					break;
+				}
+			}
+		}
+	} else {
+		ri.Printf( PRINT_WARNING, "RE_RegisterFont: Couldn't find font %s\n", psName );
+	}
+
+	return oriFontHandle;
+}
+
 void R_InitFonts(void)
 {
 	g_iCurrentFontIndex = 1;			// entry 0 is reserved for "missing/invalid"
 	g_iNonScaledCharRange = INT_MAX;	// default all chars to have no special scaling (other than user supplied)
+
+	r_fontSharpness = ri.Cvar_Get( "r_fontSharpness", "1", CVAR_ARCHIVE_ND );
 }
 
 /*
@@ -2119,6 +2225,8 @@ void R_ReloadFonts_f(void)
 	for (; iFontToFind < g_iCurrentFontIndex; iFontToFind++)
 	{
 		FontIndexMap_t::iterator it = g_mapFontIndexes.begin();
+		CFontInfo *font = GetFont( iFontToFind );
+		if ( font && font->m_isVariant ) continue;
 		for (; it != g_mapFontIndexes.end(); ++it)
 		{
 			if (iFontToFind == (*it).second)

--- a/code/ui/ui_shared.cpp
+++ b/code/ui/ui_shared.cpp
@@ -3072,7 +3072,19 @@ qboolean ItemParse_name( itemDef_t *item)
 	return qtrue;
 }
 
+int MenuFontToReal( int menuFontIndex )
+{
+	// Default fonts from a clean installation
+	switch ( menuFontIndex ) {
+		case 1: return UI_RegisterFont( "aurabesh" );
+		case 2: return UI_RegisterFont( "ergoec" );
+		case 3: return UI_RegisterFont( "anewhope" );
+		case 4: return UI_RegisterFont( "arialnb" );
 
+		default:
+			return DC->Assets.qhMediumFont;
+	}
+}
 
 qboolean ItemParse_font( itemDef_t *item )
 {
@@ -3080,6 +3092,10 @@ qboolean ItemParse_font( itemDef_t *item )
 	{
 		return qfalse;
 	}
+
+	// Translate to real font
+	item->font = MenuFontToReal( item->font );
+
 	return qtrue;
 }
 
@@ -8261,7 +8277,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				while (1)
 				{
 					// FIXME - add some type of parameter in the menu file like descfont to specify the font for the descriptions for this menu.
-					textWidth = DC->textWidth(textPtr, fDescScale, 4);	//  item->font);
+					textWidth = DC->textWidth(textPtr, fDescScale, MenuFontToReal(4));	//  item->font);
 
 					if (parent->descAlignment == ITEM_ALIGN_RIGHT)
 					{
@@ -8297,7 +8313,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 
 					// FIXME - add some type of parameter in the menu file like descfont to specify the font for the descriptions for this menu.
-					DC->drawText(xPos, parent->descY + iYadj, fDescScale, parent->descColor, textPtr, 0, parent->descTextStyle, 4);	//item->font);
+					DC->drawText(xPos, parent->descY + iYadj, fDescScale, parent->descColor, textPtr, 0, parent->descTextStyle, MenuFontToReal(4));	//item->font);
 					break;
 				}
 			}

--- a/codemp/client/cl_console.cpp
+++ b/codemp/client/cl_console.cpp
@@ -745,6 +745,8 @@ void Con_DrawSolidConsole( float frac ) {
 			(lines-(SMALLCHAR_HEIGHT+SMALLCHAR_HEIGHT/2)), JK_VERSION[x] );
 	}
 
+	// draw the input prompt, user text, and cursor if desired
+	Con_DrawInput ();
 
 	// draw the text
 	con.vislines = lines;
@@ -832,9 +834,6 @@ void Con_DrawSolidConsole( float frac ) {
 			}
 		}
 	}
-
-	// draw the input prompt, user text, and cursor if desired
-	Con_DrawInput ();
 
 	re->SetColor( NULL );
 }

--- a/codemp/client/cl_console.cpp
+++ b/codemp/client/cl_console.cpp
@@ -38,6 +38,7 @@ cvar_t		*con_conspeed;
 cvar_t		*con_notifytime;
 cvar_t		*con_opacity; // background alpha multiplier
 cvar_t		*con_autoclear;
+cvar_t		*con_height;
 
 #define	DEFAULT_CONSOLE_WIDTH	78
 
@@ -364,6 +365,7 @@ void Con_Init (void) {
 
 	con_opacity = Cvar_Get ("con_opacity", "1.0", CVAR_ARCHIVE_ND, "Opacity of console background");
 	con_autoclear = Cvar_Get ("con_autoclear", "1", CVAR_ARCHIVE_ND, "Automatically clear console input on close");
+	con_height = Cvar_Get ("con_height", "0.5", CVAR_ARCHIVE_ND);
 
 	Field_Clear( &g_consoleField );
 	g_consoleField.widthInChars = g_console_field_width;
@@ -878,7 +880,7 @@ Scroll it up or down
 void Con_RunConsole (void) {
 	// decide on the destination height of the console
 	if ( Key_GetCatcher( ) & KEYCATCH_CONSOLE )
-		con.finalFrac = 0.5;		// half screen
+		con.finalFrac = con_height->value;
 	else
 		con.finalFrac = 0;				// none visible
 

--- a/codemp/client/cl_console.cpp
+++ b/codemp/client/cl_console.cpp
@@ -732,7 +732,7 @@ void Con_DrawNotify (void)
 	currentColor = 7;
 	re->SetColor( g_color_table[currentColor] );
 
-	static int iFontIndex = re->RegisterFont("ocr_a");
+	int iFontIndex = cls.consoleFont;
 	float fFontScale = 1.0f;
 	int iPixelHeightToAdvance = 0;
 	if (re->Language_IsAsian())
@@ -928,7 +928,7 @@ void Con_DrawSolidConsole( float frac ) {
 	currentColor = 7;
 	re->SetColor( g_color_table[currentColor] );
 
-	static int iFontIndex = re->RegisterFont("ocr_a");
+	int iFontIndex = cls.consoleFont;
 	float fFontScale = 1.0f;
 	int iPixelHeightToAdvance = con.charHeight;
 	if (re->Language_IsAsian())

--- a/codemp/client/cl_console.cpp
+++ b/codemp/client/cl_console.cpp
@@ -39,8 +39,20 @@ cvar_t		*con_notifytime;
 cvar_t		*con_opacity; // background alpha multiplier
 cvar_t		*con_autoclear;
 cvar_t		*con_height;
+cvar_t		*con_scale;
+cvar_t		*con_timestamps;
 
 #define	DEFAULT_CONSOLE_WIDTH	78
+
+#define CON_BLANK_CHAR			' '
+#define CON_SCROLL_L_CHAR		'$'
+#define CON_SCROLL_R_CHAR		'$'
+#define CON_TIMESTAMP_LEN		11 // "[13:37:00] "
+#define CON_MIN_WIDTH			20
+
+
+static const conChar_t CON_WRAP = { { ColorIndex(COLOR_GREY), '\\' } };
+static const conChar_t CON_BLANK = { { ColorIndex(COLOR_WHITE), CON_BLANK_CHAR } };
 
 vec4_t	console_color = {0.509f, 0.609f, 0.847f, 1.0f};
 
@@ -158,7 +170,7 @@ void Con_Clear_f (void) {
 	int		i;
 
 	for ( i = 0 ; i < CON_TEXTSIZE ; i++ ) {
-		con.text[i] = (ColorIndex(COLOR_WHITE)<<8) | ' ';
+		con.text[i] = CON_BLANK;
 	}
 
 	Con_Bottom();		// go to end
@@ -174,12 +186,17 @@ Save the console contents out to a file
 */
 void Con_Dump_f (void)
 {
-	int		l, x, i;
-	short	*line;
+	char			filename[MAX_QPATH];
+	qboolean		empty;
+	int				l, i, j;
+	int				line;
+	int				lineLen;
 	fileHandle_t	f;
-	int		bufferlen;
-	char	*buffer;
-	char	filename[MAX_QPATH];
+#ifdef WIN32
+	char			buffer[CON_TIMESTAMP_LEN + MAXPRINTMSG + 2];
+#else
+	char			buffer[CON_TIMESTAMP_LEN + MAXPRINTMSG + 1];
+#endif
 
 	if (Cmd_Argc() != 2)
 	{
@@ -206,47 +223,59 @@ void Con_Dump_f (void)
 	Com_Printf ("Dumped console text to %s.\n", filename );
 
 	// skip empty lines
-	for (l = con.current - con.totallines + 1 ; l <= con.current ; l++)
+	for (l = 1, empty = qtrue ; l < con.totallines && empty ; l++)
 	{
-		line = con.text + (l%con.totallines)*con.linewidth;
-		for (x=0 ; x<con.linewidth ; x++)
-			if ((line[x] & 0xff) != ' ')
-				break;
-		if (x != con.linewidth)
-			break;
+		line = ((con.current + l) % con.totallines) * con.rowwidth;
+
+		for (j = CON_TIMESTAMP_LEN ; j < con.rowwidth - 1 ; j++)
+			if (con.text[line + j].f.character != CON_BLANK_CHAR)
+				empty = qfalse;
 	}
 
-#ifdef _WIN32
-	bufferlen = con.linewidth + 3 * sizeof ( char );
-#else
-	bufferlen = con.linewidth + 2 * sizeof ( char );
-#endif
-
-	buffer = (char *)Hunk_AllocateTempMemory( bufferlen );
-
-	// write the remaining lines
-	buffer[bufferlen-1] = 0;
-	for ( ; l <= con.current ; l++)
+	for ( ; l < con.totallines ; l++)
 	{
-		line = con.text + (l%con.totallines)*con.linewidth;
-		for(i=0; i<con.linewidth; i++)
-			buffer[i] = (char) (line[i] & 0xff);
-		for (x=con.linewidth-1 ; x>=0 ; x--)
+		lineLen = 0;
+		i = 0;
+
+		// Print timestamp
+		if (con_timestamps->integer) {
+			line = ((con.current + l) % con.totallines) * con.rowwidth;
+
+			for (i = 0; i < CON_TIMESTAMP_LEN; i++)
+				buffer[i] = con.text[line + i].f.character;
+
+			lineLen = CON_TIMESTAMP_LEN;
+		}
+
+		// Concatenate wrapped lines
+		for ( ; l < con.totallines ; l++)
 		{
-			if (buffer[x] == ' ')
-				buffer[x] = 0;
-			else
+			line = ((con.current + l) % con.totallines) * con.rowwidth;
+
+			for (j = CON_TIMESTAMP_LEN; j < con.rowwidth - 1 && i < (int)sizeof(buffer) - 1; j++, i++) {
+				buffer[i] = con.text[line + j].f.character;
+
+				if (con.text[line + j].f.character != CON_BLANK_CHAR)
+					lineLen = i + 1;
+			}
+
+			if (i == sizeof(buffer) - 1)
+				break;
+
+			if (con.text[line + j].compare != CON_WRAP.compare)
 				break;
 		}
-#ifdef _WIN32
-		Q_strcat(buffer, bufferlen, "\r\n");
+
+#ifdef WIN32 // I really don't like this inconsistency, but OpenJK has been doing this since April 2013
+		buffer[lineLen] = '\r';
+		buffer[lineLen+1] = '\n';
+		FS_Write(buffer, lineLen + 2, f);
 #else
-		Q_strcat(buffer, bufferlen, "\n");
+		buffer[lineLen] = '\n';
+		FS_Write(buffer, lineLen + 1, f);
 #endif
-		FS_Write(buffer, strlen(buffer), f);
 	}
 
-	Hunk_FreeTempMemory( buffer );
 	FS_FCloseFile( f );
 }
 
@@ -264,7 +293,132 @@ void Con_ClearNotify( void ) {
 	}
 }
 
+/*
+================
+Con_Initialize
 
+Initialize console for the first time.
+================
+*/
+void Con_Initialize(void)
+{
+	int	i;
+
+	VectorCopy4(colorWhite, con.color);
+	con.charWidth = SMALLCHAR_WIDTH;
+	con.charHeight = SMALLCHAR_HEIGHT;
+	con.linewidth = DEFAULT_CONSOLE_WIDTH;
+	con.rowwidth = CON_TIMESTAMP_LEN + con.linewidth + 1;
+	con.totallines = CON_TEXTSIZE / con.rowwidth;
+	con.current = con.totallines - 1;
+	con.display = con.current;
+	con.xadjust = 1.0f;
+	con.yadjust = 1.0f;
+	for(i=0; i<CON_TEXTSIZE; i++)
+	{
+		con.text[i] = CON_BLANK;
+	}
+
+	con.initialized = qtrue;
+}
+
+
+
+/*
+================
+Con_Resize
+
+Reformat the buffer for new row width
+================
+*/
+static void Con_Resize(int rowwidth)
+{
+	static conChar_t tbuf[CON_TEXTSIZE];
+	int		i, j;
+	int		oldrowwidth;
+	int		oldtotallines;
+
+	oldrowwidth = con.rowwidth;
+	oldtotallines = con.totallines;
+
+	con.rowwidth = rowwidth;
+	con.totallines = CON_TEXTSIZE / rowwidth;
+
+	Com_Memcpy (tbuf, con.text, sizeof(tbuf));
+	for(i=0; i<CON_TEXTSIZE; i++)
+		con.text[i] = CON_BLANK;
+
+	int oi = 0;
+	int ni = 0;
+
+	while (oi < oldtotallines)
+		{
+			conChar_t	line[MAXPRINTMSG];
+			conChar_t	timestamp[CON_TIMESTAMP_LEN];
+			int		lineLen = 0;
+			int		oldline = ((con.current + oi) % oldtotallines) * oldrowwidth;
+			int		newline = (ni % con.totallines) * con.rowwidth;
+
+			// Store timestamp
+			for (i = 0; i < CON_TIMESTAMP_LEN; i++)
+				timestamp[i] = tbuf[oldline + i];
+
+			// Store whole line concatenating on CON_WRAP
+			for (i = 0; oi < oldtotallines; oi++)
+				{
+					oldline = ((con.current + oi) % oldtotallines) * oldrowwidth;
+
+					for (j = CON_TIMESTAMP_LEN; j < oldrowwidth - 1 && i < (int)ARRAY_LEN(line); j++, i++) {
+						line[i] = tbuf[oldline + j];
+
+						if (line[i].f.character != CON_BLANK_CHAR)
+							lineLen = i + 1;
+					}
+
+					if (i == ARRAY_LEN(line))
+						break;
+
+					if (tbuf[oldline + j].compare != CON_WRAP.compare)
+						break;
+				}
+
+			oi++;
+
+			// Print stored line to a new text buffer
+			for (i = 0; ; ni++) {
+				newline = (ni % con.totallines) * con.rowwidth;
+
+				// Print timestamp at the begining of each line
+				for (j = 0; j < CON_TIMESTAMP_LEN; j++)
+					con.text[newline + j] = timestamp[j];
+
+				for (j = CON_TIMESTAMP_LEN; j < con.rowwidth - 1 && i < lineLen; j++, i++)
+					con.text[newline + j] = line[i];
+
+				if (i == lineLen) {
+					// Erase remaining chars in case newline wrapped
+					for (; j < con.rowwidth - 1; j++)
+						con.text[newline + j] = CON_BLANK;
+
+					ni++;
+					break;
+				}
+
+				con.text[newline + j] = CON_WRAP;
+			}
+		}
+
+	con.current = ni;
+
+	// Erase con.current line for next CL_ConsolePrint
+	int newline = (con.current % con.totallines) * con.rowwidth;
+	for (j = 0; j < con.rowwidth; j++)
+		con.text[newline + j] = CON_BLANK;
+
+	Con_ClearNotify ();
+
+	con.display = con.current;
+}
 
 /*
 ================
@@ -275,69 +429,44 @@ If the line width has changed, reformat the buffer.
 */
 void Con_CheckResize (void)
 {
-	int		i, j, width, oldwidth, oldtotallines, numlines, numchars;
-	short	tbuf[CON_TEXTSIZE];
+	int		charWidth, rowwidth, width;
+	float	scale;
 
-//	width = (SCREEN_WIDTH / SMALLCHAR_WIDTH) - 2;
-	width = (cls.glconfig.vidWidth / SMALLCHAR_WIDTH) - 2;
+	assert(SMALLCHAR_HEIGHT >= SMALLCHAR_WIDTH);
 
-	if (width == con.linewidth)
-		return;
+	scale = ((con_scale->value > 0.0f) ? con_scale->value : 1.0f);
+	charWidth = scale * SMALLCHAR_WIDTH;
 
-
-	if (width < 1)			// video hasn't been initialized yet
-	{
-		con.xadjust = 1;
-		con.yadjust = 1;
-		width = DEFAULT_CONSOLE_WIDTH;
-		con.linewidth = width;
-		con.totallines = CON_TEXTSIZE / con.linewidth;
-		for(i=0; i<CON_TEXTSIZE; i++)
-		{
-			con.text[i] = (ColorIndex(COLOR_WHITE)<<8) | ' ';
-		}
-	}
-	else
-	{
-		// on wide screens, we will center the text
-		con.xadjust = 640.0f / cls.glconfig.vidWidth;
-		con.yadjust = 480.0f / cls.glconfig.vidHeight;
-
-		oldwidth = con.linewidth;
-		con.linewidth = width;
-		oldtotallines = con.totallines;
-		con.totallines = CON_TEXTSIZE / con.linewidth;
-		numlines = oldtotallines;
-
-		if (con.totallines < numlines)
-			numlines = con.totallines;
-
-		numchars = oldwidth;
-
-		if (con.linewidth < numchars)
-			numchars = con.linewidth;
-
-		Com_Memcpy (tbuf, con.text, CON_TEXTSIZE * sizeof(short));
-		for(i=0; i<CON_TEXTSIZE; i++)
-
-			con.text[i] = (ColorIndex(COLOR_WHITE)<<8) | ' ';
-
-
-		for (i=0 ; i<numlines ; i++)
-		{
-			for (j=0 ; j<numchars ; j++)
-			{
-				con.text[(con.totallines - 1 - i) * con.linewidth + j] =
-						tbuf[((con.current - i + oldtotallines) %
-							  oldtotallines) * oldwidth + j];
-			}
-		}
-
-		Con_ClearNotify ();
+	if (charWidth < 1) {
+		charWidth = 1;
+		scale = (float)charWidth / SMALLCHAR_WIDTH;
 	}
 
-	con.current = con.totallines - 1;
-	con.display = con.current;
+	width = (cls.glconfig.vidWidth / charWidth) - 2;
+
+	if (width < 20) {
+		width = 20;
+		charWidth = cls.glconfig.vidWidth / 22;
+		scale = (float)charWidth / SMALLCHAR_WIDTH;
+	}
+
+	if (charWidth < 1) {
+		Com_Error(ERR_FATAL, "Con_CheckResize: Window too small to draw a console");
+	}
+
+	rowwidth = width + 1 + (con_timestamps->integer ? 0 : CON_TIMESTAMP_LEN);
+
+	con.charWidth = charWidth;
+	con.charHeight = scale * SMALLCHAR_HEIGHT;
+	con.linewidth = width;
+	con.xadjust = ((float)SCREEN_WIDTH) / cls.glconfig.vidWidth;
+	con.yadjust = ((float)SCREEN_HEIGHT) / cls.glconfig.vidHeight;
+	g_consoleField.widthInChars = width - 1; // Command prompt
+
+	if (con.rowwidth != rowwidth)
+	{
+		Con_Resize(rowwidth);
+	}
 }
 
 
@@ -367,6 +496,9 @@ void Con_Init (void) {
 	con_autoclear = Cvar_Get ("con_autoclear", "1", CVAR_ARCHIVE_ND, "Automatically clear console input on close");
 	con_height = Cvar_Get ("con_height", "0.5", CVAR_ARCHIVE_ND);
 
+	con_scale = Cvar_Get ("con_scale", "1", CVAR_ARCHIVE_ND, "Scale console font");
+	con_timestamps = Cvar_Get ("con_timestamps", "0", CVAR_ARCHIVE_ND, "Display timestamps infront of console lines");
+
 	Field_Clear( &g_consoleField );
 	g_consoleField.widthInChars = g_console_field_width;
 	for ( i = 0 ; i < COMMAND_HISTORY ; i++ ) {
@@ -383,6 +515,9 @@ void Con_Init (void) {
 	Cmd_AddCommand( "clear", Con_Clear_f, "Clear console text" );
 	Cmd_AddCommand( "condump", Con_Dump_f, "Dump console text to file" );
 	Cmd_SetCommandCompletionFunc( "condump", Cmd_CompleteTxtName );
+
+	//Initialize values on first print
+	con.initialized = qfalse;
 }
 
 /*
@@ -410,22 +545,37 @@ Con_Linefeed
 static void Con_Linefeed (qboolean skipnotify)
 {
 	int		i;
+	int		line = (con.current % con.totallines) * con.rowwidth;
+
+	// print timestamp on the PREVIOUS line
+	{
+		time_t t = time( NULL );
+		struct tm *tms = localtime( &t );
+		char	timestamp[CON_TIMESTAMP_LEN + 1];
+		const unsigned char color = ColorIndex(COLOR_GREY);
+
+		Com_sprintf(timestamp, sizeof(timestamp), "[%02d:%02d:%02d] ",
+			tms->tm_hour, tms->tm_min, tms->tm_sec);
+
+		for ( i = 0; i < CON_TIMESTAMP_LEN; i++ ) {
+			con.text[line + i].f = { color, timestamp[i] };
+		}
+	}
 
 	// mark time for transparent overlay
 	if (con.current >= 0)
-	{
-		if (skipnotify)
-			  con.times[con.current % NUM_CON_TIMES] = 0;
-		else
-			  con.times[con.current % NUM_CON_TIMES] = cls.realtime;
-	}
+		con.times[con.current % NUM_CON_TIMES] = skipnotify ? 0 : cls.realtime;
 
 	con.x = 0;
+
 	if (con.display == con.current)
 		con.display++;
 	con.current++;
-	for(i=0; i<con.linewidth; i++)
-		con.text[(con.current%con.totallines)*con.linewidth+i] = (ColorIndex(COLOR_WHITE)<<8) | ' ';
+
+	line = (con.current % con.totallines) * con.rowwidth;
+
+	for ( i = 0; i < con.rowwidth; i++ )
+		con.text[line + i] = CON_BLANK;
 }
 
 /*
@@ -439,8 +589,8 @@ If no console is visible, the text will appear at the top of the game window
 */
 void CL_ConsolePrint( const char *txt) {
 	int		y;
-	int		c, l;
-	int		color;
+	char			c;
+	unsigned char	color;
 	qboolean skipnotify = qfalse;		// NERVE - SMF
 	int prev;							// NERVE - SMF
 
@@ -461,13 +611,7 @@ void CL_ConsolePrint( const char *txt) {
 	}
 
 	if (!con.initialized) {
-		con.color[0] =
-		con.color[1] =
-		con.color[2] =
-		con.color[3] = 1.0f;
-		con.linewidth = -1;
-		Con_CheckResize ();
-		con.initialized = qtrue;
+		Con_Initialize();
 	}
 
 	color = ColorIndex(COLOR_WHITE);
@@ -477,19 +621,6 @@ void CL_ConsolePrint( const char *txt) {
 			color = ColorIndex( *(txt+1) );
 			txt += 2;
 			continue;
-		}
-
-		// count word length
-		for (l=0 ; l< con.linewidth ; l++) {
-			if ( txt[l] <= ' ') {
-				break;
-			}
-		}
-
-		// word wrap
-		if (l != con.linewidth && (con.x + l >= con.linewidth) ) {
-			Con_Linefeed(skipnotify);
-
 		}
 
 		txt++;
@@ -504,11 +635,15 @@ void CL_ConsolePrint( const char *txt) {
 			break;
 		default:	// display character and advance
 			y = con.current % con.totallines;
-			con.text[y*con.linewidth+con.x] = (short) ((color << 8) | c);
-			con.x++;
-			if (con.x >= con.linewidth) {
-				Con_Linefeed(skipnotify);
+
+			if (con.x == con.rowwidth - CON_TIMESTAMP_LEN - 1) {
+				con.text[y * con.rowwidth + CON_TIMESTAMP_LEN + con.x] = CON_WRAP;
+				Con_Linefeed( skipnotify );
+				y = con.current % con.totallines;
 			}
+
+			con.text[y * con.rowwidth + CON_TIMESTAMP_LEN + con.x].f = { color, c };
+			con.x++;
 			break;
 		}
 	}
@@ -555,14 +690,23 @@ void Con_DrawInput (void) {
 		return;
 	}
 
-	y = con.vislines - ( SMALLCHAR_HEIGHT * (re->Language_IsAsian() ? 1.5 : 2) );
+	y = con.vislines - ( con.charHeight * (re->Language_IsAsian() ? 1.5 : 2) );
 
 	re->SetColor( con.color );
 
-	SCR_DrawSmallChar( (int)(con.xadjust + 1 * SMALLCHAR_WIDTH), y, CONSOLE_PROMPT_CHAR );
+	Field_Draw( &g_consoleField, 2 * con.charWidth, y, qtrue, qtrue );
 
-	Field_Draw( &g_consoleField, (int)(con.xadjust + 2 * SMALLCHAR_WIDTH), y,
-				SCREEN_WIDTH - 3 * SMALLCHAR_WIDTH, qtrue, qtrue );
+	SCR_DrawSmallChar( con.charWidth, y, CONSOLE_PROMPT_CHAR );
+
+	re->SetColor( g_color_table[ColorIndex(COLOR_GREY)] );
+
+	if ( g_consoleField.scroll > 0 )
+		SCR_DrawSmallChar( 0, y, CON_SCROLL_L_CHAR );
+
+	int len = Q_PrintStrlen( g_consoleField.buffer );
+	int pos = Q_PrintStrLenTo( g_consoleField.buffer, g_consoleField.scroll, NULL );
+	if ( pos + g_consoleField.widthInChars < len )
+		SCR_DrawSmallChar( cls.glconfig.vidWidth - con.charWidth, y, CON_SCROLL_R_CHAR );
 }
 
 
@@ -578,7 +722,7 @@ Draws the last few lines of output transparently over the game top
 void Con_DrawNotify (void)
 {
 	int		x, v;
-	short	*text;
+	conChar_t		*text;
 	int		i;
 	int		time;
 	int		skip;
@@ -587,6 +731,17 @@ void Con_DrawNotify (void)
 
 	currentColor = 7;
 	re->SetColor( g_color_table[currentColor] );
+
+	static int iFontIndex = re->RegisterFont("ocr_a");
+	float fFontScale = 1.0f;
+	int iPixelHeightToAdvance = 0;
+	if (re->Language_IsAsian())
+	{
+		fFontScale = con.charWidth * 10.0f /
+			re->Font_StrLenPixels("aaaaaaaaaa", iFontIndex, 1.0f);
+		fFontScale *= con.yadjust;
+		iPixelHeightToAdvance = 2+(1.3/con.yadjust) * re->Font_HeightPixels(iFontIndex, fFontScale);
+	}
 
 	v = 0;
 	for (i= con.current-NUM_CON_TIMES+1 ; i<=con.current ; i++)
@@ -599,7 +754,9 @@ void Con_DrawNotify (void)
 		time = cls.realtime - time;
 		if (time > con_notifytime->value*1000)
 			continue;
-		text = con.text + (i % con.totallines)*con.linewidth;
+		text = con.text + (i % con.totallines)*con.rowwidth;
+		if (!con_timestamps->integer)
+			text += CON_TIMESTAMP_LEN;
 
 		if (cl.snap.ps.pm_type != PM_INTERMISSION && Key_GetCatcher( ) & (KEYCATCH_UI | KEYCATCH_CGAME) ) {
 			continue;
@@ -617,46 +774,44 @@ void Con_DrawNotify (void)
 		//
 		if (re->Language_IsAsian())
 		{
-			static int iFontIndex = re->RegisterFont("ocr_a");	// this seems naughty
-			const float fFontScale = 0.75f*con.yadjust;
-			const int iPixelHeightToAdvance =   2+(1.3/con.yadjust) * re->Font_HeightPixels(iFontIndex, fFontScale);	// for asian spacing, since we don't want glyphs to touch.
-
 			// concat the text to be printed...
 			//
-			char sTemp[4096]={0};	// ott
+			char sTemp[4096];	// ott
+			sTemp[0] = '\0';
 			for (x = 0 ; x < con.linewidth ; x++)
 			{
-				if ( ( (text[x]>>8)&Q_COLOR_BITS ) != currentColor ) {
-					currentColor = (text[x]>>8)&Q_COLOR_BITS;
-					strcat(sTemp,va("^%i", (text[x]>>8)&Q_COLOR_BITS) );
+				if ( text[x].f.color != currentColor ) {
+					currentColor = text[x].f.color;
+					strcat(sTemp,va("^%i", currentColor ));
 				}
-				strcat(sTemp,va("%c",text[x] & 0xFF));
+				strcat(sTemp,va("%c",text[x].f.character));
 			}
 			//
 			// and print...
 			//
-			re->Font_DrawString(cl_conXOffset->integer + con.xadjust*(con.xadjust + (1*SMALLCHAR_WIDTH/*aesthetics*/)), con.yadjust*(v), sTemp, g_color_table[currentColor], iFontIndex, -1, fFontScale);
+			re->Font_DrawString(cl_conXOffset->integer + con.xadjust * (con.xadjust + con.charWidth), con.yadjust * v, sTemp,
+				g_color_table[currentColor], iFontIndex, -1, fFontScale);
 
 			v +=  iPixelHeightToAdvance;
 		}
 		else
 		{
 			for (x = 0 ; x < con.linewidth ; x++) {
-				if ( ( text[x] & 0xff ) == ' ' ) {
+				if ( text[x].f.character == ' ' ) {
 					continue;
 				}
-				if ( ( (text[x]>>8)&Q_COLOR_BITS ) != currentColor ) {
-					currentColor = (text[x]>>8)&Q_COLOR_BITS;
+				if ( text[x].f.color != currentColor ) {
+					currentColor = text[x].f.color;
 					re->SetColor( g_color_table[currentColor] );
 				}
 				if (!cl_conXOffset)
 				{
 					cl_conXOffset = Cvar_Get ("cl_conXOffset", "0", 0);
 				}
-				SCR_DrawSmallChar( (int)(cl_conXOffset->integer + con.xadjust + (x+1)*SMALLCHAR_WIDTH), v, text[x] & 0xff );
+				SCR_DrawSmallChar( (int)(cl_conXOffset->integer + (x+1)*con.charWidth), v, text[x].f.character );
 			}
 
-			v += SMALLCHAR_HEIGHT;
+			v += con.charHeight;
 		}
 	}
 
@@ -682,8 +837,7 @@ void Con_DrawNotify (void)
 			skip = strlen(chattext)+1;
 		}
 
-		Field_BigDraw( &chatField, skip * BIGCHAR_WIDTH, v,
-			SCREEN_WIDTH - ( skip + 1 ) * BIGCHAR_WIDTH, qtrue, qtrue );
+		Field_BigDraw( &chatField, skip * BIGCHAR_WIDTH, v, qtrue, qtrue );
 
 		v += BIGCHAR_HEIGHT;
 	}
@@ -700,7 +854,7 @@ Draws the console with the solid background
 void Con_DrawSolidConsole( float frac ) {
 	int				i, x, y;
 	int				rows;
-	short			*text;
+	conChar_t		*text;
 	int				row;
 	int				lines;
 //	qhandle_t		conShader;
@@ -741,8 +895,8 @@ void Con_DrawSolidConsole( float frac ) {
 	i = strlen( JK_VERSION );
 
 	for (x=0 ; x<i ; x++) {
-		SCR_DrawSmallChar( cls.glconfig.vidWidth - ( i - x + 1 ) * SMALLCHAR_WIDTH,
-			(lines-(SMALLCHAR_HEIGHT+SMALLCHAR_HEIGHT/2)), JK_VERSION[x] );
+		SCR_DrawSmallChar( cls.glconfig.vidWidth - ( i - x + 1 ) * con.charWidth,
+			(lines-(con.charHeight+con.charHeight/2)), JK_VERSION[x] );
 	}
 
 	// draw the input prompt, user text, and cursor if desired
@@ -750,9 +904,9 @@ void Con_DrawSolidConsole( float frac ) {
 
 	// draw the text
 	con.vislines = lines;
-	rows = (lines-SMALLCHAR_WIDTH)/SMALLCHAR_WIDTH;		// rows of text to draw
+	rows = (lines-con.charHeight)/con.charHeight;		// rows of text to draw
 
-	y = lines - (SMALLCHAR_HEIGHT*3);
+	y = lines - (con.charHeight*3);
 
 	// draw from the bottom up
 	if (con.display != con.current)
@@ -760,8 +914,8 @@ void Con_DrawSolidConsole( float frac ) {
 	// draw arrows to show the buffer is backscrolled
 		re->SetColor( console_color );
 		for (x=0 ; x<con.linewidth ; x+=4)
-			SCR_DrawSmallChar( (int) (con.xadjust + (x+1)*SMALLCHAR_WIDTH), y, '^' );
-		y -= SMALLCHAR_HEIGHT;
+			SCR_DrawSmallChar( (x+1)*con.charWidth, y, '^' );
+		y -= con.charHeight;
 		rows--;
 	}
 
@@ -774,16 +928,15 @@ void Con_DrawSolidConsole( float frac ) {
 	currentColor = 7;
 	re->SetColor( g_color_table[currentColor] );
 
-	static int iFontIndexForAsian = 0;
-	const float fFontScaleForAsian = 0.75f*con.yadjust;
-	int iPixelHeightToAdvance = SMALLCHAR_HEIGHT;
+	static int iFontIndex = re->RegisterFont("ocr_a");
+	float fFontScale = 1.0f;
+	int iPixelHeightToAdvance = con.charHeight;
 	if (re->Language_IsAsian())
 	{
-		if (!iFontIndexForAsian)
-		{
-			iFontIndexForAsian = re->RegisterFont("ocr_a");
-		}
-		iPixelHeightToAdvance = (1.3/con.yadjust) * re->Font_HeightPixels(iFontIndexForAsian, fFontScaleForAsian);	// for asian spacing, since we don't want glyphs to touch.
+		fFontScale = con.charWidth * 10.0f /
+			re->Font_StrLenPixels("aaaaaaaaaa", iFontIndex, 1.0f);
+		fFontScale *= con.yadjust;
+		iPixelHeightToAdvance = 2+(1.3/con.yadjust) * re->Font_HeightPixels(iFontIndex, fFontScale);
 	}
 
 	for (i=0 ; i<rows ; i++, y -= iPixelHeightToAdvance, row--)
@@ -795,7 +948,9 @@ void Con_DrawSolidConsole( float frac ) {
 			continue;
 		}
 
-		text = con.text + (row % con.totallines)*con.linewidth;
+		text = con.text + (row % con.totallines)*con.rowwidth;
+		if (!con_timestamps->integer)
+			text += CON_TIMESTAMP_LEN;
 
 		// asian language needs to use the new font system to print glyphs...
 		//
@@ -805,32 +960,34 @@ void Con_DrawSolidConsole( float frac ) {
 		{
 			// concat the text to be printed...
 			//
-			char sTemp[4096]={0};	// ott
-			for (x = 0 ; x < con.linewidth ; x++)
+			char sTemp[4096];	// ott
+			sTemp[0] = '\0';
+			for (x = 0 ; x < con.linewidth + 1 ; x++)
 			{
-				if ( ( (text[x]>>8)&Q_COLOR_BITS ) != currentColor ) {
-					currentColor = (text[x]>>8)&Q_COLOR_BITS;
-					strcat(sTemp,va("^%i", (text[x]>>8)&Q_COLOR_BITS) );
+				if ( text[x].f.color != currentColor ) {
+					currentColor = text[x].f.color;
+					strcat(sTemp,va("^%i", currentColor ));
 				}
-				strcat(sTemp,va("%c",text[x] & 0xFF));
+				strcat(sTemp,va("%c",text[x].f.character));
 			}
 			//
 			// and print...
 			//
-			re->Font_DrawString(con.xadjust*(con.xadjust + (1*SMALLCHAR_WIDTH/*(aesthetics)*/)), con.yadjust*(y), sTemp, g_color_table[currentColor], iFontIndexForAsian, -1, fFontScaleForAsian);
+			re->Font_DrawString(con.xadjust*(con.xadjust + con.charWidth), con.yadjust * y, sTemp, g_color_table[currentColor],
+				iFontIndex, -1, fFontScale);
 		}
 		else
 		{
-			for (x=0 ; x<con.linewidth ; x++) {
-				if ( ( text[x] & 0xff ) == ' ' ) {
+			for (x = 0; x < con.linewidth + 1 ; x++) {
+				if ( text[x].f.character == ' ' ) {
 					continue;
 				}
 
-				if ( ( (text[x]>>8)&Q_COLOR_BITS ) != currentColor ) {
-					currentColor = (text[x]>>8)&Q_COLOR_BITS;
+				if ( text[x].f.color != currentColor ) {
+					currentColor = text[x].f.color;
 					re->SetColor( g_color_table[currentColor] );
 				}
-				SCR_DrawSmallChar(  (int) (con.xadjust + (x+1)*SMALLCHAR_WIDTH), y, text[x] & 0xff );
+				SCR_DrawSmallChar( (x+1)*con.charWidth, y, text[x].f.character );
 			}
 		}
 	}

--- a/codemp/client/cl_keys.cpp
+++ b/codemp/client/cl_keys.cpp
@@ -401,7 +401,8 @@ Handles horizontal scrolling and cursor blinking
 x, y, amd width are in pixels
 ===================
 */
-void Field_VariableSizeDraw( field_t *edit, int x, int y, int width, int size, qboolean showCursor, qboolean noColorEscape ) {
+extern console_t con;
+void Field_VariableSizeDraw( field_t *edit, int x, int y, int size, qboolean showCursor, qboolean noColorEscape ) {
 	int		len;
 	int		drawLen;
 	int		prestep;
@@ -441,7 +442,7 @@ void Field_VariableSizeDraw( field_t *edit, int x, int y, int width, int size, q
 	str[ drawLen ] = 0;
 
 	// draw it
-	if ( size == SMALLCHAR_WIDTH ) {
+	if ( size == con.charWidth ) {
 		float	color[4];
 
 		color[0] = color[1] = color[2] = color[3] = 1.0;
@@ -465,7 +466,7 @@ void Field_VariableSizeDraw( field_t *edit, int x, int y, int width, int size, q
 
 		i = drawLen - strlen( str );
 
-		if ( size == SMALLCHAR_WIDTH ) {
+		if ( size == con.charWidth ) {
 			SCR_DrawSmallChar( x + ( edit->cursor - prestep - i ) * size, y, cursorChar );
 		} else {
 			str[0] = cursorChar;
@@ -475,14 +476,14 @@ void Field_VariableSizeDraw( field_t *edit, int x, int y, int width, int size, q
 	}
 }
 
-void Field_Draw( field_t *edit, int x, int y, int width, qboolean showCursor, qboolean noColorEscape )
+void Field_Draw( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape )
 {
-	Field_VariableSizeDraw( edit, x, y, width, SMALLCHAR_WIDTH, showCursor, noColorEscape );
+	Field_VariableSizeDraw( edit, x, y, con.charWidth, showCursor, noColorEscape );
 }
 
-void Field_BigDraw( field_t *edit, int x, int y, int width, qboolean showCursor, qboolean noColorEscape )
+void Field_BigDraw( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape )
 {
-	Field_VariableSizeDraw( edit, x, y, width, BIGCHAR_WIDTH, showCursor, noColorEscape );
+	Field_VariableSizeDraw( edit, x, y, BIGCHAR_WIDTH, showCursor, noColorEscape );
 }
 
 /*

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -2290,6 +2290,7 @@ void CL_InitRenderer( void ) {
 
 	// load character sets
 	cls.charSetShader = re->RegisterShaderNoMip("gfx/2d/charsgrid_med");
+	cls.consoleFont = re->RegisterFont( "ocr_a" );
 
 	cls.whiteShader = re->RegisterShader( "white" );
 	cls.consoleShader = re->RegisterShader( "console" );

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -100,6 +100,7 @@ cvar_t	*cl_autolodscale;
 
 cvar_t	*cl_consoleKeys;
 cvar_t	*cl_consoleUseScanCode;
+cvar_t	*cl_consoleShiftRequirement;
 
 cvar_t  *cl_lanForcePackets;
 
@@ -2773,6 +2774,7 @@ void CL_Init( void ) {
 	// ~ and `, as keys and characters
 	cl_consoleKeys = Cvar_Get( "cl_consoleKeys", "~ ` 0x7e 0x60 0xb2", CVAR_ARCHIVE, "Which keys are used to toggle the console");
 	cl_consoleUseScanCode = Cvar_Get( "cl_consoleUseScanCode", "1", CVAR_ARCHIVE, "Use native console key detection" );
+	cl_consoleShiftRequirement = Cvar_Get( "cl_consoleShiftRequirement", "0", CVAR_ARCHIVE, "Require shift key to be pressed for native console key detection" );
 
 	// userinfo
 	Cvar_Get ("name", "Padawan", CVAR_USERINFO | CVAR_ARCHIVE_ND, "Player name" );

--- a/codemp/client/cl_scrn.cpp
+++ b/codemp/client/cl_scrn.cpp
@@ -137,7 +137,7 @@ void SCR_DrawSmallChar( int x, int y, int ch ) {
 		return;
 	}
 
-	if ( y < -SMALLCHAR_HEIGHT ) {
+	if ( y < -con.charHeight ) {
 		return;
 	}
 
@@ -155,7 +155,7 @@ void SCR_DrawSmallChar( int x, int y, int ch ) {
 	size2 = 0.0625;
 
 	re->DrawStretchPic( x * con.xadjust, y * con.yadjust,
-						SMALLCHAR_WIDTH * con.xadjust, SMALLCHAR_HEIGHT * con.yadjust,
+					   con.charWidth * con.xadjust, con.charHeight * con.yadjust,
 					   fcol, frow,
 					   fcol + size, frow + size2,
 					   cls.charSetShader );
@@ -263,7 +263,7 @@ void SCR_DrawSmallStringExt( int x, int y, const char *string, float *setColor, 
 			}
 		}
 		SCR_DrawSmallChar( xx, y, *s );
-		xx += SMALLCHAR_WIDTH;
+		xx += con.charWidth;
 		s++;
 	}
 	re->SetColor( NULL );

--- a/codemp/client/client.h
+++ b/codemp/client/client.h
@@ -326,6 +326,7 @@ typedef struct clientStatic_s {
 	qhandle_t	charSetShader;
 	qhandle_t	whiteShader;
 	qhandle_t	consoleShader;
+	int			consoleFont;
 } clientStatic_t;
 
 #define	CON_TEXTSIZE	0x30000 //was 32768

--- a/codemp/client/client.h
+++ b/codemp/client/client.h
@@ -331,16 +331,28 @@ typedef struct clientStatic_s {
 #define	CON_TEXTSIZE	0x30000 //was 32768
 #define	NUM_CON_TIMES	4
 
-typedef struct console_s {
+typedef union {
+	struct {
+		unsigned char	color;
+		char			character;
+	} f;
+	unsigned short	compare;
+} conChar_t;
+
+typedef struct {
 	qboolean	initialized;
 
-	short	text[CON_TEXTSIZE];
+	conChar_t	text[CON_TEXTSIZE];
 	int		current;		// line where next message will be printed
 	int		x;				// offset in current line for next print
 	int		display;		// bottom of console displays this line
 
 	int 	linewidth;		// characters across screen
+	int		rowwidth;		// timestamp, text and line wrap character
 	int		totallines;		// total lines in console scrollback
+
+	int		charWidth;		// Scaled console character width
+	int		charHeight;		// Scaled console character height
 
 	float	xadjust;		// for wide aspect screens
 	float	yadjust;		// for wide aspect screens

--- a/codemp/client/client.h
+++ b/codemp/client/client.h
@@ -410,6 +410,7 @@ extern	cvar_t	*cl_inGameVideo;
 
 extern	cvar_t	*cl_consoleKeys;
 extern	cvar_t	*cl_consoleUseScanCode;
+extern	cvar_t	*cl_consoleShiftRequirement;
 
 extern  cvar_t  *cl_lanForcePackets;
 

--- a/codemp/client/keys.h
+++ b/codemp/client/keys.h
@@ -62,8 +62,8 @@ extern int			chat_playerNum;
 
 void	Field_KeyDownEvent	( field_t *edit, int key );
 void	Field_CharEvent		( field_t *edit, int ch );
-void	Field_Draw			( field_t *edit, int x, int y, int width, qboolean showCursor, qboolean noColorEscape );
-void	Field_BigDraw		( field_t *edit, int x, int y, int width, qboolean showCursor, qboolean noColorEscape );
+void	Field_Draw			( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape );
+void	Field_BigDraw		( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape );
 
 void		Key_SetBinding			( int keynum, const char *binding );
 char *		Key_GetBinding			( int keynum );

--- a/codemp/qcommon/common.cpp
+++ b/codemp/qcommon/common.cpp
@@ -72,6 +72,8 @@ cvar_t	*com_busyWait;
 
 cvar_t *com_affinity;
 
+cvar_t	*com_timestamps;
+
 // com_speeds times
 int		time_game;
 int		time_frontend;		// renderer frontend time
@@ -129,6 +131,7 @@ void QDECL Com_Printf( const char *fmt, ... ) {
 	va_list		argptr;
 	char		msg[MAXPRINTMSG];
 	static qboolean opening_qconsole = qfalse;
+	const char *p;
 
 	va_start (argptr,fmt);
 	Q_vsnprintf (msg, sizeof(msg), fmt, argptr);
@@ -150,40 +153,67 @@ void QDECL Com_Printf( const char *fmt, ... ) {
 	CL_ConsolePrint( msg );
 #endif
 
-	// echo to dedicated console and early console
-	Sys_Print( msg );
+	p = msg;
+	while (*p) {
+		static qboolean	newLine = qtrue;
+		char			line[MAXPRINTMSG];
+		size_t			lineLen;
 
-	// logfile
-	if ( com_logfile && com_logfile->integer ) {
-    // TTimo: only open the qconsole.log if the filesystem is in an initialized state
-    //   also, avoid recursing in the qconsole.log opening (i.e. if fs_debug is on)
-		if ( !logfile && FS_Initialized() && !opening_qconsole ) {
-			struct tm *newtime;
-			time_t aclock;
+		if (newLine && com_timestamps && com_timestamps->integer) {
+			time_t t = time( NULL );
+			struct tm *tms = localtime( &t );
+			Com_sprintf(line, sizeof(line), "%04i-%02i-%02i %02i:%02i:%02i ",
+				1900 + tms->tm_year, 1 + tms->tm_mon, tms->tm_mday, tms->tm_hour, tms->tm_min, tms->tm_sec);
+			lineLen = strlen(line);
+			newLine = qfalse;
+		} else {
+			if (const char *s = strchr(p, '\n')) {
+				lineLen = (size_t)(s - p + 1);
+				newLine = qtrue;
+			} else {
+				lineLen = strlen(p);
+			}
 
-			opening_qconsole = qtrue;
+			Com_Memcpy(line, p, lineLen);
+			line[lineLen] = '\0';
+			p += lineLen;
+		}
 
-			time( &aclock );
-			newtime = localtime( &aclock );
+		// echo to dedicated console and early console
+		Sys_Print( line );
 
-			logfile = FS_FOpenFileWrite( "qconsole.log" );
+		// logfile
+		if ( com_logfile && com_logfile->integer ) {
+		// TTimo: only open the qconsole.log if the filesystem is in an initialized state
+		//   also, avoid recursing in the qconsole.log opening (i.e. if fs_debug is on)
+			if ( !logfile && FS_Initialized() && !opening_qconsole ) {
+				struct tm *newtime;
+				time_t aclock;
 
-			if ( logfile ) {
-				Com_Printf( "logfile opened on %s\n", asctime( newtime ) );
-				if ( com_logfile->integer > 1 ) {
-					// force it to not buffer so we get valid
-					// data even if we are crashing
-					FS_ForceFlush(logfile);
+				opening_qconsole = qtrue;
+
+				time( &aclock );
+				newtime = localtime( &aclock );
+
+				logfile = FS_FOpenFileWrite( "qconsole.log" );
+
+				if ( logfile ) {
+					Com_Printf( "logfile opened on %s\n", asctime( newtime ) );
+					if ( com_logfile->integer > 1 ) {
+						// force it to not buffer so we get valid
+						// data even if we are crashing
+						FS_ForceFlush(logfile);
+					}
+				}
+				else {
+					Com_Printf( "Opening qconsole.log failed!\n" );
+					Cvar_SetValue( "logfile", 0 );
 				}
 			}
-			else {
-				Com_Printf( "Opening qconsole.log failed!\n" );
-				Cvar_SetValue( "logfile", 0 );
+			opening_qconsole = qfalse;
+			if ( logfile && FS_Initialized()) {
+				FS_Write(line, strlen(line), logfile);
 			}
-		}
-		opening_qconsole = qfalse;
-		if ( logfile && FS_Initialized()) {
-			FS_Write(msg, strlen(msg), logfile);
 		}
 	}
 
@@ -1241,6 +1271,8 @@ void Com_Init( char *commandLine ) {
 		com_busyWait = Cvar_Get( "com_busyWait", "0", CVAR_ARCHIVE_ND );
 
 		com_bootlogo = Cvar_Get( "com_bootlogo", "1", CVAR_ARCHIVE_ND, "Show intro movies" );
+
+		com_timestamps = Cvar_Get( "com_timestamps", "1", CVAR_ARCHIVE_ND, "Show timestamps in terminal and qconsole.log" );
 
 		s = va("%s %s %s", JK_VERSION_OLD, PLATFORM_STRING, SOURCE_DATE );
 		com_version = Cvar_Get ("version", s, CVAR_ROM | CVAR_SERVERINFO );

--- a/codemp/rd-common/tr_font.cpp
+++ b/codemp/rd-common/tr_font.cpp
@@ -26,6 +26,8 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include "qcommon/stringed_ingame.h"
 
+cvar_t *r_fontSharpness;
+
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // This file is shared in the single and multiplayer codebases, so be CAREFUL WHAT YOU ADD/CHANGE!!!!!
@@ -192,6 +194,8 @@ struct ThaiCodes_t
 #define GLYPH_MAX_THAI_SHADERS		3
 #define GLYPH_MAX_ASIAN_SHADERS		4	// this MUST equal the larger of the above defines
 
+#define MAX_FONT_VARIANTS 8
+
 class CFontInfo
 {
 private:
@@ -226,6 +230,11 @@ public:
 	float			m_fAltSBCSFontScaleFactor;	// -1, else amount to adjust returned values by to make them fit the master western font they're substituting for
 	bool			m_bIsFakeAlienLanguage;	// ... if true, don't process as MBCS or override as SBCS etc
 
+	CFontInfo		*m_variants[MAX_FONT_VARIANTS];
+	int				m_numVariants;
+	int				m_handle;
+	qboolean		m_isVariant;
+
 	CFontInfo(const char *fontName);
 //	CFontInfo(int fill) { memset(this, fill, sizeof(*this)); }	// wtf?
 	~CFontInfo(void) {}
@@ -246,6 +255,12 @@ public:
 	bool AsianGlyphsAvailable(void) const { return !!(m_hAsianShaders[0]); }
 
 	void UpdateAsianIfNeeded( bool bForceReEval = false);
+
+	int GetHandle();
+
+	void AddVariant(CFontInfo *variant);
+	int GetNumVariants();
+	CFontInfo *GetVariant(int index);
 };
 
 //================================================
@@ -844,6 +859,11 @@ qboolean Language_UsesSpaces(void)
 //  If path present, it's a special language hack for SBCS override languages, eg: "lcd/russian", which means
 //	  just treat the file as "russian", but with the "lcd" part ensuring we don't find a different registered russian font
 //
+static const char *FontDatPath( const char *_fontName ) {
+	static char fontName[MAX_QPATH];
+	sprintf( fontName,"fonts/%s.fontdat",COM_SkipPath(const_cast<char*>(_fontName)) );	// COM_SkipPath should take a const char *, but it's just possible people use it as a char * I guess, so I have to hack around like this <groan>
+	return fontName;
+}
 CFontInfo::CFontInfo(const char *_fontName)
 {
 	int			len, i;
@@ -852,8 +872,7 @@ CFontInfo::CFontInfo(const char *_fontName)
 
 	// remove any special hack name insertions...
 	//
-	char fontName[MAX_QPATH];
-	sprintf(fontName,"fonts/%s.fontdat",COM_SkipPath(const_cast<char*>(_fontName)));	// COM_SkipPath should take a const char *, but it's just possible people use it as a char * I guess, so I have to hack around like this <groan>
+	const char *fontName = FontDatPath( _fontName );
 
 	// clear some general things...
 	//
@@ -919,6 +938,7 @@ CFontInfo::CFontInfo(const char *_fontName)
 
 	// finished...
 	g_vFontArray.resize(g_iCurrentFontIndex + 1);
+	m_handle = g_iCurrentFontIndex;
 	g_vFontArray[g_iCurrentFontIndex++] = this;
 
 
@@ -990,6 +1010,24 @@ CFontInfo::CFontInfo(const char *_fontName)
 			}
 		}
 	}
+
+	m_numVariants = 0;
+}
+
+int CFontInfo::GetHandle() {
+	return m_handle;
+}
+
+void CFontInfo::AddVariant(CFontInfo * replacer) {
+	m_variants[m_numVariants++] = replacer;
+}
+
+int CFontInfo::GetNumVariants() {
+	return m_numVariants;
+}
+
+CFontInfo *CFontInfo::GetVariant(int index) {
+	return m_variants[index];
 }
 
 void CFontInfo::UpdateAsianIfNeeded( bool bForceReEval /* = false */ )
@@ -1123,6 +1161,30 @@ static CFontInfo *GetFont_Actual(int index)
 	return(NULL);
 }
 
+static CFontInfo *RE_Font_GetVariant(CFontInfo *font, float *scale) {
+	int variants = font->GetNumVariants();
+
+	if (variants > 0) {
+		CFontInfo *variant;
+		int requestedSize = font->GetPointSize() * *scale *
+			r_fontSharpness->value * (glConfig.vidHeight / SCREEN_HEIGHT);
+
+		if (requestedSize <= font->GetPointSize())
+			return font;
+
+		for (int i = 0; i < variants; i++) {
+			variant = font->GetVariant(i);
+
+			if (requestedSize <= variant->GetPointSize())
+				break;
+		}
+
+		*scale *= (float)font->GetPointSize() / variant->GetPointSize();
+		return variant;
+	}
+
+	return font;
+}
 
 // needed to add *piShader param because of multiple TPs,
 //	if not passed in, then I also skip S,T calculations for re-usable static asian glyphinfo struct...
@@ -1355,11 +1417,13 @@ CFontInfo *GetFont(int index)
 	return pFont;
 }
 
-float RE_Font_StrLenPixelsNew( const char *psText, const int iFontHandle, const float fScale ) {
+float RE_Font_StrLenPixelsNew( const char *psText, const int iFontHandle, const float fScaleIn ) {
+	float fScale = fScaleIn;
 	CFontInfo *curfont = GetFont(iFontHandle);
 	if ( !curfont ) {
 		return 0.0f;
 	}
+	curfont = RE_Font_GetVariant(curfont, &fScale);
 
 	float fScaleAsian = fScale;
 	if (Language_IsAsian() && fScale > 0.7f )
@@ -1454,14 +1518,17 @@ int RE_Font_StrLenChars(const char *psText)
 	return iCharCount;
 }
 
-int RE_Font_HeightPixels(const int iFontHandle, const float fScale)
+int RE_Font_HeightPixels(const int iFontHandle, const float fScaleIn)
 {
+	float fScale = fScaleIn;
 	CFontInfo	*curfont;
 
 	curfont = GetFont(iFontHandle);
 	if(curfont)
 	{
-		float fValue = curfont->GetPointSize() * fScale;
+		float fValue;
+		curfont = RE_Font_GetVariant(curfont, &fScale);
+		fValue = curfont->GetPointSize() * fScale;
 		return curfont->mbRoundCalcs ? Round(fValue) : fValue;
 	}
 	return(0);
@@ -1469,13 +1536,15 @@ int RE_Font_HeightPixels(const int iFontHandle, const float fScale)
 
 // iMaxPixelWidth is -1 for "all of string", else pixel display count...
 //
-void RE_Font_DrawString(int ox, int oy, const char *psText, const float *rgba, const int iFontHandle, int iMaxPixelWidth, const float fScale)
+void RE_Font_DrawString(int ox, int oy, const char *psText, const float *rgba, const int iFontHandleIn, int iMaxPixelWidth, const float fScaleIn)
 {
 	static qboolean gbInShadow = qfalse;	// MUST default to this
 	float				fox, foy, fx, fy;
 	int					colour, offset;
 	const glyphInfo_t	*pLetter;
 	qhandle_t			hShader;
+	float				fScale = fScaleIn;
+	int					iFontHandle = iFontHandleIn;
 
 	assert (psText);
 
@@ -1537,6 +1606,8 @@ void RE_Font_DrawString(int ox, int oy, const char *psText, const float *rgba, c
 	{
 		return;
 	}
+	curfont = RE_Font_GetVariant(curfont, &fScale);
+	iFontHandle = curfont->GetHandle() | (iFontHandle & ~SET_MASK);
 
 	float fScaleAsian = fScale;
 	float fAsianYAdjust = 0.0f;
@@ -1673,7 +1744,7 @@ void RE_Font_DrawString(int ox, int oy, const char *psText, const float *rgba, c
 	//let it remember the old color //RE_SetColor(NULL);
 }
 
-int RE_RegisterFont(const char *psName)
+static int RE_RegisterFont_Real(const char *psName)
 {
 	FontIndexMap_t::iterator it = g_mapFontIndexes.find(psName);
 	if (it != g_mapFontIndexes.end() )
@@ -1702,10 +1773,42 @@ int RE_RegisterFont(const char *psName)
 	return 0;
 }
 
+int RE_RegisterFont(const char *psName) {
+	int oriFontHandle = RE_RegisterFont_Real(psName);
+	if (oriFontHandle) {
+		CFontInfo *oriFont = GetFont_Actual(oriFontHandle);
+
+		if (oriFont->GetNumVariants() == 0) {
+			for (int i = 0; i < MAX_FONT_VARIANTS; i++) {
+				const char *variantName = va( "%s_sharp%i", psName, i + 1 );
+				const char *fontDatPath = FontDatPath( variantName );
+				if ( ri.FS_ReadFile(fontDatPath, NULL) > 0 ) {
+					int replacerFontHandle = RE_RegisterFont_Real(variantName);
+					if (replacerFontHandle) {
+						CFontInfo *replacerFont = GetFont_Actual(replacerFontHandle);
+						replacerFont->m_isVariant = qtrue;
+						oriFont->AddVariant(replacerFont);
+					} else {
+						break;
+					}
+				} else {
+					break;
+				}
+			}
+		}
+	} else {
+		ri.Printf( PRINT_WARNING, "RE_RegisterFont: Couldn't find font %s\n", psName );
+	}
+
+	return oriFontHandle;
+}
+
 void R_InitFonts(void)
 {
 	g_iCurrentFontIndex = 1;			// entry 0 is reserved for "missing/invalid"
 	g_iNonScaledCharRange = INT_MAX;	// default all chars to have no special scaling (other than user supplied)
+
+	r_fontSharpness = ri.Cvar_Get( "r_fontSharpness", "1", CVAR_ARCHIVE_ND, "" );
 }
 
 /*
@@ -1754,6 +1857,8 @@ void R_ReloadFonts_f(void)
 	for (iFontToFind = 1; iFontToFind < g_iCurrentFontIndex; iFontToFind++)
 	{
 		FontIndexMap_t::iterator it;
+		CFontInfo *font = GetFont( iFontToFind );
+		if ( font && font->m_isVariant ) continue;
 		for (it = g_mapFontIndexes.begin(); it != g_mapFontIndexes.end(); ++it)
 		{
 			if (iFontToFind == (*it).second)

--- a/shared/qcommon/q_string.c
+++ b/shared/qcommon/q_string.c
@@ -266,6 +266,27 @@ int Q_PrintStrlen( const char *string ) {
 	return len;
 }
 
+int Q_PrintStrLenTo(const char *str, int chars, char *color) {
+	int		offset = 0;
+	char	lastColor = 0;
+	int		i;
+
+	for (i = 0; i < chars && str[i]; i++) {
+		if (Q_IsColorString(&str[i])) {
+			i++;
+			lastColor = str[i];
+		} else {
+			offset++;
+		}
+	}
+
+	if (color) {
+		*color = lastColor;
+	}
+
+	return offset;
+}
+
 
 char *Q_CleanStr( char *string ) {
 	char*	d;

--- a/shared/qcommon/q_string.h
+++ b/shared/qcommon/q_string.h
@@ -31,6 +31,7 @@ const char *Q_stristr( const char *s, const char *find);
 
 // strlen that discounts Quake color sequences
 int Q_PrintStrlen( const char *string );
+int Q_PrintStrLenTo(const char *str, int chars, char *color);
 
 // removes color sequences from string
 char *Q_CleanStr( char *string );

--- a/shared/sdl/sdl_input.cpp
+++ b/shared/sdl/sdl_input.cpp
@@ -253,6 +253,23 @@ static void IN_TranslateNumpad( SDL_Keysym *keysym, fakeAscii_t *key )
 
 /*
 ===============
+IN_ModTogglesConsole
+===============
+*/
+static qboolean IN_ModTogglesConsole( int mod ) {
+	switch (cl_consoleShiftRequirement->integer) {
+	case 0:
+		return qtrue;
+	case 2:
+		return (qboolean)!!(mod & KMOD_SHIFT);
+	case 1:
+	default:
+		return (qboolean)((mod & KMOD_SHIFT) || (Key_GetCatcher() & KEYCATCH_CONSOLE));
+	}
+}
+
+/*
+===============
 IN_TranslateSDLToJKKey
 ===============
 */
@@ -376,11 +393,7 @@ static fakeAscii_t IN_TranslateSDLToJKKey( SDL_Keysym *keysym, qboolean down ) {
 	{
 		if ( keysym->scancode == SDL_SCANCODE_GRAVE )
 		{
-			SDL_Keycode translated = SDL_GetKeyFromScancode( SDL_SCANCODE_GRAVE );
-
-			if ( (translated != SDLK_CARET) || (translated == SDLK_CARET && (keysym->mod & KMOD_SHIFT)) )
-			{
-				// Console keys can't be bound or generate characters
+			if ( IN_ModTogglesConsole(keysym->mod) ) {
 				key = A_CONSOLE;
 			}
 		}
@@ -842,7 +855,7 @@ static void IN_ProcessEvents( void )
 						uint32_t utf32 = ConvertUTF8ToUTF32( c, &c );
 						if( utf32 != 0 )
 						{
-							if( IN_IsConsoleKey( A_NULL, utf32 ) )
+							if( IN_IsConsoleKey( A_NULL, utf32 ) && !cl_consoleUseScanCode->integer )
 							{
 								Sys_QueEvent( 0, SE_KEY, A_CONSOLE, qtrue, 0, NULL );
 								Sys_QueEvent( 0, SE_KEY, A_CONSOLE, qfalse, 0, NULL );


### PR DESCRIPTION
This pull request aims to slightly improve the console behavior.

1) It replaces the `SDLK_CARET` shift-requirement when trying to open the console in scancode mode (`cl_consoleUseScanCode`) with the cvar check from jk2mv: `cl_consoleShiftRequirement` (prefixed `mv_` instead of `cl_` on jk2mv).

2) It adds a cvar to set the height of the console: `con_height`.