### PR TITLE
[MP] Fix array bounds overflow in checksum verification

### DIFF
--- a/codemp/server/sv_client.cpp
+++ b/codemp/server/sv_client.cpp
@@ -961,8 +961,14 @@ static void SV_VerifyPaks_f( client_t *cl ) {
 				break;
 			}
 			// store checksums since tokenization is not re-entrant
-			for (i = 0; nCurArg < nClientPaks; i++) {
+			for (i = 0; nCurArg < nClientPaks && i < 1024; i++) {
 				nClientChkSum[i] = atoi(Cmd_Argv(nCurArg++));
+			}
+
+			// check for overflow - client sent too many checksums
+			if (i >= 1024) {
+				bGood = qfalse;
+				break;
 			}
 
 			// store number to compare against (minus one cause the last is the number of checksums)


### PR DESCRIPTION
## Summary
Fix stack buffer overflow vulnerability in `SV_VerifyPaks_f` that could allow remote code execution on servers.

## Problem
The `SV_VerifyPaks_f` function reads client-provided checksums into a fixed-size array `nClientChkSum[1024]` without validating that the number of checksums doesn't exceed 1024.

**Vulnerable code:**
```cpp
int nClientChkSum[1024];
// ...
for (i = 0; nCurArg < nClientPaks; i++) {
    nClientChkSum[i] = atoi(Cmd_Argv(nCurArg++));  // No bounds check on i!
}
```

A malicious client could send a `cl_paks` command with more than 1024 checksum arguments, causing a stack buffer overflow. This could potentially be exploited for remote code execution on the server.

## Solution
Add `i < 1024` to the loop condition and reject clients that attempt to send more than 1024 checksums:

```cpp
for (i = 0; nCurArg < nClientPaks && i < 1024; i++) {
    nClientChkSum[i] = atoi(Cmd_Argv(nCurArg++));
}

if (i >= 1024) {
    bGood = qfalse;
    break;
}
```

## Security Impact
- **Severity:** Critical
- **Attack Vector:** Remote (malicious client to server)
- **Impact:** Potential remote code execution on game servers

## Files Modified
- `codemp/server/sv_client.cpp`

## Testing
- Build tested on macOS (arm64)
- Verified dedicated server builds successfully