### PR TITLE
[SP] Fix animation event sounds not playing for NPC variants

### DIFF
--- a/code/cgame/cg_players.cpp
+++ b/code/cgame/cg_players.cpp
@@ -1220,7 +1220,9 @@ static void CG_PlayerAnimEvents( int animFileIndex, qboolean torso, int oldFrame
 		}
 	}
 
-	hstring myModel = g_entities[entNum].NPC_type;		//apparently NPC_type is always the same as the model name???
+	// Use the anim file set's model name instead of NPC_type, since NPC variants
+	// (e.g., "stormtrooper2") share the same model and anim events as the base NPC
+	hstring myModel = level.knownAnimFileSets[animFileIndex].filename;
 
 	// Check for anim event
 	for ( i=0; i < MAX_ANIM_EVENTS; ++i )


### PR DESCRIPTION
## Summary

Animation event sounds (like stormtrooper death clanks) weren't playing for NPC variants such as `stormtrooper2`, `stofficer`, etc.

## Cause

Model-specific animation events are loaded from `models/players/<model>/animevents.cfg` and tagged with `modelOnly = hstring("<model>").handle()` to restrict them to that model.

At runtime, `CG_PlayerAnimEvents` compared this against `NPC_type`, but NPC variants like "stormtrooper2" use the "stormtrooper" playermodel while having a different `NPC_type`. So the event's `modelOnly` (from "stormtrooper") didn't match `myModel.handle()` (from "stormtrooper2"), and the sound was skipped.

## Fix

Use `level.knownAnimFileSets[animFileIndex].filename` - this is the model name that was used when loading the animation events, so it will always match.

Fixes #1287
