### PR TITLE
Fix opengl context leak on vid_restart

### DIFF
--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -810,8 +810,17 @@ void WIN_Shutdown( void )
 
 	IN_Shutdown();
 
+	if ( opengl_context ) {
+		SDL_GL_DeleteContext( opengl_context );
+		opengl_context = NULL;
+	}
+
+	if ( screen ) {
+		SDL_DestroyWindow( screen );
+		screen = NULL;
+	}
+
 	SDL_QuitSubSystem( SDL_INIT_VIDEO );
-	screen = NULL;
 }
 
 void GLimp_EnableLogging( qboolean enable )


### PR DESCRIPTION
Effect of opengl context leak varies depending on video driver. On my linux intel driver it was adding 4 new threads per vid_restart (+ heap space)

On windows + nvidia driver it didn't add new threads but each vid_restart added considerable amount of heap space to the process.

It's possible that the leak did not happen with some older SDL version, I tested with SDL2 2.28.5