### PR TITLE
[Shared] Fix endless loop in Z_Malloc due to imageDeleted always being qtrue

### DIFF
--- a/code/rd-vanilla/tr_image.cpp
+++ b/code/rd-vanilla/tr_image.cpp
@@ -890,7 +890,7 @@ qboolean RE_RegisterImages_LevelLoadEnd(void)
 {
 	//ri.Printf( PRINT_DEVELOPER, "RE_RegisterImages_LevelLoadEnd():\n");
 
-	qboolean imageDeleted = qtrue;
+	qboolean imageDeleted = qfalse;
 	for (AllocatedImages_t::iterator itImage = AllocatedImages.begin(); itImage != AllocatedImages.end(); /* blank */)
 	{
 		qboolean bEraseOccured = qfalse;

--- a/codemp/rd-vanilla/tr_image.cpp
+++ b/codemp/rd-vanilla/tr_image.cpp
@@ -874,7 +874,7 @@ qboolean RE_RegisterImages_LevelLoadEnd(void)
 
 //	int iNumImages = AllocatedImages.size();	// more for curiosity, really.
 
-	qboolean imageDeleted = qtrue;
+	qboolean imageDeleted = qfalse;
 	for (AllocatedImages_t::iterator itImage = AllocatedImages.begin(); itImage != AllocatedImages.end(); /* blank */)
 	{
 		qboolean bEraseOccured = qfalse;


### PR DESCRIPTION
...even if no images were deleted.

