### PR TITLE
[Shared] fix UI transition/fade effects being framerate dependent

### DIFF
--- a/code/ui/ui_shared.cpp
+++ b/code/ui/ui_shared.cpp
@@ -7788,6 +7788,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 	int		xPos,textWidth;
 	vec4_t red;
 	menuDef_t *parent;
+	const float tAdjust = DC->frameTime / (1000.0 / UI_TARGET_FPS);
 	red[0] = red[3] = 1;
 	red[1] = red[2] = 0;
 
@@ -7812,17 +7813,17 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 		if (DC->realTime > item->window.nextTime)
 		{
 			float rx, ry, a, c, s, w, h;
-			item->window.nextTime = DC->realTime + item->window.offsetTime;
+			item->window.nextTime = DC->realTime + (item->window.offsetTime * tAdjust);
 			// translate
 			w = item->window.rectClient.w / 2;
 			h = item->window.rectClient.h / 2;
-			rx = item->window.rectClient.x + w - item->window.rectEffects.x;
-			ry = item->window.rectClient.y + h - item->window.rectEffects.y;
+			rx = item->window.rectClient.x + ((w - item->window.rectEffects.x) * tAdjust);
+			ry = item->window.rectClient.y + ((h - item->window.rectEffects.y) * tAdjust);
 			a = (float) (3 * M_PI / 180);
   			c = cos(a);
 			s = sin(a);
-			item->window.rectClient.x = (rx * c - ry * s) + item->window.rectEffects.x - w;
-			item->window.rectClient.y = (rx * s + ry * c) + item->window.rectEffects.y - h;
+			item->window.rectClient.x = (rx * c - ry * s) + ((item->window.rectEffects.x - w) * tAdjust);
+			item->window.rectClient.y = (rx * s + ry * c) + ((item->window.rectEffects.y - h) * tAdjust);
 			Item_UpdatePosition(item);
 
 		}
@@ -7834,7 +7835,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 		if (DC->realTime > item->window.nextTime)
 		{
 			int done = 0;
-			item->window.nextTime = DC->realTime + item->window.offsetTime;
+			item->window.nextTime = DC->realTime + (item->window.offsetTime * tAdjust);
 
 			// transition the x,y
 			if (item->window.rectClient.x == item->window.rectEffects.x)
@@ -7845,7 +7846,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 			{
 				if (item->window.rectClient.x < item->window.rectEffects.x)
 				{
-					item->window.rectClient.x += item->window.rectEffects2.x;
+					item->window.rectClient.x += item->window.rectEffects2.x * tAdjust;
 					if (item->window.rectClient.x > item->window.rectEffects.x)
 					{
 						item->window.rectClient.x = item->window.rectEffects.x;
@@ -7854,7 +7855,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				}
 				else
 				{
-					item->window.rectClient.x -= item->window.rectEffects2.x;
+					item->window.rectClient.x -= item->window.rectEffects2.x * tAdjust;
 					if (item->window.rectClient.x < item->window.rectEffects.x)
 					{
 						item->window.rectClient.x = item->window.rectEffects.x;
@@ -7871,7 +7872,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 			{
 				if (item->window.rectClient.y < item->window.rectEffects.y)
 				{
-					item->window.rectClient.y += item->window.rectEffects2.y;
+					item->window.rectClient.y += item->window.rectEffects2.y * tAdjust;
 					if (item->window.rectClient.y > item->window.rectEffects.y)
 					{
 						item->window.rectClient.y = item->window.rectEffects.y;
@@ -7880,7 +7881,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				}
 				else
 				{
-					item->window.rectClient.y -= item->window.rectEffects2.y;
+					item->window.rectClient.y -= item->window.rectEffects2.y * tAdjust;
 					if (item->window.rectClient.y < item->window.rectEffects.y)
 					{
 						item->window.rectClient.y = item->window.rectEffects.y;
@@ -7897,7 +7898,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 			{
 				if (item->window.rectClient.w < item->window.rectEffects.w)
 				{
-					item->window.rectClient.w += item->window.rectEffects2.w;
+					item->window.rectClient.w += item->window.rectEffects2.w * tAdjust;
 					if (item->window.rectClient.w > item->window.rectEffects.w)
 					{
 						item->window.rectClient.w = item->window.rectEffects.w;
@@ -7906,7 +7907,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				}
 				else
 				{
-					item->window.rectClient.w -= item->window.rectEffects2.w;
+					item->window.rectClient.w -= item->window.rectEffects2.w * tAdjust;
 					if (item->window.rectClient.w < item->window.rectEffects.w)
 					{
 						item->window.rectClient.w = item->window.rectEffects.w;
@@ -7923,7 +7924,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 			{
 				if (item->window.rectClient.h < item->window.rectEffects.h)
 				{
-					item->window.rectClient.h += item->window.rectEffects2.h;
+					item->window.rectClient.h += item->window.rectEffects2.h * tAdjust;
 					if (item->window.rectClient.h > item->window.rectEffects.h)
 					{
 						item->window.rectClient.h = item->window.rectEffects.h;
@@ -7932,7 +7933,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				}
 				else
 				{
-					item->window.rectClient.h -= item->window.rectEffects2.h;
+					item->window.rectClient.h -= item->window.rectEffects2.h * tAdjust;
 					if (item->window.rectClient.h < item->window.rectEffects.h)
 					{
 						item->window.rectClient.h = item->window.rectEffects.h;
@@ -7967,7 +7968,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 			if (DC->realTime > item->window.nextTime)
 			{
 				int done = 0;
-				item->window.nextTime = DC->realTime + item->window.offsetTime;
+				item->window.nextTime = DC->realTime + (item->window.offsetTime * tAdjust);
 
 
 // transition the x,y,z max
@@ -7979,7 +7980,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				{
 					if (modelptr->g2maxs[0] < modelptr->g2maxs2[0])
 					{
-						modelptr->g2maxs[0] += modelptr->g2maxsEffect[0];
+						modelptr->g2maxs[0] += modelptr->g2maxsEffect[0] * tAdjust;
 						if (modelptr->g2maxs[0] > modelptr->g2maxs2[0])
 						{
 							modelptr->g2maxs[0] = modelptr->g2maxs2[0];
@@ -7988,7 +7989,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 					else
 					{
-						modelptr->g2maxs[0] -= modelptr->g2maxsEffect[0];
+						modelptr->g2maxs[0] -= modelptr->g2maxsEffect[0] * tAdjust;
 						if (modelptr->g2maxs[0] < modelptr->g2maxs2[0])
 						{
 							modelptr->g2maxs[0] = modelptr->g2maxs2[0];
@@ -8005,7 +8006,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				{
 					if (modelptr->g2maxs[1] < modelptr->g2maxs2[1])
 					{
-						modelptr->g2maxs[1] += modelptr->g2maxsEffect[1];
+						modelptr->g2maxs[1] += modelptr->g2maxsEffect[1] * tAdjust;
 						if (modelptr->g2maxs[1] > modelptr->g2maxs2[1])
 						{
 							modelptr->g2maxs[1] = modelptr->g2maxs2[1];
@@ -8014,7 +8015,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 					else
 					{
-						modelptr->g2maxs[1] -= modelptr->g2maxsEffect[1];
+						modelptr->g2maxs[1] -= modelptr->g2maxsEffect[1] * tAdjust;
 						if (modelptr->g2maxs[1] < modelptr->g2maxs2[1])
 						{
 							modelptr->g2maxs[1] = modelptr->g2maxs2[1];
@@ -8034,7 +8035,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				{
 					if (modelptr->g2maxs[2] < modelptr->g2maxs2[2])
 					{
-						modelptr->g2maxs[2] += modelptr->g2maxsEffect[2];
+						modelptr->g2maxs[2] += modelptr->g2maxsEffect[2] * tAdjust;
 						if (modelptr->g2maxs[2] > modelptr->g2maxs2[2])
 						{
 							modelptr->g2maxs[2] = modelptr->g2maxs2[2];
@@ -8043,7 +8044,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 					else
 					{
-						modelptr->g2maxs[2] -= modelptr->g2maxsEffect[2];
+						modelptr->g2maxs[2] -= modelptr->g2maxsEffect[2] * tAdjust;
 						if (modelptr->g2maxs[2] < modelptr->g2maxs2[2])
 						{
 							modelptr->g2maxs[2] = modelptr->g2maxs2[2];
@@ -8061,7 +8062,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				{
 					if (modelptr->g2mins[0] < modelptr->g2mins2[0])
 					{
-						modelptr->g2mins[0] += modelptr->g2minsEffect[0];
+						modelptr->g2mins[0] += modelptr->g2minsEffect[0] * tAdjust;
 						if (modelptr->g2mins[0] > modelptr->g2mins2[0])
 						{
 							modelptr->g2mins[0] = modelptr->g2mins2[0];
@@ -8070,7 +8071,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 					else
 					{
-						modelptr->g2mins[0] -= modelptr->g2minsEffect[0];
+						modelptr->g2mins[0] -= modelptr->g2minsEffect[0] * tAdjust;
 						if (modelptr->g2mins[0] < modelptr->g2mins2[0])
 						{
 							modelptr->g2mins[0] = modelptr->g2mins2[0];
@@ -8087,7 +8088,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				{
 					if (modelptr->g2mins[1] < modelptr->g2mins2[1])
 					{
-						modelptr->g2mins[1] += modelptr->g2minsEffect[1];
+						modelptr->g2mins[1] += modelptr->g2minsEffect[1] * tAdjust;
 						if (modelptr->g2mins[1] > modelptr->g2mins2[1])
 						{
 							modelptr->g2mins[1] = modelptr->g2mins2[1];
@@ -8096,7 +8097,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 					else
 					{
-						modelptr->g2mins[1] -= modelptr->g2minsEffect[1];
+						modelptr->g2mins[1] -= modelptr->g2minsEffect[1] * tAdjust;
 						if (modelptr->g2mins[1] < modelptr->g2mins2[1])
 						{
 							modelptr->g2mins[1] = modelptr->g2mins2[1];
@@ -8116,7 +8117,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				{
 					if (modelptr->g2mins[2] < modelptr->g2mins2[2])
 					{
-						modelptr->g2mins[2] += modelptr->g2minsEffect[2];
+						modelptr->g2mins[2] += modelptr->g2minsEffect[2] * tAdjust;
 						if (modelptr->g2mins[2] > modelptr->g2mins2[2])
 						{
 							modelptr->g2mins[2] = modelptr->g2mins2[2];
@@ -8125,7 +8126,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 					else
 					{
-						modelptr->g2mins[2] -= modelptr->g2minsEffect[2];
+						modelptr->g2mins[2] -= modelptr->g2minsEffect[2] * tAdjust;
 						if (modelptr->g2mins[2] < modelptr->g2mins2[2])
 						{
 							modelptr->g2mins[2] = modelptr->g2mins2[2];
@@ -8145,7 +8146,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				{
 					if (modelptr->fov_x < modelptr->fov_x2)
 					{
-						modelptr->fov_x += modelptr->fov_Effectx;
+						modelptr->fov_x += modelptr->fov_Effectx * tAdjust;
 						if (modelptr->fov_x > modelptr->fov_x2)
 						{
 							modelptr->fov_x = modelptr->fov_x2;
@@ -8154,7 +8155,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 					else
 					{
-						modelptr->fov_x -= modelptr->fov_Effectx;
+						modelptr->fov_x -= modelptr->fov_Effectx * tAdjust;
 						if (modelptr->fov_x < modelptr->fov_x2)
 						{
 							modelptr->fov_x = modelptr->fov_x2;
@@ -8172,7 +8173,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				{
 					if (modelptr->fov_y < modelptr->fov_y2)
 					{
-						modelptr->fov_y += modelptr->fov_Effecty;
+						modelptr->fov_y += modelptr->fov_Effecty * tAdjust;
 						if (modelptr->fov_y > modelptr->fov_y2)
 						{
 							modelptr->fov_y = modelptr->fov_y2;
@@ -8181,7 +8182,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 					else
 					{
-						modelptr->fov_y -= modelptr->fov_Effecty;
+						modelptr->fov_y -= modelptr->fov_Effecty * tAdjust;
 						if (modelptr->fov_y < modelptr->fov_y2)
 						{
 							modelptr->fov_y = modelptr->fov_y2;
@@ -8422,10 +8423,11 @@ void Fade(int *flags, float *f, float clamp, int *nextTime, int offsetTime, qboo
 	{
 		if (DC->realTime > *nextTime)
 		{
-			*nextTime = DC->realTime + offsetTime;
+			const float tAdjust = DC->frameTime / (1000.0 / UI_TARGET_FPS);
+			*nextTime = DC->realTime + (offsetTime * tAdjust);
 			if (*flags & WINDOW_FADINGOUT)
 			{
-				*f -= fadeAmount;
+				*f -= fadeAmount * tAdjust;
 				if (bFlags && *f <= 0.0)
 				{
 					*flags &= ~(WINDOW_FADINGOUT | WINDOW_VISIBLE);
@@ -8433,7 +8435,7 @@ void Fade(int *flags, float *f, float clamp, int *nextTime, int offsetTime, qboo
 			}
 			else
 			{
-				*f += fadeAmount;
+				*f += fadeAmount * tAdjust;
 				if (*f >= clamp)
 				{
 				  *f = clamp;

--- a/code/ui/ui_shared.h
+++ b/code/ui/ui_shared.h
@@ -30,6 +30,7 @@ enum {
 	SSF_PNG
 };
 
+#define UI_TARGET_FPS 60
 #define MAX_TOKENLENGTH		1024
 #define MAX_OPEN_MENUS 16
 #define	MAX_TEXTSCROLL_LINES		256

--- a/codemp/ui/ui_shared.h
+++ b/codemp/ui/ui_shared.h
@@ -30,6 +30,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include "ui/menudef.h"
 
+#define UI_TARGET_FPS				60
 #define MAX_MENUNAME				32
 #define MAX_ITEMTEXT				64
 #define MAX_ITEMACTION				64


### PR DESCRIPTION
Currently the `transition`/`fade` keywords in menus will behave differently according to your FPS.
This PR makes it consistent with the original behaviour as if you had 60 FPS - which is likely what they were designed for.

You can see these in effect in SP from the main menu:

- `New` (transition)
- `Controls` (fade in)

Demonstration of before/after this fix from JA++ with a custom menu:
https://github.com/JACoders/OpenJK/assets/844370/e84b79f1-5da6-4f6a-99fc-f67782263605

Demonstration of fixed behaviour in existing SP menu:
https://github.com/JACoders/OpenJK/assets/844370/16814f7c-94f3-4df3-9631-275bccd461ba