### PR TITLE
[MP] Perform bone conversion for jk2 models when running dedicated server.

### DIFF
--- a/codemp/rd-dedicated/tr_model.cpp
+++ b/codemp/rd-dedicated/tr_model.cpp
@@ -750,6 +750,7 @@ qboolean ServerLoadMDXA( model_t *mod, void *buffer, const char *mod_name, qbool
 ServerLoadMDXM - load a Ghoul 2 Mesh file
 =================
 */
+extern int OldToNewRemapTable[72];
 qboolean ServerLoadMDXM( model_t *mod, void *buffer, const char *mod_name, qboolean &bAlreadyCached ) {
 	int					i,l, j;
 	mdxmHeader_t		*pinmodel, *mdxm;
@@ -829,6 +830,12 @@ qboolean ServerLoadMDXM( model_t *mod, void *buffer, const char *mod_name, qbool
 	if (bAlreadyFound)
 	{
 		return qtrue;	// All done. Stop, go no further, do not LittleLong(), do not pass Go...
+	}
+
+	bool isAnOldModelFile = false;
+	if (mdxm->numBones == 72 && strstr(mdxm->animName,"_humanoid") )
+	{
+		isAnOldModelFile = true;
 	}
 
 	surfInfo = (mdxmSurfHierarchy_t *)( (byte *)mdxm + mdxm->ofsSurfHierarchy);
@@ -935,6 +942,22 @@ qboolean ServerLoadMDXM( model_t *mod, void *buffer, const char *mod_name, qbool
 				v = (mdxmVertex_t *)&v->weights[/*v->numWeights*/surf->maxVertBoneWeights];
 			}
 #endif
+			if (isAnOldModelFile)
+			{
+				int *boneRef = (int *) ( (byte *)surf + surf->ofsBoneReferences );
+				for ( j = 0 ; j < surf->numBoneReferences ; j++ )
+				{
+					assert(boneRef[j] >= 0 && boneRef[j] < 72);
+					if (boneRef[j] >= 0 && boneRef[j] < 72)
+					{
+						boneRef[j]=OldToNewRemapTable[boneRef[j]];
+					}
+					else
+					{
+						boneRef[j]=0;
+					}
+				}
+			}
 
 			// find the next surface
 			surf = (mdxmSurface_t *)( (byte *)surf + surf->ofsEnd );

--- a/codemp/rd-rend2/tr_model.cpp
+++ b/codemp/rd-rend2/tr_model.cpp
@@ -490,6 +490,7 @@ qboolean R_LoadMDXA_Server( model_t *mod, void *buffer, const char *mod_name, qb
 R_LoadMDXM_Server - load a Ghoul 2 Mesh file
 =================
 */
+extern int OldToNewRemapTable[72];
 qboolean R_LoadMDXM_Server( model_t *mod, void *buffer, const char *mod_name, qboolean &bAlreadyCached ) {
 	int					i,l, j;
 	mdxmHeader_t		*pinmodel, *mdxm;
@@ -562,6 +563,12 @@ qboolean R_LoadMDXM_Server( model_t *mod, void *buffer, const char *mod_name, qb
 		return qtrue;	// All done. Stop, go no further, do not LittleLong(), do not pass Go...
 	}
 
+	bool isAnOldModelFile = false;
+	if (mdxm->numBones == 72 && strstr(mdxm->animName,"_humanoid") )
+	{
+		isAnOldModelFile = true;
+	}
+
 	surfInfo = (mdxmSurfHierarchy_t *)( (byte *)mdxm + mdxm->ofsSurfHierarchy);
  	for ( i = 0 ; i < mdxm->numSurfaces ; i++)
 	{
@@ -620,6 +627,23 @@ qboolean R_LoadMDXM_Server( model_t *mod, void *buffer, const char *mod_name, qb
 			surf->ident = SF_MDX;
 
 			// register the shaders
+
+			if (isAnOldModelFile)
+			{
+				int *boneRef = (int *) ( (byte *)surf + surf->ofsBoneReferences );
+				for ( j = 0 ; j < surf->numBoneReferences ; j++ )
+				{
+					assert(boneRef[j] >= 0 && boneRef[j] < 72);
+					if (boneRef[j] >= 0 && boneRef[j] < 72)
+					{
+						boneRef[j]=OldToNewRemapTable[boneRef[j]];
+					}
+					else
+					{
+						boneRef[j]=0;
+					}
+				}
+			}
 
 			// find the next surface
 			surf = (mdxmSurface_t *)( (byte *)surf + surf->ofsEnd );

--- a/codemp/rd-vanilla/tr_model.cpp
+++ b/codemp/rd-vanilla/tr_model.cpp
@@ -803,6 +803,7 @@ qboolean ServerLoadMDXA( model_t *mod, void *buffer, const char *mod_name, qbool
 ServerLoadMDXM - load a Ghoul 2 Mesh file
 =================
 */
+extern int OldToNewRemapTable[72];
 qboolean ServerLoadMDXM( model_t *mod, void *buffer, const char *mod_name, qboolean &bAlreadyCached ) {
 	int					i,l, j;
 	mdxmHeader_t		*pinmodel, *mdxm;
@@ -884,6 +885,12 @@ qboolean ServerLoadMDXM( model_t *mod, void *buffer, const char *mod_name, qbool
 	if (bAlreadyFound)
 	{
 		return qtrue;	// All done. Stop, go no further, do not LittleLong(), do not pass Go...
+	}
+
+	bool isAnOldModelFile = false;
+	if (mdxm->numBones == 72 && strstr(mdxm->animName,"_humanoid") )
+	{
+		isAnOldModelFile = true;
 	}
 
 	surfInfo = (mdxmSurfHierarchy_t *)( (byte *)mdxm + mdxm->ofsSurfHierarchy);
@@ -997,7 +1004,22 @@ qboolean ServerLoadMDXM( model_t *mod, void *buffer, const char *mod_name, qbool
 				v++;
 			}
 #endif
-
+			if (isAnOldModelFile)
+			{
+				int *boneRef = (int *) ( (byte *)surf + surf->ofsBoneReferences );
+				for ( j = 0 ; j < surf->numBoneReferences ; j++ )
+				{
+					assert(boneRef[j] >= 0 && boneRef[j] < 72);
+					if (boneRef[j] >= 0 && boneRef[j] < 72)
+					{
+						boneRef[j]=OldToNewRemapTable[boneRef[j]];
+					}
+					else
+					{
+						boneRef[j]=0;
+					}
+				}
+			}
 			// find the next surface
 			surf = (mdxmSurface_t *)( (byte *)surf + surf->ofsEnd );
 		}


### PR DESCRIPTION
Perform bone conversion for jk2 models when running dedicated server.

Previously using a jk2 glm, for instance a custom npc on a custom map, would lead to a crash when trying to perform g2 traces. This affected only dedicated servers.