### PR TITLE
[MP] Fix off-by-one error in MSG_ReadString bounds check

### DIFF
--- a/codemp/qcommon/msg.cpp
+++ b/codemp/qcommon/msg.cpp
@@ -512,17 +512,9 @@ char *MSG_ReadString( msg_t *msg ) {
 
 		string[l] = c;
 		l++;
-	} while (l <= sizeof(string)-1);
+	} while (l < sizeof(string)-1);
 
-	// some bonus protection, shouldn't occur cause server doesn't write such things
-	if (l <= sizeof(string)-1)
-	{
-		string[l] = 0;
-	}
-	else
-	{
-		string[sizeof(string)-1] = 0;
-	}
+	string[l] = 0;
 
 	return string;
 }


### PR DESCRIPTION
## Summary
Fix off-by-one error in `MSG_ReadString` loop bounds check and remove redundant protection code.

## Problem
The `MSG_ReadString` function used `while (l <= sizeof(string)-1)` as the loop condition, which is inconsistent with `MSG_ReadStringLine` (which uses `<`) and the SP version.

While the old code had "bonus protection" that prevented actual buffer overflow, the logic was unnecessarily complex and the `<=` condition could theoretically allow:
1. Writing to `string[sizeof(string)-1]` (the last valid index)
2. Incrementing `l` to `sizeof(string)`
3. Requiring special handling for null termination

## Solution
Changed the loop condition from `<=` to `<` to match:
- `MSG_ReadStringLine` in the same file
- `MSG_ReadString` in the SP codebase

This ensures `l` never exceeds `sizeof(string)-2` after the loop body, making the direct `string[l] = 0` null termination safe without additional bounds checking.

Also removed the now-unnecessary "bonus protection" code block.

## Files Modified
- `codemp/qcommon/msg.cpp`

## Testing
- Build tested on macOS (arm64)
- Verified MP build compiles successfully