### PR TITLE
[SP] cap the timescale sensitivity scale when timescale > 1.0

### DIFF
--- a/code/cgame/cg_view.cpp
+++ b/code/cgame/cg_view.cpp
@@ -2037,7 +2037,7 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView ) {
 	//FIXME: should really send forcePowersActive over network onto cg.snap->ps...
 	const int fpActive = cg_entities[0].gent->client->ps.forcePowersActive;
 	const bool matrixMode = !!(fpActive & ((1 << FP_SPEED) | (1 << FP_RAGE)));
-	float speed = cg.refdef.fov_y / 75.0 * (matrixMode ? 1.0f : cg_timescale.value);
+	float speed = cg.refdef.fov_y / 75.0 * (matrixMode ? 1.0f : Q_min(cg_timescale.value, 1.0f));
 
 //FIXME: junk code, BUG:168
 

--- a/codeJK2/cgame/cg_view.cpp
+++ b/codeJK2/cgame/cg_view.cpp
@@ -1862,7 +1862,7 @@ void CG_DrawActiveFrame( int serverTime, stereoFrame_t stereoView ) {
 
 	// let the client system know what our weapon and zoom settings are
 	//FIXME: should really send forcePowersActive over network onto cg.snap->ps...
-	float speed = cg.refdef.fov_y / 75.0 * ((cg_entities[0].gent->client->ps.forcePowersActive&(1<<FP_SPEED))?1.0f:cg_timescale.value);
+	float speed = cg.refdef.fov_y / 75.0 * ((cg_entities[0].gent->client->ps.forcePowersActive&(1<<FP_SPEED))?1.0f:Q_min(cg_timescale.value, 1.0f));
 
 //FIXME: junk code, BUG:168
 


### PR DESCRIPTION
If you set timescale > 1.0 in SP, your mouse sensitivity gets scaled up with it.

It looks like the intention was to slow your mouse sensitivity down when using force speed/rage, so let's cap timescale's influence to < 1.0