### PR TITLE
Fix in_nograb not releasing the mouse cursor

### DIFF
--- a/shared/sdl/sdl_input.cpp
+++ b/shared/sdl/sdl_input.cpp
@@ -452,10 +452,13 @@ static void IN_ActivateMouse( void )
 	{
 		if( in_nograb->modified || !mouseActive )
 		{
-			if( in_nograb->integer )
+			if( in_nograb->integer ) {
+				SDL_SetRelativeMouseMode( SDL_FALSE );
 				SDL_SetWindowGrab( SDL_window, SDL_FALSE );
-			else
+			} else {
+				SDL_SetRelativeMouseMode( SDL_TRUE );
 				SDL_SetWindowGrab( SDL_window, SDL_TRUE );
+			}
 
 			in_nograb->modified = qfalse;
 		}


### PR DESCRIPTION
Now in windowed mode desktop cursor is visible and you can move it out of the game window