### PR TITLE
[JO] Fix level transition screen

### DIFF
--- a/code/client/cl_scrn.cpp
+++ b/code/client/cl_scrn.cpp
@@ -554,6 +554,8 @@ void SCR_PrecacheScreenshot()
 
 }
 
+// Returns a SG_SCR_WIDTH x SG_SCR_HEIGHT screenshot buffer
+// Must match color components with DrawStretchRaw: 4
 byte *SCR_GetScreenshot(qboolean *qValid)
 {
 	if (!screenDataValid) {

--- a/code/rd-vanilla/tr_draw.cpp
+++ b/code/rd-vanilla/tr_draw.cpp
@@ -198,10 +198,11 @@ void RE_GetScreenShot(byte *buffer, int w, int h)
 					b += src[2];
 				}
 			}
-			dst = buffer + 3 * ( y * w + x );
+			dst = buffer + 4 * ((h - y - 1) * w + x );
 			dst[0] = r / 12;
 			dst[1] = g / 12;
 			dst[2] = b / 12;
+			dst[3] = 255;
 		}
 	}
 


### PR DESCRIPTION
When redsaurus fixed the save screenshot (in ff210853d582adcf58578cba9ee2917607d49c7c ), they must have missed the double usage of SCR_GetScreenshot. Besides being used for the savegame thumbnails, it's used directly as an argument for DrawStrechRaw. DrawStrechRaw expects a RGBA buffer to draw to the screen. For drawing the level transition screen correctly I also had to flip the image in RE_GetScreenShot, so I also changed the flipping behaviour when saving the savegame.

Fixes: https://github.com/JACoders/OpenJK/issues/1114