### PR TITLE
[MP] Fix ambient sounds not playing after snd_restart

### DIFF
--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -1267,6 +1267,9 @@ void CL_Snd_Restart_f( void ) {
 
 	extern void S_RestartMusic( void );
 	S_RestartMusic();
+
+	extern void AS_ParseSets( void );
+	AS_ParseSets();
 }
 
 

--- a/codemp/client/snd_ambient.cpp
+++ b/codemp/client/snd_ambient.cpp
@@ -758,13 +758,21 @@ Loads the ambient sound sets and prepares to play them when needed
 -------------------------
 */
 
+static namePrecache_m *TheNamePrecache( void )
+{
+	// Use a static singleton so pMap persists across sound restarts.
+	// This fixes ambient sounds not playing after snd_restart.
+	static namePrecache_m singleton;
+	return &singleton;
+}
+
 void AS_Init( void )
 {
 	if (!aSets)
 	{
 		numSets = 0;
 
-		pMap = new namePrecache_m;
+		pMap = TheNamePrecache();
 
 		//Setup the structure
 		aSets = new CSetGroup();
@@ -882,8 +890,7 @@ void AS_FreePartial(void)
 
 		numSets	= 0;
 
-		delete pMap;
-		pMap = new namePrecache_m;
+		// pMap is now a static singleton, just clear it instead of delete/new
 		pMap->clear();
 	}
 }


### PR DESCRIPTION
Fixes #1063

## Root Cause

`AS_Init()` dynamically allocates `pMap`. When `snd_restart` runs:

1. `S_Shutdown()` → `AS_Free()` sets `aSets = NULL` but leaves `pMap` intact
2. `S_Init()` → `AS_Init()` sees `aSets == NULL`, allocates a **new empty `pMap`**, discarding all soundset names cgame had registered
3. `AS_ParseSets()` finds an empty `pMap` and loads nothing

The SP codebase already uses a static singleton for `pMap` (has since original Raven source), avoiding this issue.

## Affected Sounds

All 166 ambient sound sets in `sound/sound.txt`: bmodel sounds (doors, platforms, elevators), general environmental ambience, and local positional sounds.

## Fix

- Use a static singleton for `pMap` in MP (matching SP implementation)
- Call `AS_ParseSets()` in `CL_Snd_Restart_f()` to reload ambient sets after restart

## Testing

1. `devmap mp/ffa5`
2. Verify door/ambient sounds work
3. `snd_restart`
4. Confirm sounds still play (previously went silent)