### PR TITLE
[Shared] Key modifiers

### DIFF
--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -824,10 +824,10 @@ int Key_StringToKeynum( char *str ) {
 	}
 
 	// check for hex code
-	if ( strlen( str ) == 4 ) {
-		int n = Com_HexStrToInt( str );
+	if ( strlen( str ) >= 3 ) {
+		size_t n = Com_HexStrToInt( str );
 
-		if ( n >= 0 )
+		if ( n >= 0 && n < ARRAY_LEN(keynames) )
 			return n;
 	}
 

--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -42,6 +42,11 @@ field_t		historyEditLines[COMMAND_HISTORY];
 
 keyGlobals_t	kg;
 
+cvar_t *cl_keyModifiersOnlyIfUnbound;
+cvar_t *cl_keyModifiersFallbackToDefault;
+cvar_t *cl_keyModifiersEnableLocks;
+cvar_t *cl_keyModifiersPassToUI;
+
 // do NOT blithely change any of the key names (3rd field) here, since they have to match the key binds
 //	in the CFG files, they're also prepended with "KEYNAME_" when looking up StripEd references
 //
@@ -809,9 +814,12 @@ the K_* names are matched up.
 to be configured even if they don't have defined names.
 ===================
 */
-int Key_StringToKeynum( char *str ) {
+int Key_StringToKeynum( const char *str ) {
 	if ( !VALIDSTRING( str ) )
 		return -1;
+
+	// Skip all modifiers
+	str = Key_SkipModifiers( str );
 
 	// If single char bind, presume ascii char bind
 	if ( !str[1] )
@@ -924,22 +932,103 @@ const char *Key_KeynumToString( int keynum ) {
 
 /*
 ===================
+Key_ModifiersFromString
+===================
+*/
+static stringID_table_t keyModifiers[] {
+	// Regular modifiers
+	{ "LSHIFT",       KEYMOD_LSHIFT       },
+	{ "RSHIFT",       KEYMOD_RSHIFT       },
+	{ "LCTRL",        KEYMOD_LCTRL        },
+	{ "RCTRL",        KEYMOD_RCTRL        },
+	{ "LALT",         KEYMOD_LALT         },
+	{ "RALT",         KEYMOD_RALT         },
+	{ "LSUPER",       KEYMOD_LSUPER       },
+	{ "RSUPER",       KEYMOD_RSUPER       },
+
+	// LOCK modifiers
+	{ "NUMLOCK",      KEYMOD_NUMLOCK      },
+	{ "CAPSLOCK",     KEYMOD_CAPSLOCK     },
+};
+static int keyModifiersAmount = ARRAY_LEN( keyModifiers );
+
+int Key_ModifiersFromString( const char *str ) {
+	int modifiers = 0;
+
+	int i = 0;
+	int strLen = strlen( str );
+	int modLen;
+
+	for ( i = 0; i < keyModifiersAmount; i++ ) {
+		modLen = strlen( keyModifiers[i].name );
+		if ( strLen < modLen+1 ) continue;
+		if ( !Q_stricmpn(str, keyModifiers[i].name, modLen) && str[modLen] == '+' ) {
+			modifiers |= keyModifiers[i].id;
+			str += modLen+1;
+			i = -1; // Reset loop
+		}
+	}
+	return modifiers;
+}
+
+/*
+===================
+Key_SkipModifiers
+===================
+*/
+const char *Key_SkipModifiers( const char *str ) {
+	int i = 0;
+	int strLen = strlen( str );
+	int modLen;
+
+	for ( i = 0; i < keyModifiersAmount; i++ ) {
+		modLen = strlen( keyModifiers[i].name );
+		if ( strLen < modLen+1 ) continue;
+		if ( !Q_stricmpn(str, keyModifiers[i].name, modLen) && str[modLen] == '+' ) {
+			str += modLen+1;
+			i = -1; // Reset loop
+		}
+	}
+	return str;
+}
+
+/*
+===================
+Key_ModifiersStringFromModifiers
+===================
+*/
+char *Key_ModifiersStringFromModifiers( int modifiers ) {
+	static char modifiersStr[128]; // All current modifier strings above, sepearated by '+' are 66 chars in length.
+	int i;
+
+	modifiersStr[0] = 0;
+	for ( i = 0; i < keyModifiersAmount; i++ ) {
+		if ( modifiers & keyModifiers[i].id ) {
+			Q_strcat( modifiersStr, sizeof(modifiersStr), keyModifiers[i].name );
+			Q_strcat( modifiersStr, sizeof(modifiersStr), "+" );
+		}
+	}
+	return modifiersStr;
+}
+
+/*
+===================
 Key_SetBinding
 ===================
 */
-void Key_SetBinding( int keynum, const char *binding ) {
+void Key_SetBinding( int keynum, int modifiers, const char *binding ) {
 	if ( keynum < 0 || keynum >= MAX_KEYS )
 		return;
 
 	// free old bindings
-	if ( kg.keys[keynames[keynum].upper].binding ) {
-		Z_Free( kg.keys[keynames[keynum].upper].binding );
-		kg.keys[keynames[keynum].upper].binding = NULL;
+	if ( kg.keys[keynames[keynum].upper].binding[modifiers] ) {
+		Z_Free( kg.keys[keynames[keynum].upper].binding[modifiers] );
+		kg.keys[keynames[keynum].upper].binding[modifiers] = NULL;
 	}
 
 	// allocate memory for new binding
 	if ( binding )
-		kg.keys[keynames[keynum].upper].binding = CopyString( binding );
+		kg.keys[keynames[keynum].upper].binding[modifiers] = CopyString( binding );
 
 	// consider this like modifying an archived cvar, so the
 	// file write will be triggered at the next oportunity
@@ -951,11 +1040,11 @@ void Key_SetBinding( int keynum, const char *binding ) {
 Key_GetBinding
 ===================
 */
-const char *Key_GetBinding( int keynum ) {
+const char *Key_GetBinding( int keynum, int modifiers ) {
 	if ( keynum < 0 || keynum >= MAX_KEYS )
 		return "";
 
-	return kg.keys[keynum].binding;
+	return kg.keys[keynum].binding[modifiers];
 }
 
 /*
@@ -963,10 +1052,10 @@ const char *Key_GetBinding( int keynum ) {
 Key_GetKey
 ===================
 */
-int Key_GetKey( const char *binding ) {
+int Key_GetKey( const char *binding, int modifiers ) {
 	if ( binding ) {
 		for ( int i=0; i<MAX_KEYS; i++ ) {
-			if ( kg.keys[i].binding && !Q_stricmp( binding, kg.keys[i].binding ) )
+			if ( kg.keys[i].binding[modifiers] && !Q_stricmp( binding, kg.keys[i].binding[modifiers] ) )
 				return i;
 		}
 	}
@@ -991,7 +1080,9 @@ void Key_Unbind_f( void ) {
 		return;
 	}
 
-	Key_SetBinding( b, "" );
+	int modifiers = Key_ModifiersFromString( Cmd_Argv(1) );
+
+	Key_SetBinding( b, modifiers, "" );
 }
 
 /*
@@ -1000,9 +1091,11 @@ Key_Unbindall_f
 ===================
 */
 void Key_Unbindall_f( void ) {
-	for ( int i=0; i<MAX_KEYS; i++ ) {
-		if ( kg.keys[i].binding )
-			Key_SetBinding( i, "" );
+	for ( int j=0; j<KEYMOD_COMBINATIONS; j++ ) {
+		for ( int i=0; i<MAX_KEYS; i++ ) {
+			if ( kg.keys[i].binding[j] )
+				Key_SetBinding( i, j, "" );
+		}
 	}
 }
 
@@ -1025,15 +1118,17 @@ void Key_Bind_f( void ) {
 		return;
 	}
 
+	int modifiers = Key_ModifiersFromString( Cmd_Argv(1) );
+
 	if ( c == 2 ) {
-		if ( kg.keys[b].binding && kg.keys[b].binding[0] )
-			Com_Printf( S_COLOR_GREY "Bind " S_COLOR_WHITE "%s = " S_COLOR_GREY "\"" S_COLOR_WHITE "%s" S_COLOR_GREY "\"" S_COLOR_WHITE "\n", Key_KeynumToString( b ), kg.keys[b].binding );
+		if ( kg.keys[b].binding[modifiers] && kg.keys[b].binding[modifiers][0] )
+			Com_Printf( S_COLOR_GREY "Bind " S_COLOR_WHITE "%s%s = " S_COLOR_GREY "\"" S_COLOR_WHITE "%s" S_COLOR_GREY "\"" S_COLOR_WHITE "\n", Key_ModifiersStringFromModifiers( modifiers ), Key_KeynumToString( b ), kg.keys[b].binding[modifiers] );
 		else
-			Com_Printf( "\"%s\" is not bound\n", Key_KeynumToString( b ) );
+			Com_Printf( "\"%s%s\" is not bound\n", Key_ModifiersStringFromModifiers( modifiers ), Key_KeynumToString( b ) );
 		return;
 	}
 
-	Key_SetBinding( b, Cmd_ArgsFrom( 2 ) );
+	Key_SetBinding( b, modifiers, Cmd_ArgsFrom( 2 ) );
 }
 
 /*
@@ -1045,15 +1140,17 @@ Writes lines containing "bind key value"
 */
 void Key_WriteBindings( fileHandle_t f ) {
 	FS_Printf( f, "unbindall\n" );
-	for ( size_t i=0; i<MAX_KEYS; i++ ) {
-		if ( kg.keys[i].binding && kg.keys[i].binding[0] ) {
-			const char *name = Key_KeynumToString( i );
+	for ( int j = 0; j<KEYMOD_COMBINATIONS; j++ ) {
+		for ( size_t i=0; i<MAX_KEYS; i++ ) {
+			if ( kg.keys[i].binding[j] && kg.keys[i].binding[j][0] ) {
+				const char *name = Key_KeynumToString( i );
 
-			// handle the escape character nicely
-			if ( !strcmp( name, "\\" ) )
-				FS_Printf( f, "bind \"\\\" \"%s\"\n", kg.keys[i].binding );
-			else
-				FS_Printf( f, "bind \"%s\" \"%s\"\n", name, kg.keys[i].binding );
+				// handle the escape character nicely
+				if ( !strcmp( name, "\\" ) )
+					FS_Printf( f, "bind \"%s\\\" \"%s\"\n", Key_ModifiersStringFromModifiers(j), kg.keys[i].binding[j] );
+				else
+					FS_Printf( f, "bind \"%s%s\" \"%s\"\n", Key_ModifiersStringFromModifiers(j), name, kg.keys[i].binding[j] );
+			}
 		}
 	}
 }
@@ -1065,21 +1162,72 @@ Key_Bindlist_f
 ============
 */
 void Key_Bindlist_f( void ) {
-	for ( size_t i=0; i<MAX_KEYS; i++ ) {
-		if ( kg.keys[i].binding && kg.keys[i].binding[0] )
-			Com_Printf( S_COLOR_GREY "Key " S_COLOR_WHITE "%s (%s) = " S_COLOR_GREY "\"" S_COLOR_WHITE "%s" S_COLOR_GREY "\"" S_COLOR_WHITE "\n", Key_KeynumToAscii( i ), Key_KeynumToString( i ), kg.keys[i].binding );
+	for ( int j=0; j<KEYMOD_COMBINATIONS; j++) {
+		for ( size_t i=0; i<MAX_KEYS; i++ ) {
+			if ( kg.keys[i].binding[j] && kg.keys[i].binding[j][0] )
+				Com_Printf( S_COLOR_GREY "Key " S_COLOR_WHITE "%s%s (%s%s) = " S_COLOR_GREY "\"" S_COLOR_WHITE "%s" S_COLOR_GREY "\"" S_COLOR_WHITE "\n", Key_ModifiersStringFromModifiers( j ), Key_KeynumToAscii( i ), Key_ModifiersStringFromModifiers( j ), Key_KeynumToString( i ), kg.keys[i].binding[j] );
+		}
 	}
 }
 
 /*
 ============
-Key_KeynameCompletion
+Key_Completion
 ============
 */
-void Key_KeynameCompletion( callbackFunc_t callback ) {
-	for ( size_t i=0; i<numKeynames; i++ ) {
-		if ( keynames[i].name )
-			callback( keynames[i].name );
+void Key_Completion( callbackFunc_t callback, const char *input ) {
+	char suggestion[MAX_STRING_CHARS];
+	int modifiers = Key_ModifiersFromString( input );
+	const char *skipped = Key_SkipModifiers( input );
+
+	const char *lastModifierMatch = NULL;
+	int modifierMatches = 0;
+	int keyMatches = 0;
+
+	int mod;
+	size_t key;
+
+	if ( skipped-input < 0 ) {
+		Com_Printf( "Key_Completion: invalid skip\n" );
+		return;
+	} else if ( (size_t)(skipped-input) >= sizeof(suggestion) ) {
+		Com_Printf( "Key_Completion: input too long\n" );
+		return;
+	} else {
+		if ( skipped-input <= 0 ) suggestion[0] = 0;
+		else {
+			Q_strncpyz( suggestion, input, skipped-input );
+			Q_strcat( suggestion, sizeof(suggestion), "+" );
+		}
+	}
+
+	for ( mod = 0; mod < keyModifiersAmount; mod++ ) {
+		if ( keyModifiers[mod].name && !Q_stricmpn(keyModifiers[mod].name, skipped, strlen(skipped)) ) {
+			modifierMatches++;
+			lastModifierMatch = keyModifiers[mod].name;
+		}
+	}
+	for ( key = 0; key < numKeynames; key++ ) {
+		if ( keynames[key].name && !Q_stricmpn(keynames[key].name, skipped, strlen(skipped)) ) {
+			keyMatches++;
+		}
+	}
+
+	if ( modifierMatches == 1 && keyMatches == 0 )
+	{ // We want to complete the modifier and suggest all keys with that modifier
+		Q_strcat( suggestion, sizeof(suggestion), lastModifierMatch );
+		Q_strcat( suggestion, sizeof(suggestion), "+" );
+	}
+
+	for ( mod = 0; mod < keyModifiersAmount; mod++ ) {
+		if ( keyModifiers[mod].name && !(modifiers & keyModifiers[mod].id) ) {
+			callback( va("%s%s+", suggestion, keyModifiers[mod].name) );
+		}
+	}
+	for ( key = 0; key < numKeynames; key++ ) {
+		if ( keynames[key].name ) {
+			callback( va("%s%s", suggestion, keynames[key].name) );
+		}
 	}
 }
 
@@ -1134,6 +1282,12 @@ void CL_InitKeyCommands( void ) {
 	Cmd_SetCommandCompletionFunc( "unbind", Key_CompleteUnbind );
 	Cmd_AddCommand( "unbindall", Key_Unbindall_f );
 	Cmd_AddCommand( "bindlist", Key_Bindlist_f );
+
+	// Register cvars (the default values should have legacy configs play the same way without behavior changes)
+	cl_keyModifiersOnlyIfUnbound = Cvar_Get( "cl_keyModifiersOnlyIfUnbound", "1", CVAR_ARCHIVE_ND );
+	cl_keyModifiersFallbackToDefault = Cvar_Get( "cl_keyModifiersFallbackToDefault", "1", CVAR_ARCHIVE_ND );
+	cl_keyModifiersEnableLocks = Cvar_Get( "cl_keyModifiersEnableLocks", "1", CVAR_ARCHIVE_ND );
+	cl_keyModifiersPassToUI = Cvar_Get( "cl_keyModifiersPassToUI", "0", CVAR_ARCHIVE_ND );
 }
 
 /*
@@ -1162,16 +1316,21 @@ CL_ParseBinding
 Execute the commands in the bind string
 ===================
 */
-void CL_ParseBinding( int key, qboolean down, unsigned time )
+void CL_ParseBinding( int key, int modifiers, qboolean down, unsigned time )
 {
 	char buf[ MAX_STRING_CHARS ], *p = buf, *end;
 	qboolean allCommands, allowUpCmds;
 
 	if( cls.state == CA_DISCONNECTED && Key_GetCatcher( ) == 0 )
 		return;
-	if( !kg.keys[keynames[key].upper].binding || !kg.keys[keynames[key].upper].binding[0] )
-		return;
-	Q_strncpyz( buf, kg.keys[keynames[key].upper].binding, sizeof( buf ) );
+	if( !kg.keys[keynames[key].upper].binding[modifiers] || !kg.keys[keynames[key].upper].binding[modifiers][0] ) {
+		if ( !modifiers || !cl_keyModifiersFallbackToDefault->integer ) return;
+		else modifiers = 0;
+
+		if( !kg.keys[keynames[key].upper].binding[modifiers] || !kg.keys[keynames[key].upper].binding[modifiers][0] )
+			return;
+	}
+	Q_strncpyz( buf, kg.keys[keynames[key].upper].binding[modifiers], sizeof( buf ) );
 
 	// run all bind commands if console, ui, etc aren't reading keys
 	allCommands = (qboolean)( Key_GetCatcher( ) == 0 );
@@ -1224,6 +1383,7 @@ void CL_KeyDownEvent( int key, unsigned time )
 	kg.keys[keynames[key].upper].down = qtrue;
 	kg.keys[keynames[key].upper].repeats++;
 	if( kg.keys[keynames[key].upper].repeats == 1 ) {
+		kg.keys[keynames[key].upper].downModifiers = kg.modifiers;
 		kg.keyDownCount++;
 		kg.anykeydown = qtrue;
 	}
@@ -1267,18 +1427,23 @@ void CL_KeyDownEvent( int key, unsigned time )
 			return;
 		}
 
-		_UI_KeyEvent( key, qtrue );
+		_UI_KeyEvent( key, cl_keyModifiersPassToUI->integer ? kg.keys[keynames[key].upper].downModifiers : 0, qtrue );
 		return;
 	}
 
 	// send the bound action
-	CL_ParseBinding( key, qtrue, time );
+	if ( !cls.cursorActive ) CL_ParseBinding( key, kg.keys[keynames[key].upper].downModifiers, qtrue, time );
 
 	// distribute the key down event to the apropriate handler
 	if ( Key_GetCatcher() & KEYCATCH_CONSOLE ) {
 		Console_Key( key );
 	} else if ( Key_GetCatcher() & KEYCATCH_UI ) {
-		_UI_KeyEvent( key, qtrue );
+		if ( cl_keyModifiersPassToUI->integer ) {
+			if ( key == A_ALT && (kg.modifiersReal & (KEYMOD_LALT|KEYMOD_RALT)) ) return;
+			if ( key == A_CTRL && (kg.modifiersReal & (KEYMOD_LCTRL|KEYMOD_RCTRL)) ) return;
+			if ( key == A_SHIFT && (kg.modifiersReal & (KEYMOD_LSHIFT|KEYMOD_RSHIFT)) ) return;
+		}
+		_UI_KeyEvent( key, cl_keyModifiersPassToUI->integer ? kg.modifiersReal : 0, qtrue );
 	} else if ( cls.state == CA_DISCONNECTED ) {
 		Console_Key( key );
 	}
@@ -1293,8 +1458,10 @@ Called by CL_KeyEvent to handle a keyrelease
 */
 void CL_KeyUpEvent( int key, unsigned time )
 {
+	int modifiers = kg.keys[keynames[key].upper].downModifiers;
 	kg.keys[keynames[key].upper].repeats = 0;
 	kg.keys[keynames[key].upper].down = qfalse;
+	kg.keys[keynames[key].upper].downModifiers = 0;
 	kg.keyDownCount--;
 
 	if (kg.keyDownCount <= 0) {
@@ -1312,10 +1479,10 @@ void CL_KeyUpEvent( int key, unsigned time )
 	// console mode and menu mode, to keep the character from continuing
 	// an action started before a mode switch.
 	//
-	CL_ParseBinding( key, qfalse, time );
+	CL_ParseBinding( key, modifiers, qfalse, time );
 
 	if ( Key_GetCatcher( ) & KEYCATCH_UI )
-		_UI_KeyEvent( key, qfalse );
+		_UI_KeyEvent( key, cl_keyModifiersPassToUI->integer ? modifiers : 0, qfalse );
 }
 
 /*
@@ -1346,8 +1513,46 @@ void CL_CharEvent( int key ) {
 
 	// distribute the key down event to the apropriate handler
 		 if ( Key_GetCatcher() & KEYCATCH_CONSOLE )		Field_CharEvent( &g_consoleField, key );
-	else if ( Key_GetCatcher() & KEYCATCH_UI )			_UI_KeyEvent( key|K_CHAR_FLAG, qtrue );
+	else if ( Key_GetCatcher() & KEYCATCH_UI )			_UI_KeyEvent( key|K_CHAR_FLAG, 0, qtrue );
 	else if ( cls.state == CA_DISCONNECTED )			Field_CharEvent( &g_consoleField, key );
+}
+
+/*
+===================
+CL_ModifierEvent
+===================
+*/
+void CL_ModifierEvent( int modifiers ) {
+	kg.modifiers = modifiers;
+	kg.modifiersReal = modifiers;
+
+	if ( cl_keyModifiersOnlyIfUnbound->integer ) {
+		if ( kg.keys[A_SHIFT].binding[0] && kg.keys[A_SHIFT].binding[0][0] ) {
+			kg.modifiers &= ~KEYMOD_LSHIFT;
+			kg.modifiers &= ~KEYMOD_RSHIFT;
+		}
+		if ( kg.keys[A_CTRL].binding[0] && kg.keys[A_CTRL].binding[0][0] ) {
+			kg.modifiers &= ~KEYMOD_LCTRL;
+			kg.modifiers &= ~KEYMOD_RCTRL;
+		}
+		if ( kg.keys[A_ALT].binding[0] && kg.keys[A_ALT].binding[0][0] ) {
+			kg.modifiers &= ~KEYMOD_LALT;
+			kg.modifiers &= ~KEYMOD_RALT;
+		}
+		if ( cl_keyModifiersOnlyIfUnbound->integer != 2 ) {
+			// Special case: the lock modifiers are not held down, they are toggled. So we might want to bind something to the toggle.
+			if ( kg.keys[A_CAPSLOCK].binding[0] && kg.keys[A_CAPSLOCK].binding[0][0] ) {
+				kg.modifiers &= ~KEYMOD_CAPSLOCK;
+			}
+			if ( kg.keys[A_NUMLOCK].binding[0] && kg.keys[A_NUMLOCK].binding[0][0] ) {
+				kg.modifiers &= ~KEYMOD_NUMLOCK;
+			}
+		}
+	}
+	if ( !cl_keyModifiersEnableLocks->integer ) {
+		kg.modifiers &= ~KEYMOD_CAPSLOCK;
+		kg.modifiers &= ~KEYMOD_NUMLOCK;
+	}
 }
 
 /*
@@ -1364,6 +1569,7 @@ void Key_ClearStates( void ) {
 			CL_KeyEvent( i, qfalse, 0 );
 		kg.keys[i].down = qfalse;
 		kg.keys[i].repeats = 0;
+		kg.keys[i].downModifiers = 0;
 	}
 }
 

--- a/code/client/cl_keys.cpp
+++ b/code/client/cl_keys.cpp
@@ -1286,7 +1286,7 @@ void CL_InitKeyCommands( void ) {
 	// Register cvars (the default values should have legacy configs play the same way without behavior changes)
 	cl_keyModifiersOnlyIfUnbound = Cvar_Get( "cl_keyModifiersOnlyIfUnbound", "1", CVAR_ARCHIVE_ND );
 	cl_keyModifiersFallbackToDefault = Cvar_Get( "cl_keyModifiersFallbackToDefault", "1", CVAR_ARCHIVE_ND );
-	cl_keyModifiersEnableLocks = Cvar_Get( "cl_keyModifiersEnableLocks", "1", CVAR_ARCHIVE_ND );
+	cl_keyModifiersEnableLocks = Cvar_Get( "cl_keyModifiersEnableLocks", "0", CVAR_ARCHIVE_ND );
 	cl_keyModifiersPassToUI = Cvar_Get( "cl_keyModifiersPassToUI", "0", CVAR_ARCHIVE_ND );
 }
 

--- a/code/client/cl_ui.cpp
+++ b/code/client/cl_ui.cpp
@@ -96,7 +96,7 @@ Key_KeynumToStringBuf
 // only ever called by binding-display code, therefore returns non-technical "friendly" names
 //	in any language that don't necessarily match those in the config file...
 //
-void Key_KeynumToStringBuf( int keynum, char *buf, int buflen )
+void Key_KeynumToStringBuf( int keynum, int modifiers, char *buf, int buflen )
 {
 	const char *psKeyName = Key_KeynumToString( keynum/*, qtrue */);
 
@@ -104,7 +104,8 @@ void Key_KeynumToStringBuf( int keynum, char *buf, int buflen )
 	//
 	const char *psKeyNameFriendly = SE_GetString( va("KEYNAMES_KEYNAME_%s",psKeyName) );
 
-	Q_strncpyz( buf, (psKeyNameFriendly && psKeyNameFriendly[0]) ? psKeyNameFriendly : psKeyName, buflen );
+	Q_strncpyz( buf, Key_ModifiersStringFromModifiers(modifiers), buflen );
+	Q_strcat( buf, buflen, (psKeyNameFriendly && psKeyNameFriendly[0]) ? psKeyNameFriendly : psKeyName );
 }
 
 /*
@@ -112,10 +113,10 @@ void Key_KeynumToStringBuf( int keynum, char *buf, int buflen )
 Key_GetBindingBuf
 ====================
 */
-void Key_GetBindingBuf( int keynum, char *buf, int buflen ) {
+void Key_GetBindingBuf( int keynum, int modifiers, char *buf, int buflen ) {
 	const char	*value;
 
-	value = Key_GetBinding( keynum );
+	value = Key_GetBinding( keynum, modifiers );
 	if ( value ) {
 		Q_strncpyz( buf, value, buflen );
 	}
@@ -482,11 +483,11 @@ intptr_t CL_UISystemCalls( intptr_t *args )
 	  return 0;
 
 	case UI_KEY_SETBINDING:
-		Key_SetBinding( args[1], (const char *) VMA(2) );
+		Key_SetBinding( args[1], args[2], (const char *) VMA(3) );
 		return 0;
 
 	case UI_KEY_KEYNUMTOSTRINGBUF:
-		Key_KeynumToStringBuf( args[1],(char *) VMA(2), args[3] );
+		Key_KeynumToStringBuf( args[1], args[2],(char *) VMA(3), args[4] );
 		return 0;
 
 	case UI_CIN_SETEXTENTS:
@@ -494,7 +495,7 @@ intptr_t CL_UISystemCalls( intptr_t *args )
 	  return 0;
 
 	case UI_KEY_GETBINDINGBUF:
-		Key_GetBindingBuf( args[1], (char *) VMA(2), args[3] );
+		Key_GetBindingBuf( args[1], args[2], (char *) VMA(3), args[4] );
 		return 0;
 
 

--- a/code/client/client_ui.h
+++ b/code/client/client_ui.h
@@ -27,7 +27,7 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 #include "../ui/ui_public.h"
 
-void _UI_KeyEvent( int key, qboolean down );
+void _UI_KeyEvent( int key, int modifiers, qboolean down );
 void UI_SetActiveMenu( const char* menuname,const char *menuID );
 void UI_UpdateConnectionMessageString( char *string );
 qboolean UI_ConsoleCommand( void ) ;

--- a/code/client/keycodes.h
+++ b/code/client/keycodes.h
@@ -367,4 +367,17 @@ typedef enum
 // distinguished by or'ing in K_CHAR_FLAG (ugly)
 #define	K_CHAR_FLAG		1024
 
+// Supported modifiers
+#define KEYMOD_LSHIFT       (1)
+#define KEYMOD_RSHIFT       (1 << 1)
+#define KEYMOD_LCTRL        (1 << 2)
+#define KEYMOD_RCTRL        (1 << 3)
+#define KEYMOD_LALT         (1 << 4)
+#define KEYMOD_RALT         (1 << 5)
+#define KEYMOD_LSUPER       (1 << 6)
+#define KEYMOD_RSUPER       (1 << 7)
+#define KEYMOD_NUMLOCK      (1 << 8)
+#define KEYMOD_CAPSLOCK     (1 << 9)
+#define KEYMOD_COMBINATIONS ((1 << 10)-1) // NOTE: This must be the last entry
+
 #endif

--- a/code/client/keys.h
+++ b/code/client/keys.h
@@ -25,14 +25,17 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 typedef struct qkey_s {
 	qboolean	down;
+	int			downModifiers;
 	int			repeats;		// if > 1, it is autorepeating
-	char		*binding;
+	char		*binding[KEYMOD_COMBINATIONS];
 } qkey_t;
 
 typedef struct keyGlobals_s {
 	qboolean	anykeydown;
 	qboolean	key_overstrikeMode;
 	int			keyDownCount;
+	int        	modifiers;
+	int         modifiersReal; // Unfiltered
 
 	qkey_t		keys[MAX_KEYS];
 } keyGlobals_t;
@@ -58,11 +61,14 @@ void	Field_CharEvent		( field_t *edit, int ch );
 void	Field_Draw			( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape );
 void	Field_BigDraw		( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape );
 
-void		Key_SetBinding			( int keynum, const char *binding );
-const char *Key_GetBinding			( int keynum );
+int 		Key_ModifiersFromString ( const char *str );
+const char *Key_SkipModifiers		( const char *str );
+char *		Key_ModifiersStringFromModifiers( int modifiers );
+void		Key_SetBinding			( int keynum, int modifiers, const char *binding );
+const char *Key_GetBinding			( int keynum, int modifiers );
 qboolean	Key_IsDown				( int keynum );
-int			Key_StringToKeynum		( char *str );
+int			Key_StringToKeynum		( const char *str );
 qboolean	Key_GetOverstrikeMode	( void );
 void		Key_SetOverstrikeMode	( qboolean state );
 void		Key_ClearStates			( void );
-int			Key_GetKey				( const char *binding );
+int			Key_GetKey				( const char *binding, int modifiers );

--- a/code/qcommon/common.cpp
+++ b/code/qcommon/common.cpp
@@ -911,6 +911,9 @@ int Com_EventLoop( void ) {
 			Cbuf_AddText( (char *)ev.evPtr );
 			Cbuf_AddText( "\n" );
 			break;
+		case SE_MODIFIER:
+			CL_ModifierEvent( ev.evValue );
+			break;
 		}
 
 		// free any block data
@@ -1798,10 +1801,10 @@ void Field_CompleteKeyname( void )
 	matchCount = 0;
 	shortestMatch[ 0 ] = 0;
 
-	Key_KeynameCompletion( FindMatches );
+	Key_Completion( FindMatches, completionString );
 
 	if( !Field_Complete( ) )
-		Key_KeynameCompletion( PrintKeyMatches );
+		Key_Completion( PrintKeyMatches, completionString );
 }
 
 /*

--- a/code/qcommon/qcommon.h
+++ b/code/qcommon/qcommon.h
@@ -731,6 +731,7 @@ void CL_Shutdown( void );
 void CL_Frame( int msec,float fractionMsec );
 qboolean CL_GameCommand( void );
 void CL_KeyEvent (int key, qboolean down, unsigned time);
+void CL_ModifierEvent( int modifiers );
 
 void CL_CharEvent( int key );
 // char events are for field typing, not game control
@@ -759,7 +760,7 @@ void CL_FlushMemory( void );
 
 void CL_StartHunkUsers( void );
 
-void Key_KeynameCompletion ( callbackFunc_t callback );
+void Key_Completion( void(*callback)( const char *s ), const char *input );
 // for keyname autocompletion
 
 void Key_WriteBindings( fileHandle_t f );

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -212,7 +212,7 @@ extern uiInfo_t uiInfo;
 void _UI_Init( qboolean inGameLoad );
 void _UI_DrawRect( float x, float y, float width, float height, float size, const float *color );
 void _UI_MouseEvent( int dx, int dy );
-void _UI_KeyEvent( int key, qboolean down );
+void _UI_KeyEvent( int key, int modifiers, qboolean down );
 void UI_Report(void);
 
 extern char GoToMenu[];
@@ -229,7 +229,7 @@ void			trap_GetGlconfig( glconfig_t *glconfig );
 void			trap_Key_ClearStates( void );
 int				trap_Key_GetCatcher( void );
 qboolean		trap_Key_GetOverstrikeMode( void );
-void			trap_Key_SetBinding( int keynum, const char *binding );
+void			trap_Key_SetBinding( int keynum, int modifiers, const char *binding );
 void			trap_Key_SetCatcher( int catcher );
 void			trap_Key_SetOverstrikeMode( qboolean state );
 void			trap_R_DrawStretchPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader );

--- a/code/ui/ui_main.cpp
+++ b/code/ui/ui_main.cpp
@@ -2050,8 +2050,8 @@ extern void	Item_RunScript(itemDef_t *item, const char *s);		//from ui_shared;
 */
 }
 
-void Key_KeynumToStringBuf( int keynum, char *buf, int buflen );
-void Key_GetBindingBuf( int keynum, char *buf, int buflen );
+void Key_KeynumToStringBuf( int keynum, int modifiers, char *buf, int buflen );
+void Key_GetBindingBuf( int keynum, int modifiers, char *buf, int buflen );
 
 static qboolean UI_Crosshair_HandleKey(int flags, float *special, int key)
 {
@@ -4042,7 +4042,7 @@ void _UI_MouseEvent( int dx, int dy )
 UI_KeyEvent
 =================
 */
-void _UI_KeyEvent( int key, qboolean down )
+void _UI_KeyEvent( int key, int modifiers, qboolean down )
 {
 /*	extern qboolean SwallowBadNumLockedKPKey( int iKey );
 	if (SwallowBadNumLockedKPKey(key)){
@@ -4062,7 +4062,7 @@ void _UI_KeyEvent( int key, qboolean down )
 			}
 			else
 			{
-				Menu_HandleKey(menu, key, down );
+				Menu_HandleKey(menu, key, modifiers, down );
 			}
 		}
 		else

--- a/code/ui/ui_public.h
+++ b/code/ui/ui_public.h
@@ -129,9 +129,9 @@ typedef struct {
 	// =========== data shared with the client system =============
 
 	// keyboard and key binding interaction
-	void		(*Key_KeynumToStringBuf)( int keynum, char *buf, int buflen );
-	void		(*Key_GetBindingBuf)( int keynum, char *buf, int buflen );
-	void		(*Key_SetBinding)( int keynum, const char *binding );
+	void		(*Key_KeynumToStringBuf)( int keynum, int modifiers, char *buf, int buflen );
+	void		(*Key_GetBindingBuf)( int keynum, int modifiers, char *buf, int buflen );
+	void		(*Key_SetBinding)( int keynum, int modifiers, const char *binding );
 	qboolean	(*Key_IsDown)( int keynum );
 	qboolean	(*Key_GetOverstrikeMode)( void );
 	void		(*Key_SetOverstrikeMode)( qboolean state );

--- a/code/ui/ui_shared.h
+++ b/code/ui/ui_shared.h
@@ -180,12 +180,12 @@ typedef struct {
 	int			(*feederCount)(float feederID);
 	void		(*feederSelection)(float feederID, int index, struct itemDef_s *item);
 	void		(*fillRect) ( float x, float y, float w, float h, const vec4_t color);
-	void		(*getBindingBuf)( int keynum, char *buf, int buflen );
+	void		(*getBindingBuf)( int keynum, int modifiers, char *buf, int buflen );
 	void		(*getCVarString)(const char *cvar, char *buffer, int bufsize);
 	float		(*getCVarValue)(const char *cvar);
 	qboolean	(*getOverstrikeMode)();
 	float		(*getValue) (int ownerDraw);
-	void		(*keynumToStringBuf)( int keynum, char *buf, int buflen );
+	void		(*keynumToStringBuf)( int keynum, int modifiers, char *buf, int buflen );
 	void		(*modelBounds) (qhandle_t model, vec3_t min, vec3_t max);
 	qboolean	(*ownerDrawHandleKey)(int ownerDraw, int flags, float *special, int key);
 	void		(*ownerDrawItem) (float x, float y, float w, float h, float text_x, float text_y, int ownerDraw, int ownerDrawFlags, int align, float special, float scale, vec4_t color, qhandle_t shader, int textStyle, int iFontIndex);
@@ -200,7 +200,7 @@ typedef struct {
 	void		(*renderScene) ( const refdef_t *fd );
 	qboolean	(*runScript)(const char **p);
 	qboolean	(*deferScript)(const char **p);
-	void		(*setBinding)( int keynum, const char *binding );
+	void		(*setBinding)( int keynum, int modifiers, const char *binding );
 	void		(*setColor) (const vec4_t v);
 	void		(*setCVar)(const char *cvar, const char *value);
 	void		(*setOverstrikeMode)(qboolean b);
@@ -485,7 +485,7 @@ void Menu_ItemDisable(menuDef_t *menu, const char *name, qboolean disableFlag);
 int Menu_ItemsMatchingGroup(menuDef_t *menu, const char *name);
 itemDef_t *Menu_GetMatchingItemByNumber(menuDef_t *menu, int index, const char *name);
 
-void		Menu_HandleKey(menuDef_t *menu, int key, qboolean down);
+void		Menu_HandleKey(menuDef_t *menu, int key, int modifiers, qboolean down);
 void		Menu_New(char *buffer);
 void		Menus_OpenByName(const char *p);
 void		Menu_PaintAll(void);

--- a/code/ui/ui_syscalls.cpp
+++ b/code/ui/ui_syscalls.cpp
@@ -86,9 +86,9 @@ sfxHandle_t	trap_S_RegisterSound( const char *sample, qboolean compressed )
 	return S_RegisterSound(sample);
 }
 
-void trap_Key_SetBinding( int keynum, const char *binding )
+void trap_Key_SetBinding( int keynum, int modifiers, const char *binding )
 {
-	Key_SetBinding( keynum, binding);
+	Key_SetBinding( keynum, modifiers, binding);
 }
 
 qboolean trap_Key_GetOverstrikeMode( void )

--- a/codemp/client/cl_cgameapi.cpp
+++ b/codemp/client/cl_cgameapi.cpp
@@ -816,6 +816,10 @@ static void CL_G2API_GetSurfaceName( void *ghoul2, int surfNumber, int modelInde
 	strcpy( fillBuf, tmp );
 }
 
+static int CL_Key_GetKey( const char *binding ) {
+	return Key_GetKey( binding, 0 );
+}
+
 static void CL_Key_SetCatcher( int catcher ) {
 	// Don't allow the cgame module to close the console
 	Key_SetCatcher( catcher | ( Key_GetCatcher( ) & KEYCATCH_CONSOLE ) );
@@ -1259,7 +1263,7 @@ intptr_t CL_CgameSystemCalls( intptr_t *args ) {
 		return 0;
 
 	case CG_KEY_GETKEY:
-		return Key_GetKey( (const char *)VMA(1) );
+		return Key_GetKey( (const char *)VMA(1), 0 );
 
 	case CG_PC_ADD_GLOBAL_DEFINE:
 		return botlib_export->PC_AddGlobalDefine( (char *)VMA(1) );
@@ -1817,7 +1821,7 @@ void CL_BindCGame( void ) {
 		cgi.SetClientForceAngle					= CL_SetClientForceAngle;
 		cgi.SetUserCmdValue						= _CL_SetUserCmdValue;
 		cgi.Key_GetCatcher						= Key_GetCatcher;
-		cgi.Key_GetKey							= Key_GetKey;
+		cgi.Key_GetKey							= CL_Key_GetKey;
 		cgi.Key_IsDown							= Key_IsDown;
 		cgi.Key_SetCatcher						= CL_Key_SetCatcher;
 		cgi.PC_AddGlobalDefine					= botlib_export->PC_AddGlobalDefine;

--- a/codemp/client/cl_keys.cpp
+++ b/codemp/client/cl_keys.cpp
@@ -1344,7 +1344,7 @@ void CL_InitKeyCommands( void ) {
 	// Register cvars (the default values should have legacy configs play the same way without behavior changes)
 	cl_keyModifiersOnlyIfUnbound = Cvar_Get( "cl_keyModifiersOnlyIfUnbound", "1", CVAR_ARCHIVE_ND, "If set modifiers (like LCTRL, LALT, LSHIFT, LSUPER, RCTRL, RALT, RSHIFT, RSUPER, CAPSLOCK, NUMLOCK) are only usable when the associated key is unbound (CTRL, ALT, SHIFT, CAPSLOCK, KP_NUMLOCK)." );
 	cl_keyModifiersFallbackToDefault = Cvar_Get( "cl_keyModifiersFallbackToDefault", "1", CVAR_ARCHIVE_ND, "If a key is not bound on a modifier layer, fallback to the bind without a modifier." );
-	cl_keyModifiersEnableLocks = Cvar_Get( "cl_keyModifiersEnableLocks", "1", CVAR_ARCHIVE_ND, "If enabled the CAPSLOCK and NUMLOCK keys switch to another keyboard layer." );
+	cl_keyModifiersEnableLocks = Cvar_Get( "cl_keyModifiersEnableLocks", "0", CVAR_ARCHIVE_ND, "If enabled the CAPSLOCK and NUMLOCK keys switch to another keyboard layer." );
 }
 
 /*

--- a/codemp/client/cl_keys.cpp
+++ b/codemp/client/cl_keys.cpp
@@ -882,10 +882,10 @@ int Key_StringToKeynum( char *str ) {
 	}
 
 	// check for hex code
-	if ( strlen( str ) == 4 ) {
-		int n = Com_HexStrToInt( str );
+	if ( strlen( str ) >= 3 ) {
+		size_t n = Com_HexStrToInt( str );
 
-		if ( n >= 0 )
+		if ( n >= 0 && n < ARRAY_LEN(keynames) )
 			return n;
 	}
 

--- a/codemp/client/cl_keys.cpp
+++ b/codemp/client/cl_keys.cpp
@@ -45,6 +45,10 @@ int			chat_playerNum;
 
 keyGlobals_t	kg;
 
+cvar_t *cl_keyModifiersOnlyIfUnbound;
+cvar_t *cl_keyModifiersFallbackToDefault;
+cvar_t *cl_keyModifiersEnableLocks;
+
 // do NOT blithely change any of the key names (3rd field) here, since they have to match the key binds
 //	in the CFG files, they're also prepended with "KEYNAME_" when looking up StringEd references
 //
@@ -867,9 +871,12 @@ the K_* names are matched up.
 to be configured even if they don't have defined names.
 ===================
 */
-int Key_StringToKeynum( char *str ) {
+int Key_StringToKeynum( const char *str ) {
 	if ( !VALIDSTRING( str ) )
 		return -1;
+
+	// Skip all modifiers
+	str = Key_SkipModifiers( str );
 
 	// If single char bind, presume ascii char bind
 	if ( !str[1] )
@@ -983,22 +990,103 @@ const char *Key_KeynumToString( int keynum ) {
 
 /*
 ===================
+Key_ModifiersFromString
+===================
+*/
+static stringID_table_t keyModifiers[] {
+	// Regular modifiers
+	{ "LSHIFT",       KEYMOD_LSHIFT       },
+	{ "RSHIFT",       KEYMOD_RSHIFT       },
+	{ "LCTRL",        KEYMOD_LCTRL        },
+	{ "RCTRL",        KEYMOD_RCTRL        },
+	{ "LALT",         KEYMOD_LALT         },
+	{ "RALT",         KEYMOD_RALT         },
+	{ "LSUPER",       KEYMOD_LSUPER       },
+	{ "RSUPER",       KEYMOD_RSUPER       },
+
+	// LOCK modifiers
+	{ "NUMLOCK",      KEYMOD_NUMLOCK      },
+	{ "CAPSLOCK",     KEYMOD_CAPSLOCK     },
+};
+static int keyModifiersAmount = ARRAY_LEN( keyModifiers );
+
+int Key_ModifiersFromString( const char *str ) {
+	int modifiers = 0;
+
+	int i = 0;
+	int strLen = strlen( str );
+	int modLen;
+
+	for ( i = 0; i < keyModifiersAmount; i++ ) {
+		modLen = strlen( keyModifiers[i].name );
+		if ( strLen < modLen+1 ) continue;
+		if ( !Q_stricmpn(str, keyModifiers[i].name, modLen) && str[modLen] == '+' ) {
+			modifiers |= keyModifiers[i].id;
+			str += modLen+1;
+			i = -1; // Reset loop
+		}
+	}
+	return modifiers;
+}
+
+/*
+===================
+Key_SkipModifiers
+===================
+*/
+const char *Key_SkipModifiers( const char *str ) {
+	int i = 0;
+	int strLen = strlen( str );
+	int modLen;
+
+	for ( i = 0; i < keyModifiersAmount; i++ ) {
+		modLen = strlen( keyModifiers[i].name );
+		if ( strLen < modLen+1 ) continue;
+		if ( !Q_stricmpn(str, keyModifiers[i].name, modLen) && str[modLen] == '+' ) {
+			str += modLen+1;
+			i = -1; // Reset loop
+		}
+	}
+	return str;
+}
+
+/*
+===================
+Key_ModifiersStringFromModifiers
+===================
+*/
+char *Key_ModifiersStringFromModifiers( int modifiers ) {
+	static char modifiersStr[128]; // All current modifier strings above, sepearated by '+' are 66 chars in length.
+	int i;
+
+	modifiersStr[0] = 0;
+	for ( i = 0; i < keyModifiersAmount; i++ ) {
+		if ( modifiers & keyModifiers[i].id ) {
+			Q_strcat( modifiersStr, sizeof(modifiersStr), keyModifiers[i].name );
+			Q_strcat( modifiersStr, sizeof(modifiersStr), "+" );
+		}
+	}
+	return modifiersStr;
+}
+
+/*
+===================
 Key_SetBinding
 ===================
 */
-void Key_SetBinding( int keynum, const char *binding ) {
+void Key_SetBinding( int keynum, int modifiers, const char *binding ) {
 	if ( keynum < 0 || keynum >= MAX_KEYS )
 		return;
 
 	// free old bindings
-	if ( kg.keys[keynames[keynum].upper].binding ) {
-		Z_Free( kg.keys[keynames[keynum].upper].binding );
-		kg.keys[keynames[keynum].upper].binding = NULL;
+	if ( kg.keys[keynames[keynum].upper].binding[modifiers] ) {
+		Z_Free( kg.keys[keynames[keynum].upper].binding[modifiers] );
+		kg.keys[keynames[keynum].upper].binding[modifiers] = NULL;
 	}
 
 	// allocate memory for new binding
 	if ( binding )
-		kg.keys[keynames[keynum].upper].binding = CopyString( binding );
+		kg.keys[keynames[keynum].upper].binding[modifiers] = CopyString( binding );
 
 	// consider this like modifying an archived cvar, so the
 	// file write will be triggered at the next oportunity
@@ -1010,11 +1098,11 @@ void Key_SetBinding( int keynum, const char *binding ) {
 Key_GetBinding
 ===================
 */
-char *Key_GetBinding( int keynum ) {
+char *Key_GetBinding( int keynum, int modifiers ) {
 	if ( keynum < 0 || keynum >= MAX_KEYS )
 		return "";
 
-	return kg.keys[keynum].binding;
+	return kg.keys[keynum].binding[modifiers];
 }
 
 /*
@@ -1022,10 +1110,10 @@ char *Key_GetBinding( int keynum ) {
 Key_GetKey
 ===================
 */
-int Key_GetKey( const char *binding ) {
+int Key_GetKey( const char *binding, int modifiers ) {
 	if ( binding ) {
 		for ( int i=0; i<MAX_KEYS; i++ ) {
-			if ( kg.keys[i].binding && !Q_stricmp( binding, kg.keys[i].binding ) )
+			if ( kg.keys[i].binding[modifiers] && !Q_stricmp( binding, kg.keys[i].binding[modifiers] ) )
 				return i;
 		}
 	}
@@ -1050,7 +1138,9 @@ void Key_Unbind_f( void ) {
 		return;
 	}
 
-	Key_SetBinding( b, "" );
+	int modifiers = Key_ModifiersFromString( Cmd_Argv(1) );
+
+	Key_SetBinding( b, modifiers, "" );
 }
 
 /*
@@ -1059,9 +1149,11 @@ Key_Unbindall_f
 ===================
 */
 void Key_Unbindall_f( void ) {
-	for ( int i=0; i<MAX_KEYS; i++ ) {
-		if ( kg.keys[i].binding )
-			Key_SetBinding( i, "" );
+	for ( int j=0; j<KEYMOD_COMBINATIONS; j++ ) {
+		for ( int i=0; i<MAX_KEYS; i++ ) {
+			if ( kg.keys[i].binding[j] )
+				Key_SetBinding( i, j, "" );
+		}
 	}
 }
 
@@ -1084,15 +1176,17 @@ void Key_Bind_f( void ) {
 		return;
 	}
 
+	int modifiers = Key_ModifiersFromString( Cmd_Argv(1) );
+
 	if ( c == 2 ) {
-		if ( kg.keys[b].binding && kg.keys[b].binding[0] )
-			Com_Printf( S_COLOR_GREY "Bind " S_COLOR_WHITE "%s = " S_COLOR_GREY "\"" S_COLOR_WHITE "%s" S_COLOR_GREY "\"" S_COLOR_WHITE "\n", Key_KeynumToString( b ), kg.keys[b].binding );
+		if ( kg.keys[b].binding[modifiers] && kg.keys[b].binding[modifiers][0] )
+			Com_Printf( S_COLOR_GREY "Bind " S_COLOR_WHITE "%s%s = " S_COLOR_GREY "\"" S_COLOR_WHITE "%s" S_COLOR_GREY "\"" S_COLOR_WHITE "\n", Key_ModifiersStringFromModifiers( modifiers ), Key_KeynumToString( b ), kg.keys[b].binding[modifiers] );
 		else
-			Com_Printf( "\"%s\" is not bound\n", Key_KeynumToString( b ) );
+			Com_Printf( "\"%s%s\" is not bound\n", Key_ModifiersStringFromModifiers( modifiers ), Key_KeynumToString( b ) );
 		return;
 	}
 
-	Key_SetBinding( b, Cmd_ArgsFrom( 2 ) );
+	Key_SetBinding( b, modifiers, Cmd_ArgsFrom( 2 ) );
 }
 
 /*
@@ -1104,15 +1198,17 @@ Writes lines containing "bind key value"
 */
 void Key_WriteBindings( fileHandle_t f ) {
 	FS_Printf( f, "unbindall\n" );
-	for ( size_t i=0; i<MAX_KEYS; i++ ) {
-		if ( kg.keys[i].binding && kg.keys[i].binding[0] ) {
-			const char *name = Key_KeynumToString( i );
+	for ( int j = 0; j<KEYMOD_COMBINATIONS; j++ ) {
+		for ( size_t i=0; i<MAX_KEYS; i++ ) {
+			if ( kg.keys[i].binding[j] && kg.keys[i].binding[j][0] ) {
+				const char *name = Key_KeynumToString( i );
 
-			// handle the escape character nicely
-			if ( !strcmp( name, "\\" ) )
-				FS_Printf( f, "bind \"\\\" \"%s\"\n", kg.keys[i].binding );
-			else
-				FS_Printf( f, "bind \"%s\" \"%s\"\n", name, kg.keys[i].binding );
+				// handle the escape character nicely
+				if ( !strcmp( name, "\\" ) )
+					FS_Printf( f, "bind \"%s\\\" \"%s\"\n", Key_ModifiersStringFromModifiers(j), kg.keys[i].binding[j] );
+				else
+					FS_Printf( f, "bind \"%s%s\" \"%s\"\n", Key_ModifiersStringFromModifiers(j), name, kg.keys[i].binding[j] );
+			}
 		}
 	}
 }
@@ -1124,21 +1220,72 @@ Key_Bindlist_f
 ============
 */
 void Key_Bindlist_f( void ) {
-	for ( size_t i=0; i<MAX_KEYS; i++ ) {
-		if ( kg.keys[i].binding && kg.keys[i].binding[0] )
-			Com_Printf( S_COLOR_GREY "Key " S_COLOR_WHITE "%s (%s) = " S_COLOR_GREY "\"" S_COLOR_WHITE "%s" S_COLOR_GREY "\"" S_COLOR_WHITE "\n", Key_KeynumToAscii( i ), Key_KeynumToString( i ), kg.keys[i].binding );
+	for ( int j=0; j<KEYMOD_COMBINATIONS; j++) {
+		for ( size_t i=0; i<MAX_KEYS; i++ ) {
+			if ( kg.keys[i].binding[j] && kg.keys[i].binding[j][0] )
+				Com_Printf( S_COLOR_GREY "Key " S_COLOR_WHITE "%s%s (%s%s) = " S_COLOR_GREY "\"" S_COLOR_WHITE "%s" S_COLOR_GREY "\"" S_COLOR_WHITE "\n", Key_ModifiersStringFromModifiers( j ), Key_KeynumToAscii( i ), Key_ModifiersStringFromModifiers( j ), Key_KeynumToString( i ), kg.keys[i].binding[j] );
+		}
 	}
 }
 
 /*
 ============
-Key_KeynameCompletion
+Key_Completion
 ============
 */
-void Key_KeynameCompletion( callbackFunc_t callback ) {
-	for ( size_t i=0; i<numKeynames; i++ ) {
-		if ( keynames[i].name )
-			callback( keynames[i].name );
+void Key_Completion( callbackFunc_t callback, const char *input ) {
+	char suggestion[MAX_STRING_CHARS];
+	int modifiers = Key_ModifiersFromString( input );
+	const char *skipped = Key_SkipModifiers( input );
+
+	const char *lastModifierMatch = NULL;
+	int modifierMatches = 0;
+	int keyMatches = 0;
+
+	int mod;
+	size_t key;
+
+	if ( skipped-input < 0 ) {
+		Com_Printf( "Key_Completion: invalid skip\n" );
+		return;
+	} else if ( (size_t)(skipped-input) >= sizeof(suggestion) ) {
+		Com_Printf( "Key_Completion: input too long\n" );
+		return;
+	} else {
+		if ( skipped-input <= 0 ) suggestion[0] = 0;
+		else {
+			Q_strncpyz( suggestion, input, skipped-input );
+			Q_strcat( suggestion, sizeof(suggestion), "+" );
+		}
+	}
+
+	for ( mod = 0; mod < keyModifiersAmount; mod++ ) {
+		if ( keyModifiers[mod].name && !Q_stricmpn(keyModifiers[mod].name, skipped, strlen(skipped)) ) {
+			modifierMatches++;
+			lastModifierMatch = keyModifiers[mod].name;
+		}
+	}
+	for ( key = 0; key < numKeynames; key++ ) {
+		if ( keynames[key].name && !Q_stricmpn(keynames[key].name, skipped, strlen(skipped)) ) {
+			keyMatches++;
+		}
+	}
+
+	if ( modifierMatches == 1 && keyMatches == 0 )
+	{ // We want to complete the modifier and suggest all keys with that modifier
+		Q_strcat( suggestion, sizeof(suggestion), lastModifierMatch );
+		Q_strcat( suggestion, sizeof(suggestion), "+" );
+	}
+
+	for ( mod = 0; mod < keyModifiersAmount; mod++ ) {
+		if ( keyModifiers[mod].name && !(modifiers & keyModifiers[mod].id) ) {
+			callback( va("%s%s+", suggestion, keyModifiers[mod].name) );
+		}
+	}
+	for ( key = 0; key < numKeynames; key++ ) {
+		if ( keynames[key].name ) {
+			callback( va("%s%s", suggestion, keynames[key].name) );
+		}
 	}
 }
 
@@ -1193,6 +1340,11 @@ void CL_InitKeyCommands( void ) {
 	Cmd_SetCommandCompletionFunc( "unbind", Key_CompleteUnbind );
 	Cmd_AddCommand( "unbindall", Key_Unbindall_f, "Delete all key bindings" );
 	Cmd_AddCommand( "bindlist", Key_Bindlist_f, "Show all bindings in the console" );
+
+	// Register cvars (the default values should have legacy configs play the same way without behavior changes)
+	cl_keyModifiersOnlyIfUnbound = Cvar_Get( "cl_keyModifiersOnlyIfUnbound", "1", CVAR_ARCHIVE_ND, "If set modifiers (like LCTRL, LALT, LSHIFT, LSUPER, RCTRL, RALT, RSHIFT, RSUPER, CAPSLOCK, NUMLOCK) are only usable when the associated key is unbound (CTRL, ALT, SHIFT, CAPSLOCK, KP_NUMLOCK)." );
+	cl_keyModifiersFallbackToDefault = Cvar_Get( "cl_keyModifiersFallbackToDefault", "1", CVAR_ARCHIVE_ND, "If a key is not bound on a modifier layer, fallback to the bind without a modifier." );
+	cl_keyModifiersEnableLocks = Cvar_Get( "cl_keyModifiersEnableLocks", "1", CVAR_ARCHIVE_ND, "If enabled the CAPSLOCK and NUMLOCK keys switch to another keyboard layer." );
 }
 
 /*
@@ -1221,16 +1373,21 @@ CL_ParseBinding
 Execute the commands in the bind string
 ===================
 */
-void CL_ParseBinding( int key, qboolean down, unsigned time )
+void CL_ParseBinding( int key, int modifiers, qboolean down, unsigned time )
 {
 	char buf[ MAX_STRING_CHARS ], *p = buf, *end;
 	qboolean allCommands, allowUpCmds;
 
 	if( cls.state == CA_DISCONNECTED && Key_GetCatcher( ) == 0 )
 		return;
-	if( !kg.keys[keynames[key].upper].binding || !kg.keys[keynames[key].upper].binding[0] )
-		return;
-	Q_strncpyz( buf, kg.keys[keynames[key].upper].binding, sizeof( buf ) );
+	if( !kg.keys[keynames[key].upper].binding[modifiers] || !kg.keys[keynames[key].upper].binding[modifiers][0] ) {
+		if ( !modifiers || !cl_keyModifiersFallbackToDefault->integer ) return;
+		else modifiers = 0;
+
+		if( !kg.keys[keynames[key].upper].binding[modifiers] || !kg.keys[keynames[key].upper].binding[modifiers][0] )
+			return;
+	}
+	Q_strncpyz( buf, kg.keys[keynames[key].upper].binding[modifiers], sizeof( buf ) );
 
 	// run all bind commands if console, ui, etc aren't reading keys
 	allCommands = (qboolean)( Key_GetCatcher( ) == 0 );
@@ -1304,6 +1461,7 @@ void CL_KeyDownEvent( int key, unsigned time )
 	kg.keys[keynames[key].upper].down = qtrue;
 	kg.keys[keynames[key].upper].repeats++;
 	if( kg.keys[keynames[key].upper].repeats == 1 ) {
+		kg.keys[keynames[key].upper].downModifiers = kg.modifiers;
 		kg.keyDownCount++;
 		kg.anykeydown = qtrue;
 	}
@@ -1366,7 +1524,7 @@ void CL_KeyDownEvent( int key, unsigned time )
 	}
 
 	// send the bound action
-	if ( !cls.cursorActive ) CL_ParseBinding( key, qtrue, time );
+	if ( !cls.cursorActive ) CL_ParseBinding( key, kg.keys[keynames[key].upper].downModifiers, qtrue, time );
 
 	// distribute the key down event to the appropriate handler
 	// console
@@ -1402,8 +1560,10 @@ Called by CL_KeyEvent to handle a keyrelease
 */
 void CL_KeyUpEvent( int key, unsigned time )
 {
+	int modifiers = kg.keys[keynames[key].upper].downModifiers;
 	kg.keys[keynames[key].upper].repeats = 0;
 	kg.keys[keynames[key].upper].down = qfalse;
+	kg.keys[keynames[key].upper].downModifiers = 0;
 	kg.keyDownCount--;
 
 	if (kg.keyDownCount <= 0) {
@@ -1421,7 +1581,7 @@ void CL_KeyUpEvent( int key, unsigned time )
 	// console mode and menu mode, to keep the character from continuing
 	// an action started before a mode switch.
 	//
-	CL_ParseBinding( key, qfalse, time );
+	CL_ParseBinding( key, modifiers, qfalse, time );
 
 	if ( Key_GetCatcher( ) & KEYCATCH_UI && cls.uiStarted )
 		UIVM_KeyEvent( key, qfalse );
@@ -1465,6 +1625,43 @@ void CL_CharEvent( int key ) {
 
 /*
 ===================
+CL_ModifierEvent
+===================
+*/
+void CL_ModifierEvent( int modifiers ) {
+	kg.modifiers = modifiers;
+
+	if ( cl_keyModifiersOnlyIfUnbound->integer ) {
+		if ( kg.keys[A_SHIFT].binding[0] && kg.keys[A_SHIFT].binding[0][0] ) {
+			kg.modifiers &= ~KEYMOD_LSHIFT;
+			kg.modifiers &= ~KEYMOD_RSHIFT;
+		}
+		if ( kg.keys[A_CTRL].binding[0] && kg.keys[A_CTRL].binding[0][0] ) {
+			kg.modifiers &= ~KEYMOD_LCTRL;
+			kg.modifiers &= ~KEYMOD_RCTRL;
+		}
+		if ( kg.keys[A_ALT].binding[0] && kg.keys[A_ALT].binding[0][0] ) {
+			kg.modifiers &= ~KEYMOD_LALT;
+			kg.modifiers &= ~KEYMOD_RALT;
+		}
+		if ( cl_keyModifiersOnlyIfUnbound->integer != 2 ) {
+			// Special case: the lock modifiers are not held down, they are toggled. So we might want to bind something to the toggle.
+			if ( kg.keys[A_CAPSLOCK].binding[0] && kg.keys[A_CAPSLOCK].binding[0][0] ) {
+				kg.modifiers &= ~KEYMOD_CAPSLOCK;
+			}
+			if ( kg.keys[A_NUMLOCK].binding[0] && kg.keys[A_NUMLOCK].binding[0][0] ) {
+				kg.modifiers &= ~KEYMOD_NUMLOCK;
+			}
+		}
+	}
+	if ( !cl_keyModifiersEnableLocks->integer ) {
+		kg.modifiers &= ~KEYMOD_CAPSLOCK;
+		kg.modifiers &= ~KEYMOD_NUMLOCK;
+	}
+}
+
+/*
+===================
 Key_ClearStates
 ===================
 */
@@ -1476,6 +1673,7 @@ void Key_ClearStates( void ) {
 			CL_KeyEvent( i, qfalse, 0 );
 		kg.keys[i].down = qfalse;
 		kg.keys[i].repeats = 0;
+		kg.keys[i].downModifiers = 0;
 	}
 }
 

--- a/codemp/client/cl_uiapi.cpp
+++ b/codemp/client/cl_uiapi.cpp
@@ -198,7 +198,7 @@ static int GetConfigString(int index, char *buf, int size)
 static void Key_GetBindingBuf( int keynum, char *buf, int buflen ) {
 	char	*value;
 
-	value = Key_GetBinding( keynum );
+	value = Key_GetBinding( keynum, 0 );
 	if ( value ) {
 		Q_strncpyz( buf, value, buflen );
 	}
@@ -713,6 +713,10 @@ static qboolean CL_G2API_AttachG2Model( void *ghoul2From, int modelIndexFrom, vo
 	return re->G2API_AttachG2Model(*g2From, modelIndexFrom, *g2To, toBoltIndex, toModel);
 }
 
+static void CL_Key_SetBinding( int keynum, const char *binding ) {
+	Key_SetBinding( keynum, 0, binding );
+}
+
 static void CL_Key_SetCatcher( int catcher ) {
 	// Don't allow the ui module to close the console
 	Key_SetCatcher( catcher | ( Key_GetCatcher( ) & KEYCATCH_CONSOLE ) );
@@ -939,7 +943,7 @@ intptr_t CL_UISystemCalls( intptr_t *args ) {
 		return 0;
 
 	case UI_KEY_SETBINDING:
-		Key_SetBinding( args[1], (const char *)VMA(2) );
+		Key_SetBinding( args[1], 0, (const char *)VMA(2) );
 		return 0;
 
 	case UI_KEY_ISDOWN:
@@ -1316,7 +1320,7 @@ void CL_BindUI( void ) {
 		uii.Key_GetBindingBuf					= Key_GetBindingBuf;
 		uii.Key_IsDown							= Key_IsDown;
 		uii.Key_KeynumToStringBuf				= Key_KeynumToStringBuf;
-		uii.Key_SetBinding						= Key_SetBinding;
+		uii.Key_SetBinding						= CL_Key_SetBinding;
 		uii.Key_GetCatcher						= Key_GetCatcher;
 		uii.Key_GetOverstrikeMode				= Key_GetOverstrikeMode;
 		uii.Key_SetCatcher						= CL_Key_SetCatcher;

--- a/codemp/client/keys.h
+++ b/codemp/client/keys.h
@@ -27,14 +27,16 @@ along with this program; if not, see <http://www.gnu.org/licenses/>.
 
 typedef struct qkey_s {
 	qboolean	down;
+	int			downModifiers;
 	int			repeats; // if > 1, it is autorepeating
-	char		*binding;
+	char		*binding[KEYMOD_COMBINATIONS];
 } qkey_t;
 
 typedef struct keyGlobals_s {
 	qboolean	anykeydown;
 	qboolean	key_overstrikeMode;
 	int			keyDownCount;
+	int			modifiers;
 
 	qkey_t		keys[MAX_KEYS];
 } keyGlobals_t;
@@ -65,11 +67,14 @@ void	Field_CharEvent		( field_t *edit, int ch );
 void	Field_Draw			( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape );
 void	Field_BigDraw		( field_t *edit, int x, int y, qboolean showCursor, qboolean noColorEscape );
 
-void		Key_SetBinding			( int keynum, const char *binding );
-char *		Key_GetBinding			( int keynum );
+int 		Key_ModifiersFromString ( const char *str );
+const char *Key_SkipModifiers		( const char *str );
+char *		Key_ModifiersStringFromModifiers( int modifiers );
+void		Key_SetBinding			( int keynum, int modifiers, const char *binding );
+char *		Key_GetBinding			( int keynum, int modifiers );
 qboolean	Key_IsDown				( int keynum );
-int			Key_StringToKeynum		( char *str );
+int			Key_StringToKeynum		( const char *str );
 qboolean	Key_GetOverstrikeMode	( void );
 void		Key_SetOverstrikeMode	( qboolean state );
 void		Key_ClearStates			( void );
-int			Key_GetKey				( const char *binding );
+int			Key_GetKey				( const char *binding, int modifiers );

--- a/codemp/null/null_client.cpp
+++ b/codemp/null/null_client.cpp
@@ -60,6 +60,9 @@ qboolean CL_GameCommand( void ) {
 void CL_KeyEvent (int key, qboolean down, unsigned time) {
 }
 
+void CL_ModifierEvent( int modifiers ) {
+}
+
 qboolean UI_GameCommand( void ) {
 	return qfalse;
 }

--- a/codemp/qcommon/common.cpp
+++ b/codemp/qcommon/common.cpp
@@ -952,6 +952,9 @@ int Com_EventLoop( void ) {
 			}
 			Cbuf_AddText( "\n" );
 			break;
+		case SE_MODIFIER:
+			CL_ModifierEvent( ev.evValue );
+			break;
 		}
 
 		// free any block data
@@ -1905,10 +1908,10 @@ void Field_CompleteKeyname( void )
 	matchCount = 0;
 	shortestMatch[ 0 ] = 0;
 
-	Key_KeynameCompletion( FindMatches );
+	Key_Completion( FindMatches, completionString );
 
 	if( !Field_Complete( ) )
-		Key_KeynameCompletion( PrintKeyMatches );
+		Key_Completion( PrintKeyMatches, completionString );
 }
 #endif
 

--- a/codemp/qcommon/qcommon.h
+++ b/codemp/qcommon/qcommon.h
@@ -928,6 +928,7 @@ void CL_Shutdown( void );
 void CL_Frame( int msec );
 qboolean CL_GameCommand( void );
 void CL_KeyEvent (int key, qboolean down, unsigned time);
+void CL_ModifierEvent( int modifiers );
 
 void CL_CharEvent( int key );
 // char events are for field typing, not game control
@@ -963,7 +964,7 @@ void CL_StartHunkUsers( void );
 qboolean CL_ConnectedToRemoteServer( void );
 // returns qtrue if connected to a server
 
-void Key_KeynameCompletion ( void(*callback)( const char *s ) );
+void Key_Completion( void(*callback)( const char *s ), const char *input );
 // for keyname autocompletion
 
 void Key_WriteBindings( fileHandle_t f );

--- a/codemp/ui/keycodes.h
+++ b/codemp/ui/keycodes.h
@@ -365,3 +365,16 @@ typedef enum
 // to avoid duplicating the paths, the char events are just
 // distinguished by or'ing in K_CHAR_FLAG (ugly)
 #define	K_CHAR_FLAG		1024
+
+// Supported modifiers
+#define KEYMOD_LSHIFT       (1)
+#define KEYMOD_RSHIFT       (1 << 1)
+#define KEYMOD_LCTRL        (1 << 2)
+#define KEYMOD_RCTRL        (1 << 3)
+#define KEYMOD_LALT         (1 << 4)
+#define KEYMOD_RALT         (1 << 5)
+#define KEYMOD_LSUPER       (1 << 6)
+#define KEYMOD_RSUPER       (1 << 7)
+#define KEYMOD_NUMLOCK      (1 << 8)
+#define KEYMOD_CAPSLOCK     (1 << 9)
+#define KEYMOD_COMBINATIONS ((1 << 10)-1) // NOTE: This must be the last entry

--- a/shared/sys/sys_event.cpp
+++ b/shared/sys/sys_event.cpp
@@ -49,7 +49,8 @@ static const char *Sys_EventName( sysEventType_t evType ) {
 		"SE_CHAR",
 		"SE_MOUSE",
 		"SE_JOYSTICK_AXIS",
-		"SE_CONSOLE"
+		"SE_CONSOLE",
+		"SE_MODIFIER",
 	};
 
 	if ( evType >= SE_MAX ) {

--- a/shared/sys/sys_public.h
+++ b/shared/sys/sys_public.h
@@ -70,6 +70,7 @@ typedef enum {
 	SE_MOUSE,	// evValue and evValue2 are reletive signed x / y moves
 	SE_JOYSTICK_AXIS,	// evValue is an axis number and evValue2 is the current state (-127 to 127)
 	SE_CONSOLE,	// evPtr is a char*
+	SE_MODIFIER, // evValue is the current key modifier
 	SE_MAX
 } sysEventType_t;
 


### PR DESCRIPTION
# Introduce modifiers for key binds:
 - RSHIFT, LCTRL, RCTRL, LALT, RALT, LSUPER and RSUPER are usable 
 - CAPSLOCK and NUMLOCK are toggleable modifiers
 - modifiers can be combined (for example: LCTRL+LALT+LSHIFT)
 - the bind completion supports modifiers
 - SP only: the menu supports modifiers
 - cvars:
   - cl_keyModifiersOnlyIfUnbound (default: 1): if a modifier button is bound to another action, for example SHIFT as +speed, the corresponding modifier is not applied (for example if SHIFT is bound the LSHIFT and RSHIFT modifiers are not usable)
   - cl_keyModifiersFallbackToDefault (default: 1) if a button is not bound for the current modifiers the default bind for the button is used
   - cl_keyModifiersEnableLocks (default: 1) allow the use of the CAPSLOCK and NUMLOCK modifiers
   - cl_keyModifiersPassToUI (default: 0; SP only): pass modifiers along to the menu; when enabled combinations like LCTRL+1 can be bound in the menu, but the buttons can't be bound directly anymore (CTRL, SHIFT ALT, CAPSLOCK, KP_NUMLOCK)

The defaults for the cvars were chosen to work with existing configs:
 - as modifiers are only applied when not bound (cl_keyModifiersOnlyIfUnbound 1) the default binds of the game should work
 - as keys without a bind for the current modifier fallback to the default bind (cl_keyModifiersFallbackToDefault 1) any accidently activated modifiers (NUMLOCK, CAPSLOCK, holding a modifier button, ...) should not interfere with regular binds and cl_keyModifiersEnableLocks can default to 1
 - as modifiers are not passed to the menu (cl_keyModifiersPassToUI 0) the regular CTRL, ALT, SHIFT, CAPSLOCK and KP_NUMLOCK keys can be bound via the menu

As menu support for the modifiers requires API changes and as the MP modules currently don't support an extensible API the modifiers are only supported via the console in MP. The menus can only access the default binds.