### PR TITLE
[CI/CD] Update automatic release action to actively maintained one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,7 +269,7 @@ jobs:
           mv ./OpenJO-macos-arm64-Release-Non-Portable/* OpenJO-macos-arm64.tar.gz
 
       - name: Create latest build
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: crowbarmaster/GH-Automatic-Releases@latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: "latest"


### PR DESCRIPTION
https://github.com/marvinpinto/action-automatic-releases is currently used to download the artifacts and to create the "latest" release. It is in an abandoned state using Node 12 and will stop working entirely quite soon.

https://github.com/softprops/action-gh-release is an actively maintained action that achieves the same purpose. It is likely going to have a v2 soon, which will include a bump to Node 20, [which has already been committed](https://github.com/softprops/action-gh-release/commit/4634c16e79c963813287e889244c50009e7f0981) (as [Node 16 depreciation](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) warnings have now begun on actions).

Known problem with this runner:
It successfully uploads the artifacts and creates the latest release, if a latest release exists, it re-uploads the files to that pre-existing release, instead of re-creating the "latest" release as the current action does. I have only tested this on v1 so far, and will shortly run some tests to see if this behavior persists on the latest commit of the action.

**Update:**
https://github.com/crowbarmaster/GH-Automatic-Releases is a suitable replacement, it functions 1:1 to the previous implementation and has already been updated to Node 20.