### PR TITLE
SDL input: hotplug + event ordering polish

### DIFF
--- a/shared/sdl/sdl_input.cpp
+++ b/shared/sdl/sdl_input.cpp
@@ -1391,6 +1391,10 @@ static void IN_ProcessEvents( void )
 void IN_Frame (void) {
 	qboolean loading;
 
+	// Process SDL events first so joystick/controller state is up-to-date
+	// before we generate input movement for this frame.
+	IN_ProcessEvents();
+
 	IN_JoyMove( );
 
 	// If not DISCONNECTED (main menu) or ACTIVE (in game), we're loading
@@ -1413,8 +1417,6 @@ void IN_Frame (void) {
 	}
 	else
 		IN_ActivateMouse( );
-
-	IN_ProcessEvents();
 }
 
 

--- a/shared/sdl/sdl_input.cpp
+++ b/shared/sdl/sdl_input.cpp
@@ -1268,6 +1268,51 @@ static void IN_ProcessEvents( void )
 	{
 		switch( e.type )
 		{
+			case SDL_CONTROLLERDEVICEADDED:
+			case SDL_JOYDEVICEADDED:
+				// Hotplug support: if a controller/joystick is connected after startup,
+				// attempt to (re)initialize joystick input so it becomes available without restart.
+				if ( in_joystick && in_joystick->integer && !stick )
+				{
+					Com_Printf( "Controller connected.\n" );
+					IN_InitJoystick( );
+				}
+				break;
+
+			case SDL_CONTROLLERDEVICEREMOVED:
+			{
+				// If the active GameController was removed, re-init to cleanly drop input
+				// and/or pick another connected device.
+				if ( gamepad )
+				{
+					SDL_JoystickID removedId = e.cdevice.which;
+					SDL_JoystickID currentId = SDL_JoystickInstanceID( SDL_GameControllerGetJoystick( gamepad ) );
+					if ( removedId == currentId )
+					{
+						Com_Printf( "Controller disconnected.\n" );
+						IN_InitJoystick( );
+					}
+				}
+				break;
+			}
+
+			case SDL_JOYDEVICEREMOVED:
+			{
+				// If the active joystick device was removed, re-init to cleanly drop input
+				// and/or pick another connected device.
+				if ( stick )
+				{
+					SDL_JoystickID removedId = e.jdevice.which;
+					SDL_JoystickID currentId = SDL_JoystickInstanceID( stick );
+					if ( removedId == currentId )
+					{
+						Com_Printf( "Joystick disconnected.\n" );
+						IN_InitJoystick( );
+					}
+				}
+				break;
+			}
+
 			case SDL_KEYDOWN:
 				key = IN_TranslateSDLToJKKey( &e.key.keysym, qtrue );
 				if ( key != A_NULL )


### PR DESCRIPTION
Moves IN_ProcessEvents() before IN_JoyMove() in IN_Frame() so controller state is updated before generating movement for the frame.

Adds SDL hotplug handling (controller/joystick added/removed) to re-init joystick input when devices are connected/disconnected.

Scope: shared/sdl/sdl_input.cpp only.