### PR TITLE
Reorder init to match MP startup

### DIFF
--- a/code/qcommon/common.cpp
+++ b/code/qcommon/common.cpp
@@ -1094,11 +1094,11 @@ void Com_Init( char *commandLine ) {
 		//Swap_Init ();
 		Cbuf_Init ();
 
-		Com_InitZoneMemoryVars();
-		Cmd_Init ();
-
 		// override anything from the config files with command line args
 		Com_StartupVariable( NULL );
+
+		Com_InitZoneMemoryVars();
+		Cmd_Init ();
 
 		// done early so bind command exists
 		CL_InitKeyCommands();
@@ -1196,6 +1196,7 @@ void Com_Init( char *commandLine ) {
 				Cbuf_AddText ("cinematic openinglogos\n");
 			}
 		}
+		CL_StartHunkUsers();
 		com_fullyInitialized = qtrue;
 		Com_Printf ("--- Common Initialization Complete ---\n");
 


### PR DESCRIPTION
Reorders SP startup init calls to match the order of the MP binary. Fixes the audio distortion during the LucasArts intro video.

Fixes #897