### PR TITLE
Client: clamp move values while walking (MP-compatible)

### DIFF
--- a/code/client/cl_input.cpp
+++ b/code/client/cl_input.cpp
@@ -750,6 +750,20 @@ usercmd_t CL_CreateCmd( void ) {
 	// get basic movement from joystick
 	CL_JoystickMove( &cmd );
 
+	// Clamp move values while walking to keep controller/joystick "walk" compatible
+	// with the engine's typical walk magnitude (and MP's 64-threshold behavior).
+	if ( cmd.buttons & BUTTON_WALKING )
+	{
+		const int forward = (int)cmd.forwardmove;
+		const int side = (int)cmd.rightmove;
+
+		if ( forward > 64 ) cmd.forwardmove = 64;
+		else if ( forward < -64 ) cmd.forwardmove = -64;
+
+		if ( side > 64 ) cmd.rightmove = 64;
+		else if ( side < -64 ) cmd.rightmove = -64;
+	}
+
 	// check to make sure the angles haven't wrapped
 	if ( cl.viewangles[PITCH] - oldAngles[PITCH] > 90 ) {
 		cl.viewangles[PITCH] = oldAngles[PITCH] + 90;

--- a/codemp/client/cl_input.cpp
+++ b/codemp/client/cl_input.cpp
@@ -1419,6 +1419,21 @@ usercmd_t CL_CreateCmd( void ) {
 	// get basic movement from joystick
 	CL_JoystickMove( &cmd );
 
+	// MP anti-cheat clears BUTTON_WALKING when forward/right magnitudes exceed 64
+	// (see bg_pmove.c). Clamp while walking so analog movement can still "feather"
+	// without unexpectedly being forced into run/no-walk by the server.
+	if ( cmd.buttons & BUTTON_WALKING )
+	{
+		const int forward = (int)cmd.forwardmove;
+		const int side = (int)cmd.rightmove;
+
+		if ( forward > 64 ) cmd.forwardmove = 64;
+		else if ( forward < -64 ) cmd.forwardmove = -64;
+
+		if ( side > 64 ) cmd.rightmove = 64;
+		else if ( side < -64 ) cmd.rightmove = -64;
+	}
+
 	// check to make sure the angles haven't wrapped
 	if ( cl.viewangles[PITCH] - oldAngles[PITCH] > 90 ) {
 		cl.viewangles[PITCH] = oldAngles[PITCH] + 90;


### PR DESCRIPTION
MP pmove clears BUTTON_WALKING when abs(forwardmove/rightmove) > 64 (anti no-footsteps cheat).
Clamp move values to ±64 while walking so analog input can still feather without unexpectedly being forced into run.