### PR TITLE
[All] Harden FS_CheckDirTraversal against absolute paths

### DIFF
--- a/code/qcommon/files.cpp
+++ b/code/qcommon/files.cpp
@@ -2823,6 +2823,14 @@ qboolean FS_CheckDirTraversal(const char *checkdir)
 	if(strstr(checkdir, "../") || strstr(checkdir, "..\\"))
 		return qtrue;
 
+	// Check for absolute paths (Unix-style or Windows drive letters)
+	if(checkdir[0] == '/' || checkdir[0] == '\\')
+		return qtrue;
+
+	// Check for Windows drive letters (e.g., "C:")
+	if(checkdir[0] && checkdir[1] == ':')
+		return qtrue;
+
 	return qfalse;
 }
 

--- a/codemp/qcommon/files.cpp
+++ b/codemp/qcommon/files.cpp
@@ -3191,6 +3191,14 @@ qboolean FS_CheckDirTraversal(const char *checkdir)
 	if(strstr(checkdir, "../") || strstr(checkdir, "..\\"))
 		return qtrue;
 
+	// Check for absolute paths (Unix-style or Windows drive letters)
+	if(checkdir[0] == '/' || checkdir[0] == '\\')
+		return qtrue;
+
+	// Check for Windows drive letters (e.g., "C:")
+	if(checkdir[0] && checkdir[1] == ':')
+		return qtrue;
+
 	return qfalse;
 }
 


### PR DESCRIPTION
## Summary
Extend `FS_CheckDirTraversal` to also reject absolute paths, providing additional protection against directory traversal attacks.

## Problem
The existing `FS_CheckDirTraversal` function only checks for `../` and `..\` patterns. A malicious server could potentially provide absolute paths like:
- `/etc/passwd` (Unix)
- `C:\Windows\System32\...` (Windows)
- `\\network\share\...` (UNC paths)

While other parts of the filesystem code may prevent these from being exploited, defense in depth is important for security-critical validation functions.

## Solution
Extend the check to also reject:
- Paths starting with `/` or `\` (absolute Unix paths or UNC paths)
- Paths starting with a drive letter followed by `:` (Windows absolute paths like `C:`)

The existing check for `../` and `..\` patterns remains unchanged.

## Files Modified
- `code/qcommon/files.cpp` - Single player
- `codemp/qcommon/files.cpp` - Multiplayer

## Testing
- Build tested on macOS (arm64)
- Verified both SP and MP builds compile successfully