### PR TITLE
Fix memory leak in CM_SurfaceCollideFromGrid error paths

### DIFF
--- a/codemp/qcommon/cm_patch.cpp
+++ b/codemp/qcommon/cm_patch.cpp
@@ -1057,6 +1057,7 @@ static inline void CM_PatchCollideFromGrid( cGrid_t *grid, patchCollide_t *pf ) 
 			}
 
 			if ( numFacets == MAX_FACETS ) {
+				Z_Free(facets);
 				Com_Error( ERR_DROP, "MAX_FACETS" );
 			}
 			facet = &facets[numFacets];
@@ -1103,6 +1104,7 @@ static inline void CM_PatchCollideFromGrid( cGrid_t *grid, patchCollide_t *pf ) 
 				}
 
 				if ( numFacets == MAX_FACETS ) {
+					Z_Free(facets);
 					Com_Error( ERR_DROP, "MAX_FACETS" );
 				}
 				facet = &facets[numFacets];


### PR DESCRIPTION
## Summary
Fix memory leak in `CM_SurfaceCollideFromGrid` when MAX_FACETS limit is exceeded.

## Problem
The function allocates a `facets` buffer via `Z_Malloc` at the start but has two `Com_Error` calls that would leak this memory. Since `Com_Error` performs a `longjmp`, the normal cleanup code at the end of the function is bypassed.

## Fix
Add `Z_Free(facets)` before both MAX_FACETS error paths to ensure proper cleanup when the error limits are hit.

## Testing
- Verified build compiles successfully
- Code inspection confirms the fix matches the existing cleanup pattern at the end of the function