### PR TITLE
[All] Fix division by zero in vehicle speed calculations

### DIFF
--- a/code/game/AnimalNPC.cpp
+++ b/code/game/AnimalNPC.cpp
@@ -414,7 +414,10 @@ static void ProcessOrientCommands( Vehicle_t *pVeh )
 		{
 			s = -s;
 		}
-		angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+		{
+			angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		}
 		if (angDif > maxDif)
 		{
 			angDif = maxDif;
@@ -704,7 +707,14 @@ static void AnimateVehicle( Vehicle_t *pVeh )
 
 	// Percentage of maximum speed relative to current speed.
 	//float fSpeed = VectorLength( client->ps.velocity );
-	fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+	{
+		fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	}
+	else
+	{
+		fSpeedPercToMax = 0.0f;
+	}
 
 
 	// Going in reverse...
@@ -768,7 +778,14 @@ static void AnimateRiders( Vehicle_t *pVeh )
 	}
 
 	// Percentage of maximum speed relative to current speed.
-	fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+	{
+		fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	}
+	else
+	{
+		fSpeedPercToMax = 0.0f;
+	}
 
 /*	// Going in reverse...
 #ifdef _JK2MP //handled in pmove in mp

--- a/code/game/FighterNPC.cpp
+++ b/code/game/FighterNPC.cpp
@@ -1131,7 +1131,10 @@ void FighterYawAdjust(Vehicle_t *pVeh, playerState_t *riderPS, playerState_t *pa
 		{
 			s = -s;
 		}
-		angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+		{
+			angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		}
 		if (angDif > maxDif)
 		{
 			angDif = maxDif;
@@ -1157,7 +1160,10 @@ void FighterPitchAdjust(Vehicle_t *pVeh, playerState_t *riderPS, playerState_t *
 		{
 			s = -s;
 		}
-		angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+		{
+			angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		}
 		if (angDif > maxDif)
 		{
 			angDif = maxDif;

--- a/code/game/SpeederNPC.cpp
+++ b/code/game/SpeederNPC.cpp
@@ -583,7 +583,10 @@ void ProcessOrientCommands( Vehicle_t *pVeh )
 		{
 			s = -s;
 		}
-		angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+		{
+			angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		}
 		if (angDif > maxDif)
 		{
 			angDif = maxDif;

--- a/code/game/WalkerNPC.cpp
+++ b/code/game/WalkerNPC.cpp
@@ -407,7 +407,14 @@ static void AnimateVehicle( Vehicle_t *pVeh )
 
 	// Percentage of maximum speed relative to current speed.
 	//float fSpeed = VectorLength( client->ps.velocity );
-	fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+	{
+		fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	}
+	else
+	{
+		fSpeedPercToMax = 0.0f;
+	}
 
 	// If we're moving...
 	if ( fSpeedPercToMax > 0.0f ) //fSpeedPercToMax >= 0.85f )

--- a/codemp/game/AnimalNPC.c
+++ b/codemp/game/AnimalNPC.c
@@ -284,7 +284,10 @@ static void ProcessOrientCommands( Vehicle_t *pVeh )
 			{
 				s = -s;
 			}
-			angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+			if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+			{
+				angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+			}
 			if (angDif > maxDif)
 			{
 				angDif = maxDif;
@@ -443,7 +446,14 @@ static void AnimateVehicle( Vehicle_t *pVeh )
 
 	// Percentage of maximum speed relative to current speed.
 	//float fSpeed = VectorLength( client->ps.velocity );
-	fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+	{
+		fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	}
+	else
+	{
+		fSpeedPercToMax = 0.0f;
+	}
 
 
 	// Going in reverse...
@@ -500,7 +510,14 @@ static void AnimateRiders( Vehicle_t *pVeh )
 	}
 
 	// Percentage of maximum speed relative to current speed.
-	fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+	{
+		fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	}
+	else
+	{
+		fSpeedPercToMax = 0.0f;
+	}
 
 	// Going in reverse...
 	if (0)

--- a/codemp/game/FighterNPC.c
+++ b/codemp/game/FighterNPC.c
@@ -1206,7 +1206,10 @@ void FighterYawAdjust(Vehicle_t *pVeh, playerState_t *riderPS, playerState_t *pa
 		{
 			s = -s;
 		}
-		angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+		{
+			angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		}
 		if (angDif > maxDif)
 		{
 			angDif = maxDif;
@@ -1232,7 +1235,10 @@ void FighterPitchAdjust(Vehicle_t *pVeh, playerState_t *riderPS, playerState_t *
 		{
 			s = -s;
 		}
-		angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+		{
+			angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		}
 		if (angDif > maxDif)
 		{
 			angDif = maxDif;

--- a/codemp/game/SpeederNPC.c
+++ b/codemp/game/SpeederNPC.c
@@ -309,7 +309,10 @@ void ProcessOrientCommands( Vehicle_t *pVeh )
 		{
 			s = -s;
 		}
-		angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+		{
+			angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		}
 		if (angDif > maxDif)
 		{
 			angDif = maxDif;

--- a/codemp/game/WalkerNPC.c
+++ b/codemp/game/WalkerNPC.c
@@ -203,7 +203,10 @@ void WalkerYawAdjust(Vehicle_t *pVeh, playerState_t *riderPS, playerState_t *par
 		{
 			s = -s;
 		}
-		angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+		{
+			angDif *= s/pVeh->m_pVehicleInfo->speedMax;
+		}
 		if (angDif > maxDif)
 		{
 			angDif = maxDif;
@@ -360,7 +363,14 @@ static void AnimateVehicle( Vehicle_t *pVeh )
 
 	// Percentage of maximum speed relative to current speed.
 	//float fSpeed = VectorLength( client->ps.velocity );
-	fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	if (pVeh->m_pVehicleInfo->speedMax > 0.0f)
+	{
+		fSpeedPercToMax = parent->client->ps.speed / pVeh->m_pVehicleInfo->speedMax;
+	}
+	else
+	{
+		fSpeedPercToMax = 0.0f;
+	}
 
 	// If we're moving...
 	if ( fSpeedPercToMax > 0.0f ) //fSpeedPercToMax >= 0.85f )


### PR DESCRIPTION
## Summary
Add checks for `speedMax > 0.0f` before dividing by it in vehicle NPC code.

## Problem
A malformed or incomplete vehicle definition file could specify `speedMax` as 0 (or not specify it at all, leaving it at its default value of 0), causing a floating-point division by zero when:
- Calculating turn angle adjustments based on speed
- Calculating speed percentage for animation selection

While floating-point division by zero typically results in infinity rather than a crash, it leads to undefined/incorrect behavior in vehicle handling.

## Solution
Add a guard check `if (pVeh->m_pVehicleInfo->speedMax > 0.0f)` before each division. When speedMax is zero or negative:
- For turning calculations: `angDif` remains unchanged (no speed-based scaling)
- For animation selection: `fSpeedPercToMax` is set to 0.0f (treated as stationary)

## Files Modified

**Multiplayer (codemp/game/):**
- `AnimalNPC.c` - 3 locations
- `FighterNPC.c` - 2 locations
- `SpeederNPC.c` - 1 location
- `WalkerNPC.c` - 2 locations

**Single Player (code/game/):**
- `AnimalNPC.cpp` - 3 locations
- `FighterNPC.cpp` - 2 locations
- `SpeederNPC.cpp` - 1 location
- `WalkerNPC.cpp` - 1 location

## Testing
- Build tested on macOS (arm64)
- Verified both SP and MP builds compile successfully