### PR TITLE
Client: add opt-in dual-stick joystick mode (move+look)

### DIFF
--- a/code/client/cl_input.cpp
+++ b/code/client/cl_input.cpp
@@ -359,6 +359,10 @@ cvar_t	*cl_run;
 
 cvar_t	*cl_anglespeedkey;
 
+// Optional modern controller behavior (opt-in; defaults preserve legacy joystick semantics)
+static cvar_t *in_joystickDualStick;
+static cvar_t *in_joystickWalkThreshold;
+
 
 /*
 ================
@@ -493,6 +497,63 @@ void CL_JoystickMove( usercmd_t *cmd ) {
 
 	if ( !in_joystick->integer )
 	{
+		return;
+	}
+
+	// Dual-stick mode (opt-in): left stick always moves, right stick always looks.
+	// This avoids legacy "mlook/strafe swaps axes" behavior and matches modern gamepad expectations.
+	if ( in_joystickDualStick && in_joystickDualStick->integer )
+	{
+		const int sideMove = cl.joystickAxis[AXIS_SIDE];
+		const int forwardMove = cl.joystickAxis[AXIS_FORWARD];
+
+		// Analog walk/run based on stick magnitude (0..1). MP-safe default is 0.5 (~64/127).
+		if ( in_joystickWalkThreshold )
+		{
+			float walkThreshold = in_joystickWalkThreshold->value;
+			if ( walkThreshold < 0.0f ) walkThreshold = 0.0f;
+			if ( walkThreshold > 1.0f ) walkThreshold = 1.0f;
+
+			const float magSq = (float)(sideMove * sideMove + forwardMove * forwardMove) / (127.0f * 127.0f);
+			const float walkThrSq = walkThreshold * walkThreshold;
+
+			// Use squared magnitude to avoid sqrt() dependency.
+			if ( magSq > (0.01f * 0.01f) && magSq < walkThrSq )
+			{
+				cmd->buttons |= BUTTON_WALKING;
+			}
+		}
+
+		if ( in_speed.active ) {
+			anglespeed = 0.001 * cls.frametime * cl_anglespeedkey->value;
+		} else {
+			anglespeed = 0.001 * cls.frametime;
+		}
+
+		// Left stick: movement
+		cmd->rightmove = ClampChar( cmd->rightmove + sideMove );
+		cmd->forwardmove = ClampChar( cmd->forwardmove + forwardMove );
+		cmd->upmove = ClampChar( cmd->upmove + cl.joystickAxis[AXIS_UP] );
+
+		// Right stick: look
+		if ( cl_mYawOverride )
+		{
+			cl.viewangles[YAW] -= 5.0f * cl_mYawOverride * cl.joystickAxis[AXIS_YAW];
+		}
+		else
+		{
+			cl.viewangles[YAW] -= anglespeed * (cl_yawspeed->value / 100.0f) * cl.joystickAxis[AXIS_YAW];
+		}
+
+		if ( cl_mPitchOverride )
+		{
+			cl.viewangles[PITCH] += 5.0f * cl_mPitchOverride * cl.joystickAxis[AXIS_PITCH];
+		}
+		else
+		{
+			cl.viewangles[PITCH] += anglespeed * (cl_pitchspeed->value / 100.0f) * cl.joystickAxis[AXIS_PITCH];
+		}
+
 		return;
 	}
 
@@ -1089,5 +1150,8 @@ void CL_InitInput( void ) {
 
 	cl_nodelta = Cvar_Get ("cl_nodelta", "0", 0);
 	cl_debugMove = Cvar_Get ("cl_debugMove", "0", 0);
+
+	in_joystickDualStick = Cvar_Get( "in_joystickDualStick", "0", CVAR_ARCHIVE_ND );
+	in_joystickWalkThreshold = Cvar_Get( "in_joystickWalkThreshold", "0.5", CVAR_ARCHIVE_ND );
 }
 

--- a/codemp/client/cl_input.cpp
+++ b/codemp/client/cl_input.cpp
@@ -811,6 +811,10 @@ cvar_t	*cl_run;
 
 cvar_t	*cl_anglespeedkey;
 
+// Optional modern controller behavior (opt-in; defaults preserve legacy joystick semantics)
+static cvar_t *in_joystickDualStick;
+static cvar_t *in_joystickWalkThreshold;
+
 
 /*
 ================
@@ -984,6 +988,77 @@ void CL_JoystickMove( usercmd_t *cmd ) {
 
 	if ( !in_joystick->integer )
 	{
+		return;
+	}
+
+	// Dual-stick mode (opt-in): left stick always moves, right stick always looks.
+	// This avoids legacy "mlook/strafe swaps axes" behavior and matches modern gamepad expectations.
+	if ( in_joystickDualStick && in_joystickDualStick->integer )
+	{
+		const int sideMove = cl.joystickAxis[AXIS_SIDE];
+		const int forwardMove = cl.joystickAxis[AXIS_FORWARD];
+
+		// Analog walk/run based on stick magnitude (0..1). MP-safe default is 0.5 (~64/127).
+		if ( in_joystickWalkThreshold )
+		{
+			float walkThreshold = in_joystickWalkThreshold->value;
+			if ( walkThreshold < 0.0f ) walkThreshold = 0.0f;
+			if ( walkThreshold > 1.0f ) walkThreshold = 1.0f;
+
+			const float magSq = (float)(sideMove * sideMove + forwardMove * forwardMove) / (127.0f * 127.0f);
+			const float walkThrSq = walkThreshold * walkThreshold;
+
+			// Use squared magnitude to avoid sqrt() dependency.
+			if ( magSq > (0.01f * 0.01f) && magSq < walkThrSq )
+			{
+				cmd->buttons |= BUTTON_WALKING;
+			}
+		}
+
+		if ( in_speed.active ) {
+			anglespeed = 0.001 * cls.frametime * cl_anglespeedkey->value;
+		} else {
+			anglespeed = 0.001 * cls.frametime;
+		}
+
+		// Left stick: movement
+		cmd->rightmove = ClampChar( cmd->rightmove + sideMove );
+		cmd->forwardmove = ClampChar( cmd->forwardmove + forwardMove );
+		cmd->upmove = ClampChar( cmd->upmove + cl.joystickAxis[AXIS_UP] );
+
+		// Right stick: look
+		if ( cl_mYawOverride )
+		{
+			if ( cl_mSensitivityOverride )
+			{
+				cl.viewangles[YAW] -= cl_mYawOverride * cl_mSensitivityOverride * cl.joystickAxis[AXIS_YAW] / 2.0f;
+			}
+			else
+			{
+				cl.viewangles[YAW] -= cl_mYawOverride * OVERRIDE_MOUSE_SENSITIVITY * cl.joystickAxis[AXIS_YAW] / 2.0f;
+			}
+		}
+		else
+		{
+			cl.viewangles[YAW] -= anglespeed * (cl_yawspeed->value / 100.0f) * cl.joystickAxis[AXIS_YAW];
+		}
+
+		if ( cl_mPitchOverride )
+		{
+			if ( cl_mSensitivityOverride )
+			{
+				cl.viewangles[PITCH] += cl_mPitchOverride * cl_mSensitivityOverride * cl.joystickAxis[AXIS_PITCH] / 2.0f;
+			}
+			else
+			{
+				cl.viewangles[PITCH] += cl_mPitchOverride * OVERRIDE_MOUSE_SENSITIVITY * cl.joystickAxis[AXIS_PITCH] / 2.0f;
+			}
+		}
+		else
+		{
+			cl.viewangles[PITCH] += anglespeed * (cl_pitchspeed->value / 100.0f) * cl.joystickAxis[AXIS_PITCH];
+		}
+
 		return;
 	}
 
@@ -1832,6 +1907,9 @@ void CL_InitInput( void ) {
 
 	cl_nodelta = Cvar_Get ("cl_nodelta", "0", 0);
 	cl_debugMove = Cvar_Get ("cl_debugMove", "0", 0);
+
+	in_joystickDualStick = Cvar_Get( "in_joystickDualStick", "0", CVAR_ARCHIVE_ND );
+	in_joystickWalkThreshold = Cvar_Get( "in_joystickWalkThreshold", "0.5", CVAR_ARCHIVE_ND );
 }
 
 /*


### PR DESCRIPTION
Adds an opt-in dual-stick joystick/gamepad behavior in CL_JoystickMove() for both SP and MP clients.

New cvars:
in_joystickDualStick (default 0): when enabled, left stick always moves (AXIS_SIDE/AXIS_FORWARD) and right stick always looks (AXIS_YAW/AXIS_PITCH), avoiding the legacy “strafe/mlook swaps axes” behavior.
in_joystickWalkThreshold (default 0.5): analog walk/run threshold based on stick magnitude; default chosen to be MP-safe (~64/127).

Scope: code/client/cl_input.cpp + codemp/client/cl_input.cpp only. Defaults preserve current behavior unless enabled.

How to test:
set in_joystick 1
set in_joystickUseAnalog 1
set in_joystickDualStick 1

Xbox controller via SDL GameController recommended for testing.