### PR TITLE
Fix strcpy buffer overflows in player model loading

### DIFF
--- a/codemp/cgame/cg_players.c
+++ b/codemp/cgame/cg_players.c
@@ -7058,7 +7058,7 @@ void CG_G2AnimEntModelLoad(centity_t *cent)
 		int skinID;
 		char *slash;
 
-		strcpy(modelName, cModelName);
+		Q_strncpyz(modelName, cModelName, sizeof(modelName));
 
 		if (cent->currentState.NPC_class == CLASS_VEHICLE && modelName[0] == '$')
 		{ //vehicles pass their veh names over as model names, then we get the model name from the veh type
@@ -7108,7 +7108,7 @@ void CG_G2AnimEntModelLoad(centity_t *cent)
 			{
 				skinID = trap->R_RegisterSkin(va("models/players/%s/model_default.skin", modelName));
 			}
-			strcpy(modelName, va("models/players/%s/model.glm", modelName));
+			Com_sprintf(modelName, sizeof(modelName), "models/players/%s/model.glm", modelName);
 
 			//this sound is *only* used for vehicles now
 			cgs.media.noAmmoSound = trap->S_RegisterSound( "sound/weapons/noammo.wav" );

--- a/codemp/game/g_client.c
+++ b/codemp/game/g_client.c
@@ -1639,14 +1639,14 @@ void SetupGameGhoul2Model(gentity_t *ent, char *modelname, char *skinName)
 			{
 				if (skinName && skinName[0])
 				{
-					strcpy(skin, skinName);
-					strcpy(truncModelName, modelname);
+					Q_strncpyz(skin, skinName, sizeof(skin));
+					Q_strncpyz(truncModelName, modelname, sizeof(truncModelName));
 				}
 				else
 				{
 					strcpy(skin, "default");
 
-					strcpy(truncModelName, modelname);
+					Q_strncpyz(truncModelName, modelname, sizeof(truncModelName));
 					p = Q_strrchr(truncModelName, '/');
 
 					if (p)
@@ -1718,7 +1718,7 @@ void SetupGameGhoul2Model(gentity_t *ent, char *modelname, char *skinName)
 				skinHandle = trap->R_RegisterSkin(useSkinName);
 			}
 
-			strcpy(modelFullPath, va("models/players/%s/model.glm", truncModelName));
+			Com_sprintf(modelFullPath, sizeof(modelFullPath), "models/players/%s/model.glm", truncModelName);
 			handle = trap->G2API_InitGhoul2Model(&ent->ghoul2, modelFullPath, 0, skinHandle, -20, 0, 0);
 
 			if (handle<0)


### PR DESCRIPTION
## Summary
Replace unsafe `strcpy` calls with `Q_strncpyz` and `Com_sprintf` to prevent buffer overflows when processing player model/skin names.

## Problem
Several locations in player model loading code use `strcpy` to copy model names, skin names, and constructed paths into fixed-size buffers (`MAX_QPATH`). If the source string exceeds the buffer size, this causes a stack buffer overflow.

## Fixed Locations

**cg_players.c:**
- `strcpy(modelName, cModelName)` → `Q_strncpyz(modelName, cModelName, sizeof(modelName))`
- `strcpy(modelName, va("models/players/%s/model.glm", modelName))` → `Com_sprintf(modelName, sizeof(modelName), ...)`

**g_client.c:**
- `strcpy(skin, skinName)` → `Q_strncpyz(skin, skinName, sizeof(skin))`
- `strcpy(truncModelName, modelname)` → `Q_strncpyz(truncModelName, modelname, sizeof(truncModelName))` (2 locations)
- `strcpy(modelFullPath, va(...))` → `Com_sprintf(modelFullPath, sizeof(modelFullPath), ...)`

## Testing
- Verified build compiles successfully