### PR TITLE
[MP/SP] Increase MAX_ANIM_FILES from 16 to 64

### DIFF
--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -486,7 +486,7 @@ public:
 	}
 }; // animation_t
 
-#define MAX_ANIM_FILES	16
+#define MAX_ANIM_FILES	64
 #define MAX_ANIM_EVENTS 300
 
 //size of Anim eventData array...

--- a/codemp/game/bg_panimate.c
+++ b/codemp/game/bg_panimate.c
@@ -1710,6 +1710,11 @@ void BG_ClearAnimsets(void)
 animation_t *BG_AnimsetAlloc(void)
 {
 	assert (bgNumAllAnims < MAX_ANIM_FILES);
+	if (bgNumAllAnims >= MAX_ANIM_FILES)
+	{
+		Com_Printf(S_COLOR_YELLOW "BG_AnimsetAlloc: MAX_ANIM_FILES reached (%d)\n", MAX_ANIM_FILES);
+		return NULL;
+	}
 	bgAllAnims[bgNumAllAnims].anims = (animation_t *) BG_Alloc(sizeof(animation_t)*MAX_TOTALANIMATIONS);
 
 	return bgAllAnims[bgNumAllAnims].anims;
@@ -2129,7 +2134,7 @@ This file's presence is not required
 
 ======================
 */
-bgLoadedEvents_t bgAllEvents[MAX_ANIM_FILES];
+bgLoadedEvents_t bgAllEvents[MAX_ANIM_EVENT_FILES];
 int bgNumAnimEvents = 1;
 static int bg_animParseIncluding = 0;
 int BG_ParseAnimationEvtFile( const char *as_filename, int animFileIndex, int eventFileIndex )
@@ -2148,7 +2153,7 @@ int BG_ParseAnimationEvtFile( const char *as_filename, int animFileIndex, int ev
 	int				forcedIndex;
 
 	assert(animFileIndex < MAX_ANIM_FILES);
-	assert(eventFileIndex < MAX_ANIM_FILES);
+	assert(eventFileIndex < MAX_ANIM_EVENT_FILES);
 
 	if (eventFileIndex == -1)
 	{
@@ -2157,6 +2162,12 @@ int BG_ParseAnimationEvtFile( const char *as_filename, int animFileIndex, int ev
 	else
 	{
 		forcedIndex = eventFileIndex;
+	}
+
+	if (forcedIndex >= MAX_ANIM_EVENT_FILES)
+	{
+		Com_Printf(S_COLOR_YELLOW "BG_ParseAnimationEvtFile: MAX_ANIM_EVENT_FILES reached (%d), using index 0 for %s\n", MAX_ANIM_EVENT_FILES, as_filename);
+		return 0;
 	}
 
 	if (bg_animParseIncluding <= 0)

--- a/codemp/game/bg_public.h
+++ b/codemp/game/bg_public.h
@@ -321,7 +321,8 @@ typedef struct animation_s {
 extern qboolean			BGPAFtextLoaded;
 extern animation_t		bgHumanoidAnimations[MAX_TOTALANIMATIONS];
 
-#define MAX_ANIM_FILES	16
+#define MAX_ANIM_FILES	64
+#define MAX_ANIM_EVENT_FILES	128
 #define MAX_ANIM_EVENTS 300
 
 typedef enum
@@ -417,7 +418,7 @@ extern bgLoadedAnim_t bgAllAnims[MAX_ANIM_FILES];
 //On the bright side this also means we're cutting a rather large size out of
 //required game-side memory.
 #ifndef _GAME
-extern bgLoadedEvents_t bgAllEvents[MAX_ANIM_FILES];
+extern bgLoadedEvents_t bgAllEvents[MAX_ANIM_EVENT_FILES];
 extern int bgNumAnimEvents;
 #endif
 


### PR DESCRIPTION
Fixes #817

## Root Cause

Spawning more than 16 different NPC types causes out-of-bounds array access. The `bgNumAnimEvents` counter increments without checking against `MAX_ANIM_FILES`, so when it reaches 16 it overflows the `bgAllEvents[MAX_ANIM_FILES]` array.

## Fix

Increase `MAX_ANIM_FILES` from 16 to 64 in both MP and SP, matching JK2's existing limit.

Memory impact: ~900 KB additional static allocation (trivial on modern systems).