### PR TITLE
Register BigFont

### DIFF
--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -2115,7 +2115,8 @@ void CG_Init( int serverCommandSequence ) {
 	cgs.media.charsetShader = cgi_R_RegisterShaderNoMip("gfx/2d/charsgrid_med");
 
 	cgs.media.qhFontSmall = cgi_R_RegisterFont("ocr_a");
-	cgs.media.qhFontMedium= cgi_R_RegisterFont("ergoec");
+	cgs.media.qhFontMedium = cgi_R_RegisterFont("ergoec");
+	cgs.media.qhFontBig = cgi_R_RegisterFont("arialnb");
 
 	cgs.media.whiteShader   = cgi_R_RegisterShader( "white" );
 	cgs.media.loadTick		= cgi_R_RegisterShaderNoMip( "gfx/hud/load_tick" );

--- a/code/cgame/cg_media.h
+++ b/code/cgame/cg_media.h
@@ -224,6 +224,7 @@ typedef struct {
 	//
 	qhandle_t	qhFontSmall;
 	qhandle_t	qhFontMedium;
+	qhandle_t	qhFontBig;
 
 	// special effects models / etc.
 	qhandle_t	personalShieldShader;

--- a/codeJK2/cgame/cg_main.cpp
+++ b/codeJK2/cgame/cg_main.cpp
@@ -1736,7 +1736,8 @@ void CG_Init( int serverCommandSequence ) {
 	cgs.media.charsetShader = cgi_R_RegisterShaderNoMip("gfx/2d/charsgrid_med");
 
 	cgs.media.qhFontSmall = cgi_R_RegisterFont("ocr_a");
-	cgs.media.qhFontMedium= cgi_R_RegisterFont("ergoec");
+	cgs.media.qhFontMedium = cgi_R_RegisterFont("ergoec");
+	cgs.media.qhFontBig = cgi_R_RegisterFont("arialnb");
 
 	cgs.media.whiteShader   = cgi_R_RegisterShader( "white" );
 	cgs.media.loadTick		= cgi_R_RegisterShaderNoMip( "gfx/hud/load_tick" );

--- a/codeJK2/cgame/cg_media.h
+++ b/codeJK2/cgame/cg_media.h
@@ -179,6 +179,7 @@ typedef struct {
 	//
 	qhandle_t	qhFontSmall;
 	qhandle_t	qhFontMedium;
+	qhandle_t	qhFontBig;
 
 	// special effects models / etc.
 	qhandle_t	personalShieldShader;

--- a/codemp/cgame/cg_draw.c
+++ b/codemp/cgame/cg_draw.c
@@ -127,8 +127,7 @@ int MenuFontToHandle(int iMenuFont)
 		case FONT_SMALL:	return cgDC.Assets.qhSmallFont;
 		case FONT_SMALL2:	return cgDC.Assets.qhSmall2Font;
 		case FONT_MEDIUM:	return cgDC.Assets.qhMediumFont;
-		case FONT_LARGE:	return cgDC.Assets.qhMediumFont;//cgDC.Assets.qhBigFont;
-			//fixme? Big fonr isn't registered...?
+		case FONT_LARGE:	return cgDC.Assets.qhBigFont;
 	}
 
 	return cgDC.Assets.qhMediumFont;

--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -2447,7 +2447,7 @@ Ghoul2 Insert End
 //	CG_LoadFonts();
 	cgDC.Assets.qhSmallFont  = trap->R_RegisterFont("ocr_a");
 	cgDC.Assets.qhMediumFont = trap->R_RegisterFont("ergoec");
-	cgDC.Assets.qhBigFont = cgDC.Assets.qhMediumFont;
+	cgDC.Assets.qhBigFont =  trap->R_RegisterFont("arialnb");
 
 	memset( &cgs, 0, sizeof( cgs ) );
 	memset( cg_weapons, 0, sizeof(cg_weapons) );


### PR DESCRIPTION
Registers the unused BigFont, fixes a console warning in MP that I was having, need to check it for SP

Edit: Does seem to match with what SP uses
https://github.com/JACoders/OpenJK/blob/master/code/ui/ui_shared.cpp#L3075-L3087