### PR TITLE
client: add cl_joystickSensitivity

### DIFF
--- a/code/client/cl_input.cpp
+++ b/code/client/cl_input.cpp
@@ -359,6 +359,9 @@ cvar_t	*cl_run;
 
 cvar_t	*cl_anglespeedkey;
 
+// Joystick/controller look sensitivity scalar (1.0 = default behavior)
+cvar_t	*cl_joystickSensitivity;
+
 
 /*
 ================
@@ -490,6 +493,7 @@ CL_JoystickMove
 */
 void CL_JoystickMove( usercmd_t *cmd ) {
 	float	anglespeed;
+	float	joystickSensitivity;
 
 	if ( !in_joystick->integer )
 	{
@@ -506,10 +510,14 @@ void CL_JoystickMove( usercmd_t *cmd ) {
 		cmd->buttons |= BUTTON_WALKING;
 	}
 
+	joystickSensitivity = cl_joystickSensitivity ? cl_joystickSensitivity->value : 1.0f;
+	if ( joystickSensitivity < 0.0f )
+		joystickSensitivity = 0.0f;
+
 	if ( in_speed.active ) {
-		anglespeed = 0.001 * cls.frametime * cl_anglespeedkey->value;
+		anglespeed = 0.001f * cls.frametime * cl_anglespeedkey->value * joystickSensitivity;
 	} else {
-		anglespeed = 0.001 * cls.frametime;
+		anglespeed = 0.001f * cls.frametime * joystickSensitivity;
 	}
 
 	if ( !in_strafe.active ) {
@@ -1086,6 +1094,8 @@ void CL_InitInput( void ) {
 	//end buttons
 	Cmd_AddCommand ("+mlook", IN_MLookDown);
 	Cmd_AddCommand ("-mlook", IN_MLookUp);
+
+	cl_joystickSensitivity = Cvar_Get( "cl_joystickSensitivity", "1.0", CVAR_ARCHIVE_ND );
 
 	cl_nodelta = Cvar_Get ("cl_nodelta", "0", 0);
 	cl_debugMove = Cvar_Get ("cl_debugMove", "0", 0);

--- a/codemp/client/cl_input.cpp
+++ b/codemp/client/cl_input.cpp
@@ -811,6 +811,9 @@ cvar_t	*cl_run;
 
 cvar_t	*cl_anglespeedkey;
 
+// Joystick/controller look sensitivity scalar (1.0 = default behavior)
+cvar_t	*cl_joystickSensitivity;
+
 
 /*
 ================
@@ -981,6 +984,7 @@ extern cvar_t *j_up_axis;
 
 void CL_JoystickMove( usercmd_t *cmd ) {
 	float	anglespeed;
+	float	joystickSensitivity;
 
 	if ( !in_joystick->integer )
 	{
@@ -997,10 +1001,14 @@ void CL_JoystickMove( usercmd_t *cmd ) {
 		cmd->buttons |= BUTTON_WALKING;
 	}
 
+	joystickSensitivity = cl_joystickSensitivity ? cl_joystickSensitivity->value : 1.0f;
+	if ( joystickSensitivity < 0.0f )
+		joystickSensitivity = 0.0f;
+
 	if ( in_speed.active ) {
-		anglespeed = 0.001 * cls.frametime * cl_anglespeedkey->value;
+		anglespeed = 0.001f * cls.frametime * cl_anglespeedkey->value * joystickSensitivity;
 	} else {
-		anglespeed = 0.001 * cls.frametime;
+		anglespeed = 0.001f * cls.frametime * joystickSensitivity;
 	}
 
 	if ( !in_strafe.active ) {
@@ -1829,6 +1837,8 @@ CL_InitInput
 */
 void CL_InitInput( void ) {
 	Cmd_AddCommandList( inputCmds );
+
+	cl_joystickSensitivity = Cvar_Get( "cl_joystickSensitivity", "1.0", CVAR_ARCHIVE_ND );
 
 	cl_nodelta = Cvar_Get ("cl_nodelta", "0", 0);
 	cl_debugMove = Cvar_Get ("cl_debugMove", "0", 0);


### PR DESCRIPTION
Adds cl_joystickSensitivity (default 1.0) to scale joystick/controller look speed in CL_JoystickMove() for both SP and MP clients.

Default value preserves existing behavior; users can raise/lower it to tune turn speed without touching other joystick cvars.

Scope: code/client/cl_input.cpp, codemp/client/cl_input.cpp only.

Inspired by jk2mv’s controller work (joystick sensitivity scalar) — adapted to OpenJK’s input code and kept default-neutral.