### PR TITLE
build: modernize CMake infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,113 @@
+# OpenJK — Agent guidance
+
+## What this is
+
+Community-maintained engine for Jedi Academy (SP + MP) and Jedi Outcast (SP only).  
+C++11 / C, CMake 4.3+, GPLv2. Backwards-compatible with vanilla game + mods.
+
+## Directory layout
+
+| Path | What |
+|---|---|
+| `code/` | JA SP engine + game (`openjk_sp.*`, `jagame*`) |
+| `codemp/` | JA MP engine + game + renderers (`openjk.*`, `openjkded.*`, `jampgame*`, `cgame*`, `ui*`) |
+| `codeJK2/` | JO SP support — off by default |
+| `shared/` | Cross-target code (`qcommon/`, `sys/`, `sdl/`) |
+| `tests/` | Boost.Test unit tests (opt-in, requires Boost) |
+| `lib/` | Bundled libs (SDL2, OpenAL, zlib, libpng, jpeg-9a, minizip, gsl-lite) |
+| `cmake/` | Custom modules + cross-compile toolchains |
+| `docs/` | Architecture docs (renderer, libraries, save games) |
+
+## Build
+
+CMake 4.3+ required. Presets are provided for common configurations.
+
+### Configure
+
+```bash
+cmake --preset windows-msvc-debug    # or windows-msvc-release
+# cmake --preset linux-gcc-debug     # Linux
+# cmake --preset macos-clang-debug   # macOS
+```
+
+Available presets: `windows-msvc-debug/release`, `linux-gcc-debug/release`, `linux-i686-debug`, `macos-clang-debug/release`.
+
+Manual configure (if presets don't fit):
+```bash
+cmake -B build -G "Visual Studio 18 2026" -A x64 \
+  -DBuildJK2SPEngine=ON -DBuildJK2SPGame=ON -DBuildJK2SPRdVanilla=ON
+```
+
+Notable flags:
+- `-DBuildTests=ON` — unit tests (requires Boost, MSVC wants static lib)
+- `-DBuildPortableVersion=ON` — don't read/write user home dir
+- `-DUseInternalLibs=ON` — use bundled deps (auto-on for Windows)
+- Linux x86: add `-DCMAKE_TOOLCHAIN_FILE=cmake/Toolchains/linux-i686.cmake`
+- Individual components can be toggled OFF (see `CMakeLists.txt:38-53`)
+
+### Build & test
+
+```bash
+cmake --build --preset windows-msvc-debug -j 8
+ctest --test-dir build              # if -DBuildTests=ON
+```
+
+### Install
+
+```bash
+cmake --install build --config Debug/Release
+```
+
+Release output goes to `build/bin/JediAcademy` and `build/bin/JediOutcast`.
+
+## Key binary names (architecture-suffixed)
+
+| Target | Name |
+|---|---|
+| JA SP engine | `openjk_sp.<arch>` |
+| JA SP game DLL | `jagame<arch>` |
+| JA SP renderer | `rdsp-vanilla_<arch>` |
+| JA MP client | `openjk.<arch>` |
+| JA MP ded server | `openjkded.<arch>` |
+| JA MP game DLL | `jampgame<arch>` |
+| JA MP cgame DLL | `cgame<arch>` |
+| JA MP UI DLL | `ui<arch>` |
+| JO SP engine | `openjo_sp.<arch>` |
+| JO SP game DLL | `jospgame<arch>` |
+| JO SP renderer | `rdjosp-vanilla_<arch>` |
+
+## Versioning
+
+Version string is derived from `git describe --tag` at CMake configure time.  
+CI checks out with `fetch-depth: 0` and `fetch-tags: true`. Reproducible builds via `SOURCE_DATE_EPOCH`.
+
+## Testing
+
+- Boost.Test framework, opt-in (`-DBuildTests=ON`)
+- Test files in `tests/` (safe string, limited_vector)
+- `BOOST_AUTO_TEST_SUITE` / `BOOST_AUTO_TEST_CASE` style
+- Only built when `find_package(Boost COMPONENTS unit_test_framework)` succeeds
+
+## Architecture notes
+
+- **Renderer split**: frontend (scene build, no GL) + backend (OpenGL draw). See `docs/renderer-architecture.md`.
+- **Mod ABI**: legacy `vmMain`/`dllEntry` interface (Q3 VM style) or newer typed `GetModuleAPI`. See `docs/libraries.md`.
+- **JK2_MODE** preprocessor define for Jedi Outcast builds (disables gore, sets product to `openjo_sp`).
+- **Engine vs Game separation**: `.exe` loads game `.dll` — enables modding without touching engine.
+- **Bundled minizip** always used (modified for `Z_Malloc`).
+- **Portable version** (`-DBuildPortableVersion=ON`) writes all files next to the binary instead of user home dir.
+
+## Compiler quirks
+
+- MSVC: `/arch:SSE2`, `/MP` (multi-proc build), `NOMINMAX` + CRT safety disables
+- GCC x86: `-msse2 -mstackrealign -mfpmath=sse` (VM crash workaround)
+- GCC/Clang: `-fvisibility=hidden` (not project-wide — per-target due to bundled zlib)
+- GCC on Windows: static `-static-libgcc -static-libstdc++`
+- `NOEXCEPT` macro for VS2013/GCC compat; `OVERRIDE` maps to `override`
+
+## Rules of thumb
+
+- No linter, formatter, or typecheck runner exists.
+- No JavaScript, package.json, or Node tooling.
+- `q_shared.h` is included first by everything — it's ~2800 lines and defines the project-wide types (`qboolean`, `byte`, etc.), endian helpers, and MSVC warning suppressions.
+- GPLv2 — license header on every source file.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 #============================================================================
 
-# The <min>...<policy_max> syntax is needed to remain compatible with 3.1, but also newer versions that dropped 3.1 compatibility
-# More info here: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
-cmake_minimum_required(VERSION 3.1...3.31)
+cmake_minimum_required(VERSION 4.3)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
 
 set(InOpenJK ON)
@@ -129,7 +127,7 @@ else()
 	set(X86 OFF)
 	if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
 		set(Architecture "arm64")
-		add_definitions(-DPNG_ARM_NEON_OPT=0)
+		add_compile_definitions(PNG_ARM_NEON_OPT=0)
 	elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm")
 		set(Architecture "arm")
 	elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
@@ -215,7 +213,7 @@ if (NOT WIN32 AND NOT APPLE)
 endif()
 
 if(CMAKE_SYSTEM_NAME MATCHES "BSD")
-  add_definitions(-DIOAPI_NO_64)
+  add_compile_definitions(IOAPI_NO_64)
 endif()
 
 # Compiler settings

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,150 @@
+{
+  "version": 8,
+  "cmakeMinimumRequired": {
+    "major": 4,
+    "minor": 3,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "windows-msvc-debug",
+      "displayName": "Windows MSVC Debug",
+      "description": "Debug build using Visual Studio 2026 + MSVC",
+      "generator": "Visual Studio 18 2026",
+      "architecture": {
+        "value": "x64",
+        "strategy": "set"
+      },
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "BuildJK2SPEngine": "ON",
+        "BuildJK2SPGame": "ON",
+        "BuildJK2SPRdVanilla": "ON"
+      }
+    },
+    {
+      "name": "windows-msvc-release",
+      "displayName": "Windows MSVC Release",
+      "description": "Release build using Visual Studio 2026 + MSVC",
+      "generator": "Visual Studio 18 2026",
+      "architecture": {
+        "value": "x64",
+        "strategy": "set"
+      },
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "BuildJK2SPEngine": "ON",
+        "BuildJK2SPGame": "ON",
+        "BuildJK2SPRdVanilla": "ON"
+      }
+    },
+    {
+      "name": "linux-gcc-debug",
+      "displayName": "Linux GCC Debug",
+      "description": "Debug build using Ninja + GCC",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "BuildJK2SPEngine": "ON",
+        "BuildJK2SPGame": "ON",
+        "BuildJK2SPRdVanilla": "ON"
+      }
+    },
+    {
+      "name": "linux-gcc-release",
+      "displayName": "Linux GCC Release",
+      "description": "Release build using Ninja + GCC",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "BuildJK2SPEngine": "ON",
+        "BuildJK2SPGame": "ON",
+        "BuildJK2SPRdVanilla": "ON"
+      }
+    },
+    {
+      "name": "macos-clang-debug",
+      "displayName": "macOS Clang Debug",
+      "description": "Debug build using Ninja + Apple Clang",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "BuildJK2SPEngine": "ON",
+        "BuildJK2SPGame": "ON",
+        "BuildJK2SPRdVanilla": "ON"
+      }
+    },
+    {
+      "name": "macos-clang-release",
+      "displayName": "macOS Clang Release",
+      "description": "Release build using Ninja + Apple Clang",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "BuildJK2SPEngine": "ON",
+        "BuildJK2SPGame": "ON",
+        "BuildJK2SPRdVanilla": "ON"
+      }
+    },
+    {
+      "name": "linux-i686-debug",
+      "displayName": "Linux x86 Debug",
+      "description": "32-bit Linux debug using toolchain file",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/cmake/Toolchains/linux-i686.cmake",
+        "BuildJK2SPEngine": "ON",
+        "BuildJK2SPGame": "ON",
+        "BuildJK2SPRdVanilla": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "windows-msvc-debug",
+      "configurePreset": "windows-msvc-debug",
+      "configuration": "Debug"
+    },
+    {
+      "name": "windows-msvc-release",
+      "configurePreset": "windows-msvc-release",
+      "configuration": "Release"
+    },
+    {
+      "name": "linux-gcc-debug",
+      "configurePreset": "linux-gcc-debug"
+    },
+    {
+      "name": "linux-gcc-release",
+      "configurePreset": "linux-gcc-release"
+    },
+    {
+      "name": "macos-clang-debug",
+      "configurePreset": "macos-clang-debug"
+    },
+    {
+      "name": "macos-clang-release",
+      "configurePreset": "macos-clang-release"
+    },
+    {
+      "name": "linux-i686-debug",
+      "configurePreset": "linux-i686-debug"
+    }
+  ]
+}

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,81 @@
+# Modernization Plan
+
+**Goal:** Incrementally modernize OpenJK's toolchain and codebase — CMake, C++20, Catch2, Clang-first, cleaner architecture.
+**Strategy:** Many small, self-contained PRs, no big-bang rewrites.
+
+---
+
+## PR 1 — CMake minimum version bump
+
+Bump `cmake_minimum_required` to 4.3 across the project.
+
+| File | Change |
+|---|---|
+| `CMakeLists.txt:21` | `3.1...3.31` → `4.3` |
+| `tools/WinSymbol/CMakeLists.txt:18` | `3.1` → `4.3` |
+
+**Completion check:** `cmake -B build_vs -G "Visual Studio 18 2026" -A x64 && cmake --build build_vs` passes.
+
+---
+
+## PR 2 — Switch to CMAKE_CXX_STANDARD 20
+
+Replace the hardcoded `-std=c++11` flag with proper `CMAKE_CXX_STANDARD 20` target property.
+
+| File | Change |
+|---|---|
+| `CMakeLists.txt:274` | Remove `set(CMAKE_CXX_FLAGS ... -std=c++11)` |
+| `CMakeLists.txt` (new) | `set(CMAKE_CXX_STANDARD 20)` + `set(CMAKE_CXX_STANDARD_REQUIRED ON)` |
+
+**Completion check:** Build passes, compiler invocations show `-std=c++20` instead of `-std=c++11`.
+
+---
+
+## PR 3 — Simplify NOEXCEPT / OVERRIDE macros
+
+C++20 baseline means `noexcept` and `override` are always available — collapse the legacy workarounds.
+
+| File | Change |
+|---|---|
+| `shared/qcommon/q_platform.h:187-197` | Replace conditional `NOEXCEPT` with direct `noexcept` |
+
+---
+
+## PR 4 — Swap Boost.Test for Catch2
+
+Replace the only Boost dependency with header-only Catch2.
+
+| File | Change |
+|---|---|
+| `tests/CMakeLists.txt` | Remove `find_package(Boost)`, add Catch2 |
+| `tests/main.cpp` | Remove `BOOST_TEST_MODULE`, add Catch2 `#define CATCH_CONFIG_MAIN` |
+| `tests/safe/string.cpp` | Port `BOOST_*` macros to `REQUIRE`/`CHECK` |
+| `tests/safe/limited_vector.cpp` | Port `BOOST_*` macros to `REQUIRE`/`CHECK` |
+| `CMakeLists.txt:54` | Remove `(requires Boost)` from option text |
+
+---
+
+## PR 5 — Add Catch2 library, verify tests pass
+
+Land a copy of Catch2 (single-header or submodule) and run `ctest`.
+
+---
+
+## PR 6+ — Phase 2 (tooling) and Phase 3 (code modernization)
+
+Per PLAN.md as discussed — `.clang-format`, `.clang-tidy`, CI updates, incremental code modernizations.
+
+---
+
+## Reversibility
+
+Every PR is a self-contained commit that can be backed out if it breaks.
+
+---
+
+## Non-goals (for now)
+
+- Full ECS / data-oriented engine rewrite
+- Dropping MSVC or GCC support entirely
+- Rewriting the renderer backend
+- Changing the mod-loading ABI

--- a/README.md
+++ b/README.md
@@ -64,8 +64,20 @@ If you have the Mac App Store Version of Jedi Academy, follow these steps to get
 
 ### Building OpenJK
 
-- [Compilation guide](https://github.com/JACoders/OpenJK/wiki/Compilation-guide)
-- [Debugging guide](https://github.com/JACoders/OpenJK/wiki/Debugging)
+CMake 4.3+ is required.
+
+**Quick start (presets):**
+
+```bash
+cmake --preset windows-msvc-debug    # configure
+cmake --build --preset windows-msvc-debug -j 8   # build
+```
+
+Presets available: `windows-msvc-debug/release`, `linux-gcc-debug/release`, `linux-i686-debug`, `macos-clang-debug/release`.
+
+**Legacy workflow:**
+
+See the [Compilation guide](https://github.com/JACoders/OpenJK/wiki/Compilation-guide) and [Debugging guide](https://github.com/JACoders/OpenJK/wiki/Debugging) for platform-specific details.
 
 ### Contributing to OpenJK
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -387,14 +387,16 @@ if(BuildSPEngine OR BuildJK2SPEngine)
 			add_executable(${ProjectName} WIN32 ${SPEngineFiles})
 			if(UseInternalSDL2)
 				if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-					set(SPEngineExtraInstallFiles
-						${OpenJKLibDir}/SDL2/bin/x86/SDL2.dll
-						)
+					set(_sdl2_dll "${OpenJKLibDir}/SDL2/bin/x86/SDL2.dll")
 				else()
-					set(SPEngineExtraInstallFiles
-						${OpenJKLibDir}/SDL2/bin/x64/SDL2.dll
-						)
+					set(_sdl2_dll "${OpenJKLibDir}/SDL2/bin/x64/SDL2.dll")
 				endif()
+				set(SPEngineExtraInstallFiles "${_sdl2_dll}")
+				add_custom_command(TARGET ${ProjectName} POST_BUILD
+					COMMAND ${CMAKE_COMMAND} -E copy_if_different
+						"${_sdl2_dll}"
+						"$<TARGET_FILE_DIR:${ProjectName}>"
+					COMMENT "Copying SDL2.dll to ${ProjectName} output")
 			endif()
 		else(WIN32)
 			if(MakeApplicationBundles)
@@ -433,15 +435,15 @@ if(BuildSPEngine OR BuildJK2SPEngine)
 			endif()
 		endif(MakeApplicationBundles)
 
-		set_target_properties(${ProjectName} PROPERTIES COMPILE_DEFINITIONS "${SPEngineDefines}")
+		target_compile_definitions(${ProjectName} PRIVATE ${SPEngineDefines})
 
 		# Hide symbols not explicitly marked public.
 		set_property(TARGET ${ProjectName} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-		set_target_properties(${ProjectName} PROPERTIES INCLUDE_DIRECTORIES "${SPEngineIncludeDirectories}")
+		target_include_directories(${ProjectName} PRIVATE ${SPEngineIncludeDirectories})
 		set_target_properties(${ProjectName} PROPERTIES PROJECT_LABEL ${Label})
 		if(SPEngineLibraries)
-			target_link_libraries(${ProjectName} ${SPEngineLibraries})
+			target_link_libraries(${ProjectName} PRIVATE ${SPEngineLibraries})
 		endif(SPEngineLibraries)
 	endfunction(add_sp_project)
 	if(BuildSPEngine)

--- a/code/game/CMakeLists.txt
+++ b/code/game/CMakeLists.txt
@@ -402,10 +402,10 @@ else(WIN32)
 	endif()
 endif()
 
-set_target_properties(${SPGame} PROPERTIES COMPILE_DEFINITIONS "${SPGameDefines}")
-set_target_properties(${SPGame} PROPERTIES INCLUDE_DIRECTORIES "${SPGameIncludeDirectories}")
+target_compile_definitions(${SPGame} PRIVATE ${SPGameDefines})
+target_include_directories(${SPGame} PRIVATE ${SPGameIncludeDirectories})
 set_target_properties(${SPGame} PROPERTIES PROJECT_LABEL "SP Game Library")
 # no libraries used
 if(SPGameLibraries)
-	target_link_libraries(${SPGame} ${SPGameLibraries})
+	target_link_libraries(${SPGame} PRIVATE ${SPGameLibraries})
 endif(SPGameLibraries)

--- a/code/rd-vanilla/CMakeLists.txt
+++ b/code/rd-vanilla/CMakeLists.txt
@@ -181,15 +181,15 @@ if(BuildSPRdVanilla OR BuildJK2SPRdVanilla)
 			endif()
 		endif()
 
-		set_target_properties(${ProjectName} PROPERTIES COMPILE_DEFINITIONS "${SPRDVanillaDefines}")
+		target_compile_definitions(${ProjectName} PRIVATE ${SPRDVanillaDefines})
 
 		# Hide symbols not explicitly marked public.
 		set_property(TARGET ${ProjectName} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-		set_target_properties(${ProjectName} PROPERTIES INCLUDE_DIRECTORIES "${SPRDVanillaRendererIncludeDirectories}")
+		target_include_directories(${ProjectName} PRIVATE ${SPRDVanillaRendererIncludeDirectories})
 		set_target_properties(${ProjectName} PROPERTIES PROJECT_LABEL ${Label})
 
-		target_link_libraries(${ProjectName} ${SPRDVanillaRendererLibraries})
+		target_link_libraries(${ProjectName} PRIVATE ${SPRDVanillaRendererLibraries})
 	endfunction(add_sp_renderer_project)
 
 	if(BuildSPRdVanilla)

--- a/codeJK2/game/CMakeLists.txt
+++ b/codeJK2/game/CMakeLists.txt
@@ -301,14 +301,14 @@ else(WIN32)
 	endif(MakeApplicationBundles AND BuildJK2SPEngine)
 endif(WIN32)
 
-set_target_properties(${JK2SPGame} PROPERTIES COMPILE_DEFINITIONS "${JK2SPGameDefines}")
+target_compile_definitions(${JK2SPGame} PRIVATE ${JK2SPGameDefines})
 
 # Hide symbols not explicitly marked public.
 set_property(TARGET ${JK2SPGame} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-set_target_properties(${JK2SPGame} PROPERTIES INCLUDE_DIRECTORIES "${JK2SPGameIncludeDirectories}")
+target_include_directories(${JK2SPGame} PRIVATE ${JK2SPGameIncludeDirectories})
 set_target_properties(${JK2SPGame} PROPERTIES PROJECT_LABEL "JK2 SP Game Library")
 # no libraries used
 if(JK2SPGameLibraries)
-	target_link_libraries(${JK2SPGame} ${JK2SPGameLibraries})
+	target_link_libraries(${JK2SPGame} PRIVATE ${JK2SPGameLibraries})
 endif(JK2SPGameLibraries)

--- a/codemp/CMakeLists.txt
+++ b/codemp/CMakeLists.txt
@@ -166,8 +166,8 @@ if(BuildMPEngine OR BuildMPDed)
 	# Hide symbols not explicitly marked public.
 	set_property(TARGET ${MPBotLib} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-	set_target_properties(${MPBotLib} PROPERTIES COMPILE_DEFINITIONS "${MPBotlibDefines}")
-	set_target_properties(${MPBotLib} PROPERTIES INCLUDE_DIRECTORIES "${MPBotlibIncludeDirectories}")
+	target_compile_definitions(${MPBotLib} PRIVATE ${MPBotlibDefines})
+	target_include_directories(${MPBotLib} PRIVATE ${MPBotlibIncludeDirectories})
 	set_target_properties(${MPBotLib} PROPERTIES PROJECT_LABEL "Bot Library")
 
 	#    Common files/libraries/defines of both Engine and Dedicated Server
@@ -569,14 +569,16 @@ if(BuildMPEngine)
 		add_executable(${MPEngine} WIN32 ${MPEngineFiles})
 		if(UseInternalSDL2)
 			if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-				set(MPEngineExtraInstallFiles
-					${OpenJKLibDir}/SDL2/bin/x86/SDL2.dll
-					)
+				set(_sdl2_dll "${OpenJKLibDir}/SDL2/bin/x86/SDL2.dll")
 			else()
-				set(MPEngineExtraInstallFiles
-					${OpenJKLibDir}/SDL2/bin/x64/SDL2.dll
-					)
+				set(_sdl2_dll "${OpenJKLibDir}/SDL2/bin/x64/SDL2.dll")
 			endif()
+			set(MPEngineExtraInstallFiles "${_sdl2_dll}")
+			add_custom_command(TARGET ${MPEngine} POST_BUILD
+				COMMAND ${CMAKE_COMMAND} -E copy_if_different
+					"${_sdl2_dll}"
+					"$<TARGET_FILE_DIR:${MPEngine}>"
+				COMMENT "Copying SDL2.dll to ${MPEngine} output")
 		endif()
 	else(WIN32)
 		if(MakeApplicationBundles)
@@ -610,14 +612,14 @@ if(BuildMPEngine)
 		endif()
 	endif(MakeApplicationBundles)
 
-	set_target_properties(${MPEngine} PROPERTIES COMPILE_DEFINITIONS "${MPEngineDefines}")
+	target_compile_definitions(${MPEngine} PRIVATE ${MPEngineDefines})
 
 	# Hide symbols not explicitly marked public.
 	set_property(TARGET ${MPEngine} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-	set_target_properties(${MPEngine} PROPERTIES INCLUDE_DIRECTORIES "${MPEngineIncludeDirectories}")
+	target_include_directories(${MPEngine} PRIVATE ${MPEngineIncludeDirectories})
 	set_target_properties(${MPEngine} PROPERTIES PROJECT_LABEL "MP Client")
-	target_link_libraries(${MPEngine} ${MPEngineLibraries})
+	target_link_libraries(${MPEngine} PRIVATE ${MPEngineLibraries})
 endif(BuildMPEngine)
 
 #        Dedicated Server (Engine) (jampded.exe)
@@ -702,12 +704,12 @@ if(BuildMPDed)
 		DESTINATION ${JKAInstallDir}
 		COMPONENT ${JKAMPServerComponent})
 
-	set_target_properties(${MPDed} PROPERTIES COMPILE_DEFINITIONS "${MPDedDefines}")
+	target_compile_definitions(${MPDed} PRIVATE ${MPDedDefines})
 
 	# Hide symbols not explicitly marked public.
 	set_property(TARGET ${MPDed} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-	set_target_properties(${MPDed} PROPERTIES INCLUDE_DIRECTORIES "${MPDedIncludeDirectories}")
+	target_include_directories(${MPDed} PRIVATE ${MPDedIncludeDirectories})
 	set_target_properties(${MPDed} PROPERTIES PROJECT_LABEL "MP Dedicated Server")
-	target_link_libraries(${MPDed} ${MPDedLibraries})
+	target_link_libraries(${MPDed} PRIVATE ${MPDedLibraries})
 endif(BuildMPDed)

--- a/codemp/cgame/CMakeLists.txt
+++ b/codemp/cgame/CMakeLists.txt
@@ -178,14 +178,14 @@ else()
 		COMPONENT ${JKAMPCoreComponent})
 endif()
 
-set_target_properties(${MPCGame} PROPERTIES COMPILE_DEFINITIONS "${MPCGameDefines}")
+target_compile_definitions(${MPCGame} PRIVATE ${MPCGameDefines})
 
 # Hide symbols not explicitly marked public.
 set_property(TARGET ${MPCGame} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-set_target_properties(${MPCGame} PROPERTIES INCLUDE_DIRECTORIES "${MPCGameIncludeDirectories}")
+target_include_directories(${MPCGame} PRIVATE ${MPCGameIncludeDirectories})
 set_target_properties(${MPCGame} PROPERTIES PROJECT_LABEL "MP Client Game Library")
 # no libraries used
 if(MPCGameLibraries)
-	target_link_libraries(${MPCGame} ${MPCGameLibraries})
+	target_link_libraries(${MPCGame} PRIVATE ${MPCGameLibraries})
 endif(MPCGameLibraries)

--- a/codemp/game/CMakeLists.txt
+++ b/codemp/game/CMakeLists.txt
@@ -246,14 +246,14 @@ else()
 		COMPONENT ${JKAMPCoreComponent})
 endif()
 
-set_target_properties(${MPGame} PROPERTIES COMPILE_DEFINITIONS "${MPGameDefines}")
+target_compile_definitions(${MPGame} PRIVATE ${MPGameDefines})
 
 # Hide symbols not explicitly marked public.
 set_property(TARGET ${MPGame} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-set_target_properties(${MPGame} PROPERTIES INCLUDE_DIRECTORIES "${MPGameIncludeDirectories}")
+target_include_directories(${MPGame} PRIVATE ${MPGameIncludeDirectories})
 set_target_properties(${MPGame} PROPERTIES PROJECT_LABEL "MP Game Library")
 # no libraries used
 if(MPGameLibraries)
-	target_link_libraries(${MPGame} ${MPGameLibraries})
+	target_link_libraries(${MPGame} PRIVATE ${MPGameLibraries})
 endif(MPGameLibraries)

--- a/codemp/rd-rend2/CMakeLists.txt
+++ b/codemp/rd-rend2/CMakeLists.txt
@@ -173,13 +173,13 @@ else(WIN32)
 	endif()
 endif()
 
-set_target_properties(${MPRend2} PROPERTIES COMPILE_DEFINITIONS "${SharedDefines}")
+target_compile_definitions(${MPRend2} PRIVATE ${SharedDefines})
 
 # Hide symbols not explicitly marked public.
 set_property(TARGET ${MPRend2} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
-set_target_properties(${MPRend2} PROPERTIES INCLUDE_DIRECTORIES "${MPRend2IncludeDirectories}")
+target_include_directories(${MPRend2} PRIVATE ${MPRend2IncludeDirectories})
 set_target_properties(${MPRend2} PROPERTIES PROJECT_LABEL "MP Rend2 Renderer")
-target_link_libraries(${MPRend2} ${MPRend2Libraries})
+target_link_libraries(${MPRend2} PRIVATE ${MPRend2Libraries})
 target_include_directories(${MPRend2} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # GLSL shader file generator

--- a/codemp/rd-vanilla/CMakeLists.txt
+++ b/codemp/rd-vanilla/CMakeLists.txt
@@ -158,11 +158,11 @@ else(WIN32)
 	endif()
 endif()
 
-set_target_properties(${MPVanillaRenderer} PROPERTIES COMPILE_DEFINITIONS "${SharedDefines}")
+target_compile_definitions(${MPVanillaRenderer} PRIVATE ${SharedDefines})
 
 # Hide symbols not explicitly marked public.
 set_property(TARGET ${MPVanillaRenderer} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-set_target_properties(${MPVanillaRenderer} PROPERTIES INCLUDE_DIRECTORIES "${MPVanillaRendererIncludeDirectories}")
+target_include_directories(${MPVanillaRenderer} PRIVATE ${MPVanillaRendererIncludeDirectories})
 set_target_properties(${MPVanillaRenderer} PROPERTIES PROJECT_LABEL "MP Vanilla Renderer")
-target_link_libraries(${MPVanillaRenderer} ${MPVanillaRendererLibraries})
+target_link_libraries(${MPVanillaRenderer} PRIVATE ${MPVanillaRendererLibraries})

--- a/codemp/ui/CMakeLists.txt
+++ b/codemp/ui/CMakeLists.txt
@@ -131,14 +131,14 @@ else()
 		COMPONENT ${JKAMPCoreComponent})
 endif()
 
-set_target_properties(${MPUI} PROPERTIES COMPILE_DEFINITIONS "${MPUIDefines}")
+target_compile_definitions(${MPUI} PRIVATE ${MPUIDefines})
 
 # Hide symbols not explicitly marked public.
 set_property(TARGET ${MPUI} APPEND PROPERTY COMPILE_OPTIONS ${OPENJK_VISIBILITY_FLAGS})
 
-set_target_properties(${MPUI} PROPERTIES INCLUDE_DIRECTORIES "${MPUIIncludeDirectories}")
+target_include_directories(${MPUI} PRIVATE ${MPUIIncludeDirectories})
 set_target_properties(${MPUI} PROPERTIES PROJECT_LABEL "MP UI Library")
 # no libraries used
 if(MPUILibraries)
-	target_link_libraries(${MPUI} ${MPUILibraries})
+	target_link_libraries(${MPUI} PRIVATE ${MPUILibraries})
 endif(MPUILibraries)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,10 +52,10 @@ set(TestIncludeDirectories
 set(TestDefines "${SharedDefines}")
 
 add_executable(${TestTarget} ${TestFiles})
-set_target_properties(${TestTarget} PROPERTIES COMPILE_DEFINITIONS "${TestDefines}")
-set_target_properties(${TestTarget} PROPERTIES INCLUDE_DIRECTORIES "${TestIncludeDirectories}")
+target_compile_definitions(${TestTarget} PRIVATE ${TestDefines})
+target_include_directories(${TestTarget} PRIVATE ${TestIncludeDirectories})
 set_target_properties(${TestTarget} PROPERTIES PROJECT_LABEL "Unit Tests")
-target_link_libraries(${TestTarget} ${TestLibraries})
+target_link_libraries(${TestTarget} PRIVATE ${TestLibraries})
 install(TARGETS ${TestTarget} DESTINATION ".")
 
 if(NOT MSVC)

--- a/tools/WinSymbol/CMakeLists.txt
+++ b/tools/WinSymbol/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 #============================================================================
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 4.3)
 
 add_executable(GetExeSymbolDir get_exe_dir.cpp)
 target_link_libraries(GetExeSymbolDir Dbghelp)


### PR DESCRIPTION
## Summary

Modernizes the CMake build system without changing any game logic.

### Changes

- **CMake minimum**: bumped from 3.1 to 4.3
- **Modern target commands**: replaced legacy set_target_properties(COMPILE_DEFINITIONS/INCLUDE_DIRECTORIES) with 	arget_compile_definitions / 	arget_include_directories
- **Link visibility**: added PRIVATE to all 	arget_link_libraries calls
- **Definitions**: replaced dd_definitions with dd_compile_definitions
- **SDL2 runtime**: copy SDL2.dll to build output via POST_BUILD command (previously only happened on cmake --install)
- **Presets**: added CMakePresets.json with common configurations for Windows, Linux, and macOS
- **Docs**: updated README.md and added AGENTS.md with preset-based workflow

### Testing

- [x] Configure + build passes on Windows MSVC (Visual Studio 2026, x64)
- [x] All binaries produced: openjk_sp, openjo_sp, openjk, openjkded, game DLLs, renderers
- [x] SDL2.dll copied automatically to build output
- [x] Game launches successfully with assets