### PR TITLE
Add .editorconfig - default indentation for text editors and github

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 
 [*]
 insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.{txt,md}]
+charset = utf-8


### PR DESCRIPTION
Set default tab width to 4 and other properties for github pages and text editors (see https://editorconfig.org/)