### PR TITLE
Bump actions macOS runner image versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,13 +191,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [macos-13, macos-14]
+        runner: [macos-15-intel, macos-15]
         build_type: [Debug, Release]
         portable: [Non-Portable]
         include:
-          - runner: macos-13
+          - runner: macos-15-intel
             arch: x86_64
-          - runner: macos-14
+          - runner: macos-15
             arch: arm64
 
     steps:

--- a/lib/libpng/pngpriv.h
+++ b/lib/libpng/pngpriv.h
@@ -436,18 +436,8 @@
     */
 #  include <float.h>
 
-#  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
-     /* We need to check that <math.h> hasn't already been included earlier
-      * as it seems it doesn't agree with <fp.h>, yet we should really use
-      * <fp.h> if possible.
-      */
-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
-#      include <fp.h>
-#    endif
-#  else
-#    include <math.h>
-#  endif
+#  include <math.h>
+
 #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
      /* Amiga SAS/C: We must include builtin FPU functions when compiling using
       * MATH=68881


### PR DESCRIPTION
- macos-13 is depreciated, causing builds to fail. (https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)
- libpng update is required for builds to pass on macos-15, but also includes various security fixes, fixed in #1314 (from https://www.libpng.org/pub/png/libpng.html)
- for builds to pass without libpng update, i have committed the required workaround for libpng to not cause builds to fail (from https://github.com/pnggroup/libpng/commit/893b8113f04d408cc6177c6de19c9889a48faa24)