### PR TITLE
[MP] Fix memory leak when loading sub BSPs

### DIFF
--- a/codemp/qcommon/cm_load.cpp
+++ b/codemp/qcommon/cm_load.cpp
@@ -757,7 +757,12 @@ static void CM_LoadMap_Actual( const char *name, qboolean clientload, int *check
 	//	for the renderer to chew on... (but not if this gets ported to a big-endian machine, because some of the
 	//	map data will have been Little-Long'd, but some hasn't).
 	//
-	if (Sys_LowPhysicalMemory()
+	// For sub BSPs, always free immediately since caching only applies to main maps
+	if ( newBuff && newBuff != gpvCachedMapDiskImage )
+	{
+		Z_Free(newBuff);
+	}
+	else if (Sys_LowPhysicalMemory()
 		|| com_dedicated->integer
 //		|| we're on a big-endian machine
 		)


### PR DESCRIPTION
In `CM_LoadMap_Actual`, a temporary buffer is allocated via `Z_Malloc` to hold the raw BSP file data. For the main map, this buffer is cached in `gpvCachedMapDiskImage`. However, for sub BSPs, the buffer is allocated but never freed, leaking memory on every sub BSP load.

This fix frees the temporary buffer for sub BSPs after parsing while preserving the main map caching.

