### PR TITLE
[Shared] Adjust FX_AddPrimitive to take a regular pointer instead of …

### DIFF
--- a/code/cgame/FxUtil.cpp
+++ b/code/cgame/FxUtil.cpp
@@ -384,19 +384,19 @@ void FX_Add( bool portal )
 // all effects are being stopped.
 //-------------------------
 extern bool gEffectsInPortal;	//from FXScheduler.cpp so i don't have to pass it in on EVERY FX_ADD*
-void FX_AddPrimitive( CEffect **pEffect, int killTime )
+void FX_AddPrimitive( CEffect *pEffect, int killTime )
 {
 	SEffectList *item = FX_GetValidEffect();
 
-	item->mEffect = *pEffect;
+	item->mEffect = pEffect;
 	item->mKillTime = theFxHelper.mTime + killTime;
 	item->mPortal = gEffectsInPortal;	//global set in AddScheduledEffects
 
 	activeFx++;
 
 	// Stash these in the primitive so it has easy access to the vals
-	(*pEffect)->SetTimeStart( theFxHelper.mTime );
-	(*pEffect)->SetTimeEnd( theFxHelper.mTime + killTime );
+	pEffect->SetTimeStart( theFxHelper.mTime );
+	pEffect->SetTimeEnd( theFxHelper.mTime + killTime );
 }
 
 
@@ -485,7 +485,7 @@ CParticle *FX_AddParticle(  int clientID, const vec3_t org, const vec3_t vel, co
 		fx->SetDeathFxID( deathID );
 		fx->SetImpactFxID( impactID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -568,7 +568,7 @@ CLine *FX_AddLine( int clientID, vec3_t start, vec3_t end, float size1, float si
 		fx->SetSTScale( 1.0f, 1.0f );
 		fx->SetImpactFxID( impactFX_id );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -651,7 +651,7 @@ CElectricity *FX_AddElectricity( int clientID, vec3_t start, vec3_t end, float s
 
 		fx->SetSTScale( 1.0f, 1.0f );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL?
 		if ( fx )
 		{
@@ -758,7 +758,7 @@ CTail *FX_AddTail( int clientID, vec3_t org, vec3_t vel, vec3_t accel,
 		fx->SetDeathFxID( deathID );
 		fx->SetImpactFxID( impactID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -868,7 +868,7 @@ CCylinder *FX_AddCylinder( int clientID, vec3_t start, vec3_t normal,
 		fx->SetShader( shader );
 		fx->SetFlags( flags );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -957,7 +957,7 @@ CEmitter *FX_AddEmitter( vec3_t org, vec3_t vel, vec3_t accel,
 		fx->SetLastOrg( org );
 		fx->SetLastVel( vel );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -1011,7 +1011,7 @@ CLight *FX_AddLight( vec3_t org, float size1, float size2, float sizeParm,
 
 		fx->SetFlags( flags );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -1106,7 +1106,7 @@ COrientedParticle *FX_AddOrientedParticle( int clientID, vec3_t org, vec3_t norm
 		fx->SetDeathFxID( deathID );
 		fx->SetImpactFxID( impactID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -1180,7 +1180,7 @@ CPoly *FX_AddPoly( vec3_t *verts, vec2_t *st, int numVerts,
 		// Now that we've set our data up, let's process it into a useful format
 		fx->PolyInit();
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -1259,7 +1259,7 @@ CBezier *FX_AddBezier( const vec3_t start, const vec3_t end,
 
 		fx->SetSTScale( 1.0f, 1.0f );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -1329,7 +1329,7 @@ CFlash *FX_AddFlash( vec3_t origin, vec3_t sRGB, vec3_t eRGB, float rgbParm,
 
 		fx->Init();
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;

--- a/code/cgame/cg_players.cpp
+++ b/code/cgame/cg_players.cpp
@@ -5928,7 +5928,7 @@ static void CG_CreateSaberMarks( vec3_t start, vec3_t end, vec3_t normal )
 	}
 }
 
-extern void FX_AddPrimitive( CEffect **effect, int killTime );
+extern void FX_AddPrimitive( CEffect *effect, int killTime );
 //-------------------------------------------------------
 void CG_CheckSaberInWater( centity_t *cent, centity_t *scent, int saberNum, int modelIndex, vec3_t origin, vec3_t angles )
 {
@@ -6691,7 +6691,7 @@ Ghoul2 Insert End
 					fx->mVerts[3].destST[1] = 0.99f;
 
 	//				fx->SetFlags( FX_USE_ALPHA );
-					FX_AddPrimitive( (CEffect**)&fx, duration );//SABER_TRAIL_TIME );
+					FX_AddPrimitive( fx, duration );//SABER_TRAIL_TIME );
 				}
 			}
 

--- a/codeJK2/cgame/FxUtil.cpp
+++ b/codeJK2/cgame/FxUtil.cpp
@@ -367,18 +367,18 @@ void FX_Add( void )
 // Note - in the editor, this function may change *pEffect to NULL, indicating that
 // all effects are being stopped.
 //-------------------------
-void FX_AddPrimitive( CEffect **pEffect, int killTime )
+void FX_AddPrimitive( CEffect *pEffect, int killTime )
 {
 	SEffectList *item = FX_GetValidEffect();
 
-	item->mEffect = *pEffect;
+	item->mEffect = pEffect;
 	item->mKillTime = theFxHelper.mTime + killTime;
 
 	activeFx++;
 
 	// Stash these in the primitive so it has easy access to the vals
-	(*pEffect)->SetTimeStart( theFxHelper.mTime );
-	(*pEffect)->SetTimeEnd( theFxHelper.mTime + killTime );
+	pEffect->SetTimeStart( theFxHelper.mTime );
+	pEffect->SetTimeEnd( theFxHelper.mTime + killTime );
 }
 
 
@@ -456,7 +456,7 @@ CParticle *FX_AddParticle( const vec3_t org, const vec3_t vel, const vec3_t acce
 		fx->SetDeathFxID( deathID );
 		fx->SetImpactFxID( impactID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -537,7 +537,7 @@ CParticle *FX_AddParticle( int clientID, const vec3_t org, const vec3_t vel, con
 		fx->SetMax( NULL );
 		fx->SetClient( clientID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -608,7 +608,7 @@ CLine *FX_AddLine( vec3_t start, vec3_t end, float size1, float size2, float siz
 
 		fx->SetSTScale( 1.0f, 1.0f );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -683,7 +683,7 @@ CLine *FX_AddLine( int clientID, vec3_t start, float size1, float size2, float s
 		fx->SetClient( clientID );
 		fx->SetImpactFxID( impactFX_id );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -756,7 +756,7 @@ CElectricity *FX_AddElectricity( vec3_t start, vec3_t end, float size1, float si
 
 		fx->SetSTScale( 1.0f, 1.0f );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL?
 		if ( fx )
 		{
@@ -855,7 +855,7 @@ CTail *FX_AddTail( vec3_t org, vec3_t vel, vec3_t accel,
 		fx->SetDeathFxID( deathID );
 		fx->SetImpactFxID( impactID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -951,7 +951,7 @@ CTail *FX_AddTail( int clientID, vec3_t org, vec3_t vel, vec3_t accel,
 		fx->SetImpactFxID( impactID );
 		fx->SetClient( clientID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -1050,7 +1050,7 @@ CCylinder *FX_AddCylinder( vec3_t start, vec3_t normal,
 		fx->SetShader( shader );
 		fx->SetFlags( flags );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -1139,7 +1139,7 @@ CEmitter *FX_AddEmitter( vec3_t org, vec3_t vel, vec3_t accel,
 		fx->SetLastOrg( org );
 		fx->SetLastVel( vel );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -1193,7 +1193,7 @@ CLight *FX_AddLight( vec3_t org, float size1, float size2, float sizeParm,
 
 		fx->SetFlags( flags );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -1278,7 +1278,7 @@ COrientedParticle *FX_AddOrientedParticle( vec3_t org, vec3_t norm, vec3_t vel, 
 		fx->SetDeathFxID( deathID );
 		fx->SetImpactFxID( impactID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -1352,7 +1352,7 @@ CPoly *FX_AddPoly( vec3_t *verts, vec2_t *st, int numVerts,
 		// Now that we've set our data up, let's process it into a useful format
 		fx->PolyInit();
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL
 	}
 
@@ -1431,7 +1431,7 @@ CBezier *FX_AddBezier( const vec3_t start, const vec3_t end,
 
 		fx->SetSTScale( 1.0f, 1.0f );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -1501,7 +1501,7 @@ CFlash *FX_AddFlash( vec3_t origin, vec3_t sRGB, vec3_t eRGB, float rgbParm,
 
 		fx->Init();
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;

--- a/codeJK2/cgame/cg_players.cpp
+++ b/codeJK2/cgame/cg_players.cpp
@@ -4368,7 +4368,7 @@ void CG_CreateSaberMarks( vec3_t start, vec3_t end, vec3_t normal )
 	}
 }
 
-extern void FX_AddPrimitive( CEffect **effect, int killTime );
+extern void FX_AddPrimitive( CEffect *effect, int killTime );
 //-------------------------------------------------------
 void CG_CheckSaberInWater( centity_t *cent, centity_t *scent, int modelIndex, vec3_t origin, vec3_t angles )
 {
@@ -4716,7 +4716,7 @@ Ghoul2 Insert End
 
 				fx->mShader = cgs.media.saberBlurShader;
 //				fx->SetFlags( FX_USE_ALPHA );
-				FX_AddPrimitive( (CEffect**)&fx, SABER_TRAIL_TIME );
+				FX_AddPrimitive( fx, SABER_TRAIL_TIME );
 			}
 		}
 

--- a/codemp/client/FxPrimitives.cpp
+++ b/codemp/client/FxPrimitives.cpp
@@ -2302,7 +2302,7 @@ void CFlash::Draw( void )
 	drawnFx++;
 }
 
-void FX_AddPrimitive( CEffect **pEffect, int killTime );
+void FX_AddPrimitive( CEffect *pEffect, int killTime );
 void FX_FeedTrail(effectTrailArgStruct_t *a)
 {
 	CTrail *fx = new CTrail;
@@ -2330,6 +2330,6 @@ void FX_FeedTrail(effectTrailArgStruct_t *a)
 
 	fx->mShader = a->mShader;
 
-	FX_AddPrimitive((CEffect **)&fx, a->mKillTime);
+	FX_AddPrimitive(fx, a->mKillTime);
 }
 // end

--- a/codemp/client/FxUtil.cpp
+++ b/codemp/client/FxUtil.cpp
@@ -238,19 +238,19 @@ void FX_Add( bool portal )
 // all effects are being stopped.
 //-------------------------
 extern bool gEffectsInPortal;	//from FXScheduler.cpp so i don't have to pass it in on EVERY FX_ADD*
-void FX_AddPrimitive( CEffect **pEffect, int killTime )
+void FX_AddPrimitive( CEffect *pEffect, int killTime )
 {
 	SEffectList *item = FX_GetValidEffect();
 
-	item->mEffect = *pEffect;
+	item->mEffect = pEffect;
 	item->mKillTime = theFxHelper.mTime + killTime;
 	item->mPortal = gEffectsInPortal;	//global set in AddScheduledEffects
 
 	activeFx++;
 
 	// Stash these in the primitive so it has easy access to the vals
-	(*pEffect)->SetTimeStart( theFxHelper.mTime );
-	(*pEffect)->SetTimeEnd( theFxHelper.mTime + killTime );
+	pEffect->SetTimeStart( theFxHelper.mTime );
+	pEffect->SetTimeEnd( theFxHelper.mTime + killTime );
 }
 
 //-------------------------
@@ -343,7 +343,7 @@ CParticle *FX_AddParticle( vec3_t org, vec3_t vel, vec3_t accel, float size1, fl
 
 		fx->Init();
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -430,7 +430,7 @@ CLine *FX_AddLine( vec3_t start, vec3_t end, float size1, float size2, float siz
 
 		fx->SetSTScale( 1.0f, 1.0f );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -517,7 +517,7 @@ CElectricity *FX_AddElectricity( vec3_t start, vec3_t end, float size1, float si
 
 		fx->SetSTScale( 1.0f, 1.0f );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 		// in the editor, fx may now be NULL?
 		if ( fx )
 		{
@@ -629,7 +629,7 @@ CTail *FX_AddTail( vec3_t org, vec3_t vel, vec3_t accel,
 		fx->SetDeathFxID( deathID );
 		fx->SetImpactFxID( impactID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -745,7 +745,7 @@ CCylinder *FX_AddCylinder( vec3_t start, vec3_t normal,
 		fx->SetShader( shader );
 		fx->SetFlags( flags );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -843,7 +843,7 @@ CEmitter *FX_AddEmitter( vec3_t org, vec3_t vel, vec3_t accel,
 		fx->SetLastOrg( org );
 		fx->SetLastVel( vel );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -909,7 +909,7 @@ CLight *FX_AddLight( vec3_t org, float size1, float size2, float sizeParm,
 
 		fx->SetFlags( flags );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -1007,7 +1007,7 @@ COrientedParticle *FX_AddOrientedParticle( vec3_t org, vec3_t norm, vec3_t vel, 
 		fx->SetDeathFxID( deathID );
 		fx->SetImpactFxID( impactID );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -1080,7 +1080,7 @@ CPoly *FX_AddPoly( vec3_t *verts, vec2_t *st, int numVerts,
 		// Now that we've set our data up, let's process it into a useful format
 		fx->PolyInit();
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -1163,7 +1163,7 @@ CFlash *FX_AddFlash( vec3_t origin,
 
 		fx->Init();
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;
@@ -1240,7 +1240,7 @@ CBezier *FX_AddBezier( vec3_t start, vec3_t end,
 
 		fx->SetSTScale( 1.0f, 1.0f );
 
-		FX_AddPrimitive( (CEffect**)&fx, killTime );
+		FX_AddPrimitive( fx, killTime );
 	}
 
 	return fx;


### PR DESCRIPTION
Adjust FX_AddPrimitive to take a regular pointer instead of a double pointer.

This allows us to get rid of invalid casts. Using gcc 15.1.1 on Arch Linux these casts lead to crashes in release builds due to strict aliasing rules in c++.

Thanks to skull for helping to debug this one.