### PR TITLE
macOS libpng, SDL_window fixes 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ endif()
 
 if(APPLE)
   set(UseInternalJPEGDefault ON)
+  set(UseInternalPNGDefault  ON)
 endif()
 
 option(UseInternalOpenAL "If set, use bundled OpenAL."  ${UseInternalOpenALDefault})

--- a/shared/sdl/sdl_window.cpp
+++ b/shared/sdl/sdl_window.cpp
@@ -421,7 +421,11 @@ static rserr_t GLimp_SetMode(glconfig_t *glConfig, const windowDesc_t *windowDes
 
 	if( fullscreen )
 	{
-		flags |= SDL_WINDOW_FULLSCREEN;
+#ifdef MACOS_X
+        flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+#else
+        flags |= SDL_WINDOW_FULLSCREEN;
+#endif
 		glConfig->isFullscreen = qtrue;
 	}
 	else


### PR DESCRIPTION
- Force use of internal libpng on macOS, fixes version mismatch problems on current macOS installations
- SDL_Window fix from https://github.com/ec-/Quake3e/pull/295
    - Fixes tabbing out of the game, macbook notch mode, and macOS game mode
- Tested, works locally, used
```
sudo xattr -r -d com.apple.quarantine openjk.arm64.app openjk_sp.arm64.app
codesign --force --deep --sign - openjk.arm64.app openjk_sp.arm64.app
```

To quarantine and codesign the app locally and ran as expected in-game.
