### PR TITLE
rend2 - fixed out-of-bounds crash with weather

### DIFF
--- a/codemp/rd-rend2/tr_weather.cpp
+++ b/codemp/rd-rend2/tr_weather.cpp
@@ -1141,8 +1141,8 @@ void RB_SurfaceWeather( srfWeather_t *surf )
 		{
 			for (int x = -1; x <= 1; ++x, ++currentIndex)
 			{
-				chunkIndex  = (int(centerZoneOffsetX + numMinZonesX) + x + 1) % 3;
-				chunkIndex += (int(centerZoneOffsetY + numMinZonesY) + y + 1) % 3 * 3;
+				chunkIndex  = ((int(centerZoneOffsetX + numMinZonesX) + x + 1) % 3 + 3) % 3;
+				chunkIndex += (((int(centerZoneOffsetY + numMinZonesY) + y + 1) % 3 + 3) % 3) * 3;
 				VectorSet2(
 					zoneOffsets[chunkIndex],
 					x,


### PR DESCRIPTION
See issue https://github.com/JACoders/OpenJK/issues/1189

The game will crash, if a map features weather (e.g. vjun1) and you noclip far enough beneath the map.

This was caused by an out-of-bounds exception caused by chunkIndex sometimes being negative.

The code change ensures the result is always in the range [0, 2] for each axis. This makes sure chunkIndex is always in [0, 8], which is safe for zoneOffsets[9].