### PR TITLE
[Rend] Fix null pointer dereferences in shader stage access

### DIFF
--- a/codemp/rd-rend2/tr_bsp.cpp
+++ b/codemp/rd-rend2/tr_bsp.cpp
@@ -3960,10 +3960,15 @@ static void R_GenerateSurfaceSprites(
 	// FIXME: Need a better way to handle this.
 	out->shader = R_CreateShaderFromTextureBundle(va("*ss_%08x\n", hash),
 			bundle, stage->stateBits);
+	if ( !out->shader ) {
+		return;
+	}
 	out->shader->spriteUbo = shader->spriteUbo;
 
 	out->shader->cullType = shader->cullType;
-	out->shader->stages[0]->glslShaderGroup = tr.spriteShader;
+	if ( out->shader->stages[0] ) {
+		out->shader->stages[0]->glslShaderGroup = tr.spriteShader;
+	}
 	out->alphaTestType = stage->alphaTestType;
 
 	out->numAttributes = 4;

--- a/codemp/rd-rend2/tr_surface.cpp
+++ b/codemp/rd-rend2/tr_surface.cpp
@@ -2200,6 +2200,8 @@ static void RB_SurfaceSprites( srfSprites_t *surf )
 
 	// TODO: Check which pass (z-prepass/shadow/forward) we're rendering for?
 	shader_t *shader = surf->shader;
+	if ( !shader || !shader->stages[0] )
+		return;
 	shaderStage_t *firstStage = shader->stages[0];
 	shaderProgram_t *programGroup = firstStage->glslShaderGroup;
 	const surfaceSprite_t *ss = surf->sprite;

--- a/codemp/rd-vanilla/tr_backend.cpp
+++ b/codemp/rd-vanilla/tr_backend.cpp
@@ -1418,6 +1418,9 @@ const void *RB_RotatePic ( const void *data )
 	cmd = (const rotatePicCommand_t *)data;
 
 	shader = cmd->shader;
+	if ( !shader || !shader->stages ) {
+		return (const void *)(cmd + 1);
+	}
 	image = &shader->stages[0].bundle[0].image[0];
 
 	if ( image ) {


### PR DESCRIPTION
## Summary
Add null checks before dereferencing shader and shader stage pointers to prevent crashes.

## Problem
Several rendering functions access shader stage data without validating that the shader or its stages exist:
- `shader->stages[0]` accessed without checking if `shader` is valid
- `shader->stages[0]->member` accessed without checking if `stages[0]` is non-null

This can cause crashes when:
- A shader fails to load
- A shader has no stages defined
- Corrupt or missing shader data

## Fixes

### rd-vanilla/tr_backend.cpp - RB_RotatePic()
```cpp
// Before: No check
image = &shader->stages[0].bundle[0].image[0];

// After: Check shader and stages
if ( !shader || !shader->stages ) {
    return (const void *)(cmd + 1);
}
```

### rd-rend2/tr_surface.cpp - RB_SurfaceSprites()
```cpp
// Before: No check
shaderStage_t *firstStage = shader->stages[0];

// After: Check shader and stages[0]
if ( !shader || !shader->stages[0] )
    return;
```

### rd-rend2/tr_bsp.cpp - Sprite shader creation
```cpp
// Before: No check after R_CreateShaderFromTextureBundle
out->shader->stages[0]->glslShaderGroup = tr.spriteShader;

// After: Check shader creation result and stages[0]
if ( !out->shader ) {
    return;
}
if ( out->shader->stages[0] ) {
    out->shader->stages[0]->glslShaderGroup = tr.spriteShader;
}
```

## Testing
- Build completes successfully for both rd-vanilla and rd-rend2
- No functional changes for valid shaders