### PR TITLE
avoid configstring index clash with base_entranced

### DIFF
--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -111,7 +111,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define CS_FLAGSTATUS			23		// string indicating flag status in CTF
 #define CS_SHADERSTATE			24
 #define CS_BOTINFO				25
-#define CS_LEGACY_FIXES			26
+
 #define	CS_ITEMS				27		// string of 0's and 1's that tell which items are present
 
 #define CS_CLIENT_JEDIMASTER	28		// current jedi master
@@ -119,6 +119,8 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define CS_CLIENT_DUELISTS		30		// client numbers for both current duelists. Needed for a number of client-side things.
 #define CS_CLIENT_DUELHEALTHS	31		// nmckenzie: DUEL_HEALTH.  Hopefully adding this cs is safe and good?
 #define CS_GLOBAL_AMBIENT_SET	32
+
+#define CS_LEGACY_FIXES			36
 
 #define CS_AMBIENT_SET			37
 


### PR DESCRIPTION
Alereon pointed out that CS index 26 is used by deathsythe47/base_entranced@e62eda6, so let's try to not stamp over that with our `CS_LEGACY_FIXES`.
Our configstring was only introduced very recently, so we can probably get away with just changing our index now.

base_entranced now also makes use of most of the other free CS indexes:

- 26: base_entranced: `CS_ENHANCEDLOCATIONS` / clash with our `CS_LEGACY_FIXES`
- [...] used by basejka
- 33: base_entranced: `CS_CUSTOMOBITUARIES`
- 34: base_entranced: `CS_CUSTOMVOTES`
- 35: \<free>
- 36: \<free>
- [...] used by basejka

So I chose 36. I don't know if/what other mods might use this.

The next free slot is 1644 (max: 1700). We could also insert our new configstrings after this index, which hopefully no one else has?
It would look like this:

```diff
diff --git a/codemp/game/bg_public.h b/codemp/game/bg_public.h
index 0326fb64f..69287fee3 100644
--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -120,8 +120,6 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 #define CS_CLIENT_DUELHEALTHS	31		// nmckenzie: DUEL_HEALTH.  Hopefully adding this cs is safe and good?
 #define CS_GLOBAL_AMBIENT_SET	32
 
-#define CS_LEGACY_FIXES			36
-
 #define CS_AMBIENT_SET			37
 
 #define CS_SIEGE_STATE			(CS_AMBIENT_SET+MAX_AMBIENT_SETS)
@@ -152,7 +150,11 @@ Ghoul2 Insert End
 #define CS_TERRAINS				(CS_LIGHT_STYLES + (MAX_LIGHT_STYLES*3))
 #define CS_BSP_MODELS			(CS_TERRAINS + MAX_TERRAINS)
 
-#define CS_MAX					(CS_BSP_MODELS + MAX_SUB_BSP)
+#define CS_MAX_RETAIL			(CS_BSP_MODELS + MAX_SUB_BSP)
+
+#define CS_LEGACY_FIXES			(CS_MAX_RETAIL+1)
+
+#define CS_MAX					(CS_LEGACY_FIXES+1)
 
 #if (CS_MAX) > MAX_CONFIGSTRINGS
 #error overflow: (CS_MAX) > MAX_CONFIGSTRINGS
```

Otherwise, we can work our way backwards from `MAX_CONFIGSTRINGS`, but I don't like that idea :shrug: