### PR TITLE
rend2 - fixed out-of-bounds crash with weather

### DIFF
--- a/codemp/rd-rend2/tr_weather.cpp
+++ b/codemp/rd-rend2/tr_weather.cpp
@@ -1145,7 +1145,7 @@ void RB_SurfaceWeather( srfWeather_t *surf )
 				chunkIndex += (int(centerZoneOffsetY + numMinZonesY) + y + 1) % 3 * 3;
 
 				if (chunkIndex < 0) {
-					chunkIndex *= -1;
+					chunkIndex += 9;
 				}
 
 				VectorSet2(

--- a/codemp/rd-rend2/tr_weather.cpp
+++ b/codemp/rd-rend2/tr_weather.cpp
@@ -1143,6 +1143,11 @@ void RB_SurfaceWeather( srfWeather_t *surf )
 			{
 				chunkIndex  = (int(centerZoneOffsetX + numMinZonesX) + x + 1) % 3;
 				chunkIndex += (int(centerZoneOffsetY + numMinZonesY) + y + 1) % 3 * 3;
+
+				if (chunkIndex < 0) {
+					chunkIndex *= -1;
+				}
+
 				VectorSet2(
 					zoneOffsets[chunkIndex],
 					x,


### PR DESCRIPTION
See issue #1189 

The game will crash, if a map features weather (e.g. vjun1) and you noclip far enough beneath the map.

This was caused by an out-of-bounds exception caused by chunkIndex sometimes being negative.