### PR TITLE
[SP] Font fixes

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1231,4 +1231,6 @@ void	CG_ClearLightStyles( void );
 void	CG_RunLightStyles( void );
 void	CG_SetLightstyle( int i );
 
+int CG_MagicFontToReal( int menuFontIndex );
+
 #endif	//__CG_LOCAL_H__

--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -4353,10 +4353,47 @@ void CG_DrawDataPadForceSelect( void )
 		const float	textScale = 1.0f;
 
 		CG_DisplayBoxedText(textboxXPos,textboxYPos,textboxWidth,textboxHeight,va("%s%s",text,text2),
-													4,
+													CG_MagicFontToReal(4),
 													textScale,
 													colorTable[CT_WHITE]
 													);
+	}
+}
+
+int CG_MagicFontToReal( int menuFontIndex )
+{
+	// As the engine supports multiple renderers now we can no longer assume the
+	// order of fontindex values to be the same as it was on vanilla jasp with
+	// vanilla assets. Sadly the code uses magic numbers in various places that
+	// no longer match. This function tries to map these magic numbers to the
+	// fonts the would refer to on vanilla jasp with vanilla assets.
+
+	static int fonthandle_aurabesh;
+	static int fonthandle_ergoec;
+	static int fonthandle_anewhope;
+	static int fonthandle_arialnb;
+
+	static qboolean fontsRegistered = qfalse;
+
+	if ( !fontsRegistered )
+	{ // Only try registering the fonts once
+		fonthandle_aurabesh = cgi_R_RegisterFont( "aurabesh" );
+		fonthandle_ergoec   = cgi_R_RegisterFont( "ergoec" );
+		fonthandle_anewhope = cgi_R_RegisterFont( "anewhope" );
+		fonthandle_arialnb  = cgi_R_RegisterFont( "arialnb" );
+
+		fontsRegistered = qtrue;
+	}
+
+	// Default fonts from a clean installation
+	switch ( menuFontIndex ) {
+		case 1: return fonthandle_aurabesh;
+		case 2: return fonthandle_ergoec;
+		case 3: return fonthandle_anewhope;
+		case 4: return fonthandle_arialnb;
+
+		default:
+			return cgs.media.qhFontMedium;
 	}
 }
 

--- a/code/cgame/cg_weapons.cpp
+++ b/code/cgame/cg_weapons.cpp
@@ -1685,7 +1685,7 @@ void CG_DrawDataPadWeaponSelect( void )
 			textboxXPos, textboxYPos,
 			textboxWidth, textboxHeight,
 			text,
-			4,
+			CG_MagicFontToReal(4),
 			textScale,
 			colorTable[CT_WHITE]
 				);

--- a/code/rd-common/tr_font.cpp
+++ b/code/rd-common/tr_font.cpp
@@ -1019,6 +1019,7 @@ CFontInfo::CFontInfo(const char *_fontName)
 	m_fAltSBCSFontScaleFactor = -1;
 #endif
 	m_bIsFakeAlienLanguage = !strcmp(_fontName,"aurabesh");	// dont try and make SBCS or asian overrides for this
+	m_isVariant = qfalse;
 
 	len = ri.FS_ReadFile(fontName, NULL);
 	if (len == sizeof(dfontdat_t))

--- a/code/ui/ui_atoms.cpp
+++ b/code/ui/ui_atoms.cpp
@@ -441,12 +441,31 @@ UI_RegisterFont
 =================
 */
 
+int registeredFontsCount = 0;
+int registeredFonts[MAX_FONTS];
+
 int UI_RegisterFont(const char *fontName)
 {
 	int iFontIndex = ui.R_RegisterFont(fontName);
 	if (iFontIndex == 0)
 	{
 		iFontIndex = ui.R_RegisterFont("ergoec");	// fall back
+	}
+
+	// Store font
+	if ( iFontIndex )
+	{
+		int i;
+		for ( i = 0; i < registeredFontsCount; i++ )
+		{
+			if ( registeredFonts[i] == iFontIndex ) break;
+		}
+
+		if ( i == registeredFontsCount )
+		{ // It's not in the list: add it
+			if ( registeredFontsCount >= MAX_FONTS ) Com_Printf( "^3UI_RegisterFont: MAX_FONTS (%i) exceeded\n", MAX_FONTS );
+			else registeredFonts[registeredFontsCount++] = iFontIndex;
+		}
 	}
 
 	return iFontIndex;

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -246,4 +246,8 @@ void			trap_S_StartLocalSound( sfxHandle_t sfx, int channelNum );
 
 void _UI_Refresh( int realtime );
 
+#define MAX_FONTS 64
+extern int registeredFontsCount;
+extern int registeredFonts[MAX_FONTS];
+
 #endif

--- a/code/ui/ui_shared.cpp
+++ b/code/ui/ui_shared.cpp
@@ -352,7 +352,7 @@ qboolean MenuParse_font( itemDef_t *item)
 
 	if (!DC->Assets.fontRegistered)
 	{
-		DC->Assets.qhMediumFont = DC->registerFont(menu->font);
+		DC->Assets.qhMediumFont = UI_RegisterFont(menu->font);
 		DC->Assets.fontRegistered = qtrue;
 	}
 	return qtrue;
@@ -3072,35 +3072,19 @@ qboolean ItemParse_name( itemDef_t *item)
 	return qtrue;
 }
 
-int MenuFontToReal( int menuFontIndex )
+int UI_MenuFontToReal( int menuFontIndex )
 {
-	static int fonthandle_aurabesh;
-	static int fonthandle_ergoec;
-	static int fonthandle_anewhope;
-	static int fonthandle_arialnb;
+	// The font array starts at 0, but the valid font indexes start at 1. As the
+	// original menu files have direct font indexes we need to subtract 1 from
+	// the given index to get the correct index for our mapping array.
+	menuFontIndex--;
 
-	static qboolean fontsRegistered = qfalse;
+	// Make sure we don't go out of bound, fallback to medium font
+	if ( menuFontIndex < 0 || menuFontIndex >= registeredFontsCount )
+		return DC->Assets.qhMediumFont;
 
-	if ( !fontsRegistered )
-	{ // Only try registering the fonts once
-		fonthandle_aurabesh = UI_RegisterFont( "aurabesh" );
-		fonthandle_ergoec   = UI_RegisterFont( "ergoec" );
-		fonthandle_anewhope = UI_RegisterFont( "anewhope" );
-		fonthandle_arialnb  = UI_RegisterFont( "arialnb" );
-
-		fontsRegistered = qtrue;
-	}
-
-	// Default fonts from a clean installation
-	switch ( menuFontIndex ) {
-		case 1: return fonthandle_aurabesh;
-		case 2: return fonthandle_ergoec;
-		case 3: return fonthandle_anewhope;
-		case 4: return fonthandle_arialnb;
-
-		default:
-			return DC->Assets.qhMediumFont;
-	}
+	// Use the mapped index
+	return registeredFonts[menuFontIndex];
 }
 
 qboolean ItemParse_font( itemDef_t *item )
@@ -3111,7 +3095,7 @@ qboolean ItemParse_font( itemDef_t *item )
 	}
 
 	// Translate to real font
-	item->font = MenuFontToReal( item->font );
+	item->font = UI_MenuFontToReal( item->font );
 
 	return qtrue;
 }
@@ -8294,7 +8278,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 				while (1)
 				{
 					// FIXME - add some type of parameter in the menu file like descfont to specify the font for the descriptions for this menu.
-					textWidth = DC->textWidth(textPtr, fDescScale, MenuFontToReal(4));	//  item->font);
+					textWidth = DC->textWidth(textPtr, fDescScale, UI_MenuFontToReal(4));	//  item->font);
 
 					if (parent->descAlignment == ITEM_ALIGN_RIGHT)
 					{
@@ -8330,7 +8314,7 @@ static qboolean Item_Paint(itemDef_t *item, qboolean bDraw)
 					}
 
 					// FIXME - add some type of parameter in the menu file like descfont to specify the font for the descriptions for this menu.
-					DC->drawText(xPos, parent->descY + iYadj, fDescScale, parent->descColor, textPtr, 0, parent->descTextStyle, MenuFontToReal(4));	//item->font);
+					DC->drawText(xPos, parent->descY + iYadj, fDescScale, parent->descColor, textPtr, 0, parent->descTextStyle, UI_MenuFontToReal(4));	//item->font);
 					break;
 				}
 			}

--- a/codemp/rd-common/tr_font.cpp
+++ b/codemp/rd-common/tr_font.cpp
@@ -882,6 +882,7 @@ CFontInfo::CFontInfo(const char *_fontName)
 	m_iOriginalFontWhenSBCSOverriden = -1;
 	m_fAltSBCSFontScaleFactor = -1;
 	m_bIsFakeAlienLanguage = !strcmp(_fontName,"aurabesh");	// dont try and make SBCS or asian overrides for this
+	m_isVariant = qfalse;
 
 	len = ri.FS_ReadFile(fontName, NULL);
 	if (len == sizeof(dfontdat_t))


### PR DESCRIPTION
This pull request fixes 2 bugs in SP:
 - the datapad showed incorrect fonts for the weapons and force tabs (#1226)
 - the r_reloadfonts command made all fonts vanish

Additionally it adjusts `MenuFontToReal` in the ui module to be more flexible in case of menu files that don't actually load the default fonts.