### PR TITLE
Fix missing defaults for `fx_rain` and broken weather zone creation

### DIFF
--- a/code/game/g_fx.cpp
+++ b/code/game/g_fx.cpp
@@ -563,6 +563,12 @@ void SP_CreateRain( gentity_t *ent )
 		G_EffectIndex( "world/acid_fizz" );
 		G_FindConfigstringIndex("acidrain", CS_WORLD_FX, MAX_WORLD_FX, qtrue);
 	}
+	else
+	{
+		G_FindConfigstringIndex("lightrain", CS_WORLD_FX, MAX_WORLD_FX, qtrue);
+		G_FindConfigstringIndex("wind", CS_WORLD_FX, MAX_WORLD_FX, qtrue);
+		return;
+	}
 
 
 	// OUTSIDE SHAKE

--- a/code/game/g_fx.cpp
+++ b/code/game/g_fx.cpp
@@ -567,7 +567,6 @@ void SP_CreateRain( gentity_t *ent )
 	{
 		G_FindConfigstringIndex("lightrain", CS_WORLD_FX, MAX_WORLD_FX, qtrue);
 		G_FindConfigstringIndex("wind", CS_WORLD_FX, MAX_WORLD_FX, qtrue);
-		return;
 	}
 
 

--- a/code/rd-vanilla/tr_WorldEffects.cpp
+++ b/code/rd-vanilla/tr_WorldEffects.cpp
@@ -697,6 +697,14 @@ public:
 			return;
 		}
 
+		// Record The Extents Of The World Incase No Other Weather Zones Exist
+		//---------------------------------------------------------------------
+		if (!mWeatherZones.size())
+		{
+			Com_Printf("WARNING: No Weather Zones Encountered\n");
+			AddWeatherZone(tr.world->bmodels[0].bounds[0], tr.world->bmodels[0].bounds[1]);
+		}
+
 		// all this piece of code does really is fill in the bool "SWeatherZone::mMarkedOutside", plus the mPointCache[] for each zone,
 		//	so we can diskload those. Maybe.
 		fileHandle_t f = ReadCachedWeatherFile();
@@ -719,15 +727,6 @@ public:
 			bool		curPosOutside;
 			uint32_t		contents;
 			uint32_t		bit;
-
-
-			// Record The Extents Of The World Incase No Other Weather Zones Exist
-			//---------------------------------------------------------------------
-			if (!mWeatherZones.size())
-			{
-				Com_Printf("WARNING: No Weather Zones Encountered\n");
-				AddWeatherZone(tr.world->bmodels[0].bounds[0], tr.world->bmodels[0].bounds[1]);
-			}
 
 			f = WriteCachedWeatherFile();
 

--- a/codeJK2/game/g_fx.cpp
+++ b/codeJK2/game/g_fx.cpp
@@ -287,6 +287,7 @@ void SP_CreateSnow( gentity_t *ent )
 		sprintf( temp, "snow init %i", (int)( ent->count * r_weatherScale->value ));
 
 		G_FindConfigstringIndex( temp, CS_WORLD_FX, MAX_WORLD_FX, qtrue );
+		G_FindConfigstringIndex( "wind", CS_WORLD_FX, MAX_WORLD_FX, qtrue );
 
 		level.worldFlags |= WF_SNOWING;
 	}
@@ -311,6 +312,7 @@ void SP_CreateRain( gentity_t *ent )
 		sprintf( temp, "rain init %i", (int)( ent->count * r_weatherScale->value ));
 
 		G_FindConfigstringIndex( temp, CS_WORLD_FX, MAX_WORLD_FX, qtrue );
+		G_FindConfigstringIndex( "wind", CS_WORLD_FX, MAX_WORLD_FX, qtrue );
 
 		level.worldFlags |= WF_RAINING;
 	}


### PR DESCRIPTION
`lightrain` and `wind` added to `fx_rain`  since it was missing defaults if it was created without any spawn flags (since the JO weather system doesn't use spawn flags). JO's rain system always has random wind, unlike JA's rain system. Enabling `wind` is close enough for this purpose.

JO code:
https://github.com/grayj/Jedi-Outcast/blob/master/code/game/g_fx.cpp#L276-L287
https://github.com/grayj/Jedi-Outcast/blob/master/code/renderer/tr_worldeffects.cpp#L1986-L2003

Auto generated weather zones were also not being created properly beyond first map load because of bad operation placement, resulting in weather effects clipping through geometry. Currently, if a cache file is found and `mWeatherZones` is empty (not all maps have pre-placed weather zones, for example JO's yavin4) then `mWeatherZones` will never be filled, and the point data from the cached file is useless. Weather zones should always be generated if `mWeatherZones` is empty (whether or not a cache file is found is irrelevant), as the cache file only contains point data, not weather zones themselves.

Fixes #1104