### PR TITLE
[Shared] Fix portable build on windows, revert change to "latest" release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
           mv ./OpenJO-macos-arm64-Release-Non-Portable/* OpenJO-macos-arm64.tar.gz
 
       - name: Create latest build
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1 # latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           automatic_release_tag: "latest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,11 +298,10 @@ jobs:
           mv ./OpenJO-macos-arm64-Release-Non-Portable/* OpenJO-macos-arm64.tar.gz
 
       - name: Create latest build
-        uses: softprops/action-gh-release@v1
+        uses: marvinpinto/action-automatic-releases@latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          generate_release_notes: true
-          tag_name: "latest"
+          automatic_release_tag: "latest"
           prerelease: false
           title: Latest Build
           files: |

--- a/shared/sys/sys_win32.cpp
+++ b/shared/sys/sys_win32.cpp
@@ -19,6 +19,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include "qcommon/game_version.h"
 #include "sys_local.h"
 #include <direct.h>
 #include <io.h>


### PR DESCRIPTION
Fixes some regressions introduced in #1176

sys_win32.cpp 
- Replace `q_version.h` definition with `game_version.h` instead of removing it entirely (q_version.h contains the cmakeportable definition when it gets generated, removing it was causing portable builds to not be portable on windows)

build.yml
- Revert action change from `marvinpinto/action-automatic-releases` to `softprops/action-gh-release` as the `softprops` action is not intended for rolling releases, and does not generate release notes in the same fashion that would be compatible for such an intention (ie, listing all commits since the previous latest release), the `marvinpinto` action is deprecated and abandoned, but a custom solution using GitHub CLI would probably be the ideal solution.
- Additionally pins `marvinpinto/action-automatic-releases` to a commit instead of to the `@latest` tag, I did a test run here on a dummy repo: https://github.com/taysta/cicd-tester/actions/runs/15209021255/workflow#L99-L183