### PR TITLE
[JO] Fix potential memory leak in screenshot code

### DIFF
--- a/code/server/sv_savegame.cpp
+++ b/code/server/sv_savegame.cpp
@@ -1062,6 +1062,11 @@ static void SG_WriteScreenshot(qboolean qbAutosave, const char *psMapName)
 
 	if (!pbRawScreenShot)
 	{
+		if (byBlank != NULL)
+		{
+			delete[] byBlank;
+		}
+
 		const size_t bySize = SG_SCR_WIDTH * SG_SCR_HEIGHT * 3;
 
 		byBlank = new byte[bySize];


### PR DESCRIPTION
byBlank can be allocated on autosave and it can still fail to read the levelshot image. Missed that when I fixed the level transition screen in https://github.com/JACoders/OpenJK/pull/1254