### PR TITLE
[All] Fix integer overflow in ZIP file loading

### DIFF
--- a/code/qcommon/files.cpp
+++ b/code/qcommon/files.cpp
@@ -1895,6 +1895,15 @@ static pack_t *FS_LoadZipFile( const char *zipfile, const char *basename )
 		unzGoToNextFile(uf);
 	}
 
+	// Validate number_entry to prevent integer overflow in allocation calculations
+	// Use conservative limit that prevents overflow on both 32-bit and 64-bit systems
+	const size_t maxEntries = (SIZE_MAX - len) / sizeof( fileInPack_t );
+	if ( gi.number_entry == 0 || gi.number_entry > maxEntries ) {
+		Com_Printf( "FS_LoadZipFile: %s has invalid entry count\n", zipfile );
+		unzClose( uf );
+		return NULL;
+	}
+
 	buildBuffer = (struct fileInPack_s *)Z_Malloc( (gi.number_entry * sizeof( fileInPack_t )) + len, TAG_FILESYS, qtrue );
 	namePtr = ((char *) buildBuffer) + gi.number_entry * sizeof( fileInPack_t );
 	fs_headerLongs = (int *)Z_Malloc( gi.number_entry * sizeof(int), TAG_FILESYS, qtrue );

--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -2147,6 +2147,15 @@ static pack_t *FS_LoadZipFile( const char *zipfile, const char *basename )
 		unzGoToNextFile(uf);
 	}
 
+	// Validate number_entry to prevent integer overflow in allocation calculations
+	// Use conservative limit that prevents overflow on both 32-bit and 64-bit systems
+	const size_t maxEntries = (SIZE_MAX - len) / sizeof( fileInPack_t );
+	if ( gi.number_entry == 0 || gi.number_entry > maxEntries ) {
+		Com_Printf( "FS_LoadZipFile: %s has invalid entry count\n", zipfile );
+		unzClose( uf );
+		return NULL;
+	}
+
 	buildBuffer = (struct fileInPack_s *)Z_Malloc( (gi.number_entry * sizeof( fileInPack_t )) + len, TAG_FILESYS, qtrue );
 	namePtr = ((char *) buildBuffer) + gi.number_entry * sizeof( fileInPack_t );
 	fs_headerLongs = (int *)Z_Malloc( ( gi.number_entry + 1 ) * sizeof(int), TAG_FILESYS, qtrue );


### PR DESCRIPTION
## Summary
Add overflow validation in `FS_LoadZipFile` to prevent integer overflow when calculating allocation sizes from `gi.number_entry`.

## Problem
A maliciously crafted PK3 file could specify an extremely large `number_entry` value that, when multiplied by `sizeof(fileInPack_t)`, would overflow and result in a small allocation. Subsequent writes to this undersized buffer would cause heap corruption.

The vulnerable code was:
```cpp
buildBuffer = (struct fileInPack_s *)Z_Malloc( (gi.number_entry * sizeof( fileInPack_t )) + len, ...);
```

If `gi.number_entry` is crafted to cause overflow in the multiplication, a tiny buffer is allocated but then filled with data for the claimed number of entries.

## Solution
Add validation before performing any allocations:
- Reject ZIP files with zero entries
- Calculate the maximum safe number of entries that won't overflow: `(SIZE_MAX - len) / sizeof(fileInPack_t)`
- Reject ZIP files where `number_entry` exceeds this safe maximum

## Files Modified
- `code/qcommon/files.cpp` - Single player build
- `codemp/qcommon/files.cpp` - Multiplayer build

## Testing
- Build tested on macOS (arm64)
- Verified both SP and MP builds compile successfully