### PR TITLE
Validate vehicle mass to prevent division by zero

### DIFF
--- a/code/game/bg_vehicleLoad.cpp
+++ b/code/game/bg_vehicleLoad.cpp
@@ -869,6 +869,12 @@ void BG_VehicleClampData( vehicleInfo_t *vehicle )
 	{
 		vehicle->maxPassengers = 0;
 	}
+
+	// Validate mass to prevent division by zero.
+	if ( vehicle->mass <= 0 )
+	{
+		vehicle->mass = VEH_DEFAULT_MASS;
+	}
 }
 
 static vehField_t *FindVehicleParm( const char *parmName )

--- a/codemp/game/bg_vehicleLoad.c
+++ b/codemp/game/bg_vehicleLoad.c
@@ -762,6 +762,12 @@ void BG_VehicleClampData( vehicleInfo_t *vehicle )
 	{
 		vehicle->maxPassengers = 0;
 	}
+
+	// Validate mass to prevent division by zero.
+	if ( vehicle->mass <= 0 )
+	{
+		vehicle->mass = VEH_DEFAULT_MASS;
+	}
 }
 
 static qboolean BG_ParseVehicleParm( vehicleInfo_t *vehicle, const char *parmName, char *pValue )


### PR DESCRIPTION
## Summary
Add mass validation in `BG_VehicleClampData` to prevent division by zero when processing vehicle collision physics.

## Problem
Vehicle mass is loaded from `.veh` data files and is used as a divisor in multiple places in `bg_slidemove.c` for vehicle collision and bounce calculations. A malformed or malicious vehicle definition file could set `mass = 0`, causing a division by zero.

Affected code locations:
- `bg_slidemove.c:257` - `pm->ps->speed*0.25f/pSelfVeh->m_pVehicleInfo->mass`
- `bg_slidemove.c:273` - `l/pSelfVeh->m_pVehicleInfo->mass`
- `bg_slidemove.c:368` - `l*0.5f/hitEnt->m_pVehicle->m_pVehicleInfo->mass`

## Fix
Add validation in the existing `BG_VehicleClampData` function (which already validates other vehicle parameters) to ensure mass is never zero or negative. If invalid, reset it to `VEH_DEFAULT_MASS` (200).

Applied to both:
- `codemp/game/bg_vehicleLoad.c` (Multiplayer)
- `code/game/bg_vehicleLoad.cpp` (Single Player)

## Testing
- Verified build compiles successfully