### PR TITLE
[MP] Fix array bounds error in bot enemy scanning

### DIFF
--- a/codemp/game/ai_main.c
+++ b/codemp/game/ai_main.c
@@ -2195,7 +2195,7 @@ int ScanForEnemies(bot_state_t *bs)
 		}
 	}
 
-	while (i <= MAX_CLIENTS)
+	while (i < MAX_CLIENTS)
 	{
 		if (i != bs->client && g_entities[i].client && !OnSameTeam(&g_entities[bs->client], &g_entities[i]) && PassStandardEnemyChecks(bs, &g_entities[i]) && BotPVSCheck(g_entities[i].client->ps.origin, bs->eye) && PassLovedOneCheck(bs, &g_entities[i]))
 		{


### PR DESCRIPTION
## Summary
Fix an off-by-one array bounds error in the bot AI enemy scanning code.

## Problem
In `ScanForEnemies()` function in `ai_main.c`, the loop condition was:
```c
i = 0;
// ...
while (i <= MAX_CLIENTS)
{
    // accesses g_entities[i].client
    i++;
}
```

This allows `i` to reach `MAX_CLIENTS`, causing access to `g_entities[MAX_CLIENTS]` which is out of bounds. Valid client indices are 0 to MAX_CLIENTS-1.

## Solution
Change `while (i <= MAX_CLIENTS)` to `while (i < MAX_CLIENTS)`

## Impact
This could cause:
- Memory corruption when bots scan for enemies
- Server crashes
- Undefined behavior

## Testing
- Build completes successfully
- Logic unchanged for valid client indices (0 to MAX_CLIENTS-1)