### PR TITLE
[SP] ignore numBones assert if we're mixing jk2/jka models

### DIFF
--- a/code/rd-vanilla/tr_ghoul2.cpp
+++ b/code/rd-vanilla/tr_ghoul2.cpp
@@ -3611,7 +3611,11 @@ qboolean R_LoadMDXM( model_t *mod, void *buffer, const char *mod_name, qboolean 
 #ifndef JK2_MODE
 	else
 	{
-		assert (tr.models[mdxm->animIndex]->mdxa->numBones == mdxm->numBones);
+		// let us mix JK2/JKA models and animations
+		if (tr.models[mdxm->animIndex]->mdxa->numBones != 53 && tr.models[mdxm->animIndex]->mdxa->numBones != 72 && mdxm->numBones != 53 &&
+			mdxm->numBones != 72) {
+			assert(tr.models[mdxm->animIndex]->mdxa->numBones == mdxm->numBones);
+		}
 		if (tr.models[mdxm->animIndex]->mdxa->numBones != mdxm->numBones)
 		{
 			if ( isAnOldModelFile )


### PR DESCRIPTION
This is annoying and inconsequential. The game will try to make these combinations work anyway.
It also only affects debug builds :shrug: 