### PR TITLE
Fix r_showtris

### DIFF
--- a/codemp/rd-rend2/tr_shade.cpp
+++ b/codemp/rd-rend2/tr_shade.cpp
@@ -897,7 +897,7 @@ static void DrawTris(shaderCommands_t *input, const VertexArraysProperties *vert
 		uniformDataWriter.SetUniformVec4(UNIFORM_VERTCOLOR, vertColor);
 
 		DrawItem item = {};
-		item.renderState.stateBits = GLS_POLYMODE_LINE | GLS_DEPTHMASK_TRUE | GLS_POLYGON_OFFSET_FILL;
+		item.renderState.stateBits = GLS_POLYMODE_LINE | GLS_DEPTHMASK_TRUE | GLS_POLYGON_OFFSET_FILL | GLS_DEPTHTEST_DISABLE;
 		item.renderState.cullType = RB_GetCullType(&backEnd.viewParms, backEnd.currentEntity, input->shader->cullType);
 		item.renderState.depthRange = RB_GetDepthRange(backEnd.currentEntity, input->shader);
 		item.program = sp;


### PR DESCRIPTION
Depth test should be disabled when rendering wireframes so we can see the triangles being drawn behind the front-most surfaces.