### PR TITLE
[MP] implement PC_AddGlobalDefine, PC_RemoveGlobalDefine when DEFINEHASHING is defined

### DIFF
--- a/codemp/botlib/be_interface.cpp
+++ b/codemp/botlib/be_interface.cpp
@@ -910,5 +910,7 @@ botlib_export_t *GetBotLibAPI(int apiVersion, botlib_import_t *import) {
 	be_botlib_export.BotLibUpdateEntity = Export_BotLibUpdateEntity;
 	be_botlib_export.Test = BotExportTest;
 
+	PC_Init();
+
 	return &be_botlib_export;
 }

--- a/codemp/botlib/botlib.h
+++ b/codemp/botlib/botlib.h
@@ -426,7 +426,7 @@ typedef struct botlib_export_s
 	int (*BotLibVarGet)(char *var_name, char *value, int size);
 
 	//sets a C-like define returns BLERR_
-	int (*PC_AddGlobalDefine)(char *string);
+	int (*PC_AddGlobalDefine)(const char *string);
 	int (*PC_LoadSourceHandle)(const char *filename);
 	int (*PC_FreeSourceHandle)(int handle);
 	int (*PC_ReadTokenHandle)(int handle, pc_token_t *pc_token);

--- a/codemp/botlib/l_precomp.h
+++ b/codemp/botlib/l_precomp.h
@@ -115,7 +115,8 @@ typedef struct source_s
 	token_t token;							//last read token
 } source_t;
 
-
+// initialise the precompiler
+void PC_Init(void);
 //read a token from the source
 int PC_ReadToken(source_t *source, token_t *token);
 //expect a certain token
@@ -139,9 +140,9 @@ int PC_ReadLine(source_t *source, token_t *token);
 //returns true if there was a white space in front of the token
 int PC_WhiteSpaceBeforeToken(token_t *token);
 //add a define to the source
-int PC_AddDefine(source_t *source, char *string);
+int PC_AddDefine(source_t *source, const char *string);
 //add a globals define that will be added to all opened sources
-int PC_AddGlobalDefine(char *string);
+int PC_AddGlobalDefine(const char *string);
 //remove the given global define
 int PC_RemoveGlobalDefine(char *name);
 //remove all globals defines

--- a/codemp/botlib/l_script.cpp
+++ b/codemp/botlib/l_script.cpp
@@ -1399,7 +1399,7 @@ script_t *LoadScriptFile(const char *filename)
 // Returns:				-
 // Changes Globals:		-
 //============================================================================
-script_t *LoadScriptMemory(char *ptr, int length, char *name)
+script_t *LoadScriptMemory(const char *ptr, int length, char *name)
 {
 	void *buffer;
 	script_t *script;

--- a/codemp/botlib/l_script.h
+++ b/codemp/botlib/l_script.h
@@ -242,7 +242,7 @@ const char *PunctuationFromNum(script_t *script, int num);
 //load a script from the given file at the given offset with the given length
 script_t *LoadScriptFile(const char *filename);
 //load a script from the given memory with the given length
-script_t *LoadScriptMemory(char *ptr, int length, char *name);
+script_t *LoadScriptMemory(const char *ptr, int length, char *name);
 //free a script
 void FreeScript(script_t *script);
 //set the base folder to load files from

--- a/codemp/cgame/cg_public.h
+++ b/codemp/cgame/cg_public.h
@@ -614,7 +614,7 @@ typedef struct cgameImport_s {
 	void			(*Key_SetCatcher)						( int catcher );
 
 	// preprocessor (botlib_export->PC_***)
-	int				(*PC_AddGlobalDefine)					( char *string );
+	int				(*PC_AddGlobalDefine)					( const char *string );
 	int				(*PC_FreeSource)						( int handle );
 	int				(*PC_LoadGlobalDefines)					( const char *filename );
 	int				(*PC_LoadSource)						( const char *filename );

--- a/codemp/cgame/cg_syscalls.c
+++ b/codemp/cgame/cg_syscalls.c
@@ -386,7 +386,7 @@ void trap_Key_SetCatcher( int catcher ) {
 int trap_Key_GetKey( const char *binding ) {
 	return Q_syscall( CG_KEY_GETKEY, binding );
 }
-int trap_PC_AddGlobalDefine( char *define ) {
+int trap_PC_AddGlobalDefine( const char *define ) {
 	return Q_syscall( CG_PC_ADD_GLOBAL_DEFINE, define );
 }
 int trap_PC_LoadSource( const char *filename ) {

--- a/codemp/client/cl_cgameapi.cpp
+++ b/codemp/client/cl_cgameapi.cpp
@@ -1262,7 +1262,7 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		return Key_GetKey( (const char *)VMA(1) );
 
 	case CG_PC_ADD_GLOBAL_DEFINE:
-		return botlib_export->PC_AddGlobalDefine( (char *)VMA(1) );
+		return botlib_export->PC_AddGlobalDefine( (const char *)VMA(1) );
 
 	case CG_PC_LOAD_SOURCE:
 		return botlib_export->PC_LoadSourceHandle( (const char *)VMA(1) );

--- a/codemp/client/cl_uiapi.cpp
+++ b/codemp/client/cl_uiapi.cpp
@@ -1071,7 +1071,7 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return re->AnyLanguage_ReadCharFromString( (const char *)VMA(1), (int *) VMA(2), (qboolean *) VMA(3) );
 
 	case UI_PC_ADD_GLOBAL_DEFINE:
-		return botlib_export->PC_AddGlobalDefine( (char *)VMA(1) );
+		return botlib_export->PC_AddGlobalDefine( (const char *)VMA(1) );
 
 	case UI_PC_LOAD_SOURCE:
 		return botlib_export->PC_LoadSourceHandle( (const char *)VMA(1) );

--- a/codemp/game/g_public.h
+++ b/codemp/game/g_public.h
@@ -971,7 +971,7 @@ typedef struct gameImport_s {
 	int			(*BotLibShutdown)						( void );
 	int			(*BotLibVarSet)							( char *var_name, char *value );
 	int			(*BotLibVarGet)							( char *var_name, char *value, int size );
-	int			(*BotLibDefine)							( char *string );
+	int			(*BotLibDefine)							( const char *string );
 	int			(*BotLibStartFrame)						( float time );
 	int			(*BotLibLoadMap)						( const char *mapname );
 	int			(*BotLibUpdateEntity)					( int ent, void *bue );

--- a/codemp/game/g_syscalls.c
+++ b/codemp/game/g_syscalls.c
@@ -421,7 +421,7 @@ int trap_BotLibVarSet(char *var_name, char *value) {
 int trap_BotLibVarGet(char *var_name, char *value, int size) {
 	return Q_syscall( BOTLIB_LIBVAR_GET, var_name, value, size );
 }
-int trap_BotLibDefine(char *string) {
+int trap_BotLibDefine(const char *string) {
 	return Q_syscall( BOTLIB_PC_ADD_GLOBAL_DEFINE, string );
 }
 int trap_BotLibStartFrame(float time) {

--- a/codemp/server/sv_gameapi.cpp
+++ b/codemp/server/sv_gameapi.cpp
@@ -1211,7 +1211,7 @@ static int SV_BotLibVarGet( char *var_name, char *value, int size ) {
 	return botlib_export->BotLibVarGet( var_name, value, size );
 }
 
-static int SV_BotLibDefine( char *string ) {
+static int SV_BotLibDefine( const char *string ) {
 	return botlib_export->PC_AddGlobalDefine( string );
 }
 
@@ -2226,7 +2226,7 @@ intptr_t SV_GameSystemCalls( intptr_t *args ) {
 		return botlib_export->BotLibVarGet( (char *)VMA(1), (char *)VMA(2), args[3] );
 
 	case BOTLIB_PC_ADD_GLOBAL_DEFINE:
-		return botlib_export->PC_AddGlobalDefine( (char *)VMA(1) );
+		return botlib_export->PC_AddGlobalDefine( (const char *)VMA(1) );
 	case BOTLIB_PC_LOAD_SOURCE:
 		return botlib_export->PC_LoadSourceHandle( (const char *)VMA(1) );
 	case BOTLIB_PC_FREE_SOURCE:

--- a/codemp/ui/ui_public.h
+++ b/codemp/ui/ui_public.h
@@ -269,7 +269,7 @@ typedef struct uiImport_s {
 	void			(*Key_SetCatcher)						( int catcher );
 	void			(*Key_SetOverstrikeMode)				( qboolean state );
 
-	int				(*PC_AddGlobalDefine)					( char *define );
+	int				(*PC_AddGlobalDefine)					( const char *define );
 	int				(*PC_FreeSource)						( int handle );
 	int				(*PC_LoadGlobalDefines)					( const char* filename );
 	int				(*PC_LoadSource)						( const char *filename );

--- a/codemp/ui/ui_syscalls.c
+++ b/codemp/ui/ui_syscalls.c
@@ -286,7 +286,7 @@ int trap_LAN_CompareServers( int source, int sortKey, int sortDir, int s1, int s
 int trap_MemoryRemaining( void ) {
 	return Q_syscall( UI_MEMORY_REMAINING );
 }
-int trap_PC_AddGlobalDefine( char *define ) {
+int trap_PC_AddGlobalDefine( const char *define ) {
 	return Q_syscall( UI_PC_ADD_GLOBAL_DEFINE, define );
 }
 int trap_PC_LoadSource( const char *filename ) {


### PR DESCRIPTION
This allows you to programmatically expose values to `.menu` files from cgame/ui via preprocessor defines.

So we could in theory do:

```diff
diff --git a/codemp/cgame/cg_main.c b/codemp/cgame/cg_main.c
index 12bbd470e..ff1827912 100644
--- a/codemp/cgame/cg_main.c
+++ b/codemp/cgame/cg_main.c
@@ -2196,6 +2196,9 @@ void CG_LoadMenus(const char *menuFile)
 	buf[len] = 0;
 	trap->FS_Close( f );
 
+	trap->PC_AddGlobalDefine("ARCH_STRING \"" ARCH_STRING "\"");
+	trap->PC_LoadGlobalDefines("ui/jamp/menudef.h");
+
 	p = buf;
 
 	COM_BeginParseSession ("CG_LoadMenus");
diff --git a/codemp/ui/ui_main.c b/codemp/ui/ui_main.c
index 45501d947..d11a20f21 100644
--- a/codemp/ui/ui_main.c
+++ b/codemp/ui/ui_main.c
@@ -1423,6 +1423,7 @@ void UI_LoadMenus(const char *menuFile, qboolean reset) {
 	int handle;
 //	int start = trap->Milliseconds();
 
+	trap->PC_AddGlobalDefine("ARCH_STRING \"" ARCH_STRING "\"");
 	trap->PC_LoadGlobalDefines ( "ui/jamp/menudef.h" );
 
 	handle = trap->PC_LoadSource( menuFile );
```