### PR TITLE
A few small changes (cl_filterGames + MAX_PATCH_PLANES increase)

### DIFF
--- a/code/qcommon/cm_patch.h
+++ b/code/qcommon/cm_patch.h
@@ -62,7 +62,7 @@ properly.
 
 
 #define	MAX_FACETS			1024
-#define	MAX_PATCH_PLANES	2048
+#define	MAX_PATCH_PLANES	4096 // Was 2048 on vanilla jka
 
 typedef struct {
 	float	plane[4];

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -2776,7 +2776,7 @@ void CL_Init( void ) {
 	cl_consoleKeys = Cvar_Get( "cl_consoleKeys", "~ ` 0x7e 0x60 0xb2", CVAR_ARCHIVE, "Which keys are used to toggle the console");
 	cl_consoleUseScanCode = Cvar_Get( "cl_consoleUseScanCode", "1", CVAR_ARCHIVE, "Use native console key detection" );
 
-	cl_filterGames = Cvar_Get( "cl_filterGames", "", CVAR_ARCHIVE_ND, "List of fs_game to filter (space separated)" );
+	cl_filterGames = Cvar_Get( "cl_filterGames", "MBII MBIIOpenBeta", CVAR_ARCHIVE_ND, "List of fs_game to filter (space separated)" );
 
 	// userinfo
 	Cvar_Get ("name", "Padawan", CVAR_USERINFO | CVAR_ARCHIVE_ND, "Player name" );

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -2998,12 +2998,15 @@ void CL_ServerInfoPacket( netadr_t from, msg_t *msg ) {
 	if ( cl_filterGames && cl_filterGames->string && cl_filterGames->string[0] ) {
 		const char *gameFolder = Info_ValueForKey( infoString, "game" );
 
+		// If no game folder was specified the server is using base. Use the BASEGAME string so we can filter for it.
+		if ( !gameFolder[0] ) gameFolder = BASEGAME;
+
 		// NOTE: As the command tokenization doesn't support nested quotes we can't filter fs_game with spaces using
 		//       this approach, but fs_game with spaces cause other issues as well, like downloads not working and at
 		//       the time of writing this no public servers actually use an fs_game with spaces...
 		Cmd_TokenizeString( cl_filterGames->string );
 		for ( i = 0; i < Cmd_Argc(); i++ ) {
-			if ( !Q_stricmp(Cmd_Argv(i), gameFolder) ) {
+			if ( !Q_stricmp(Cmd_Argv(i), gameFolder) && Q_stricmp(Cmd_Argv(i), FS_GetCurrentGameDir(false)) ) {
 				return;
 			}
 		}

--- a/codemp/qcommon/cm_patch.h
+++ b/codemp/qcommon/cm_patch.h
@@ -64,7 +64,7 @@ properly.
 
 
 #define	MAX_FACETS			1024
-#define	MAX_PATCH_PLANES	2048
+#define	MAX_PATCH_PLANES	4096 // Was 2048 on vanilla jka
 
 typedef struct patchPlane_s {
 	float	plane[4];


### PR DESCRIPTION
This pull request introduces a new cvar `cl_filterGames` and defaults it to `MBII MBIIOpenBeta`. Servers using an `fs_game` value that's on the list specified in `cl_filterGames` are going to be ignored on the serverlist. The default value seems to cover the majoriy of MBII servers.

Additionally the `MAX_PATCH_PLANES` value got increased from `2048` to `4096`, because some maps (at least for jk2) require a higher limit.