### PR TITLE
[Shared] Add exit command as an alias to quit

### DIFF
--- a/code/qcommon/common.cpp
+++ b/code/qcommon/common.cpp
@@ -1124,6 +1124,7 @@ void Com_Init( char *commandLine ) {
 		// init commands and vars
 		//
 		Cmd_AddCommand ("quit", Com_Quit_f);
+		Cmd_AddCommand ("exit", Com_Quit_f);
 		Cmd_AddCommand ("writeconfig", Com_WriteConfig_f );
 
 		com_developer = Cvar_Get ("developer", "0", CVAR_TEMP );

--- a/codemp/qcommon/common.cpp
+++ b/codemp/qcommon/common.cpp
@@ -1207,6 +1207,7 @@ void Com_Init( char *commandLine ) {
 			Cmd_AddCommand ("freeze", Com_Freeze_f);
 		}
 		Cmd_AddCommand ("quit", Com_Quit_f, "Quits the game" );
+		Cmd_AddCommand ("exit", Com_Quit_f, "Quits the game" );
 #ifndef FINAL_BUILD
 		Cmd_AddCommand ("changeVectors", MSG_ReportChangeVectors_f );
 #endif


### PR DESCRIPTION
I can't tell you how many times I've tried to close a server with `exit` like most other CLI programs, interpreters, shells etc.

Quality of life :sparkles: