### PR TITLE
[SP] Fix animation events not playing for certain npc variants

### DIFF
--- a/code/cgame/cg_main.cpp
+++ b/code/cgame/cg_main.cpp
@@ -35,7 +35,7 @@ typedef	std::map< sstring_t, unsigned char  >	namePrecache_m;
 extern namePrecache_m	*as_preCacheMap;
 extern void CG_RegisterNPCCustomSounds( clientInfo_t *ci );
 extern qboolean G_AddSexToMunroString ( char *string, qboolean qDoBoth );
-extern int G_ParseAnimFileSet( const char *skeletonName, const char *modelName=0);
+extern int G_ParseAnimFileSet( const char *skeletonName, const char *modelName=0, const char *npcType=0);
 extern void CG_DrawDataPadInventorySelect( void );
 
 void CG_Init( int serverCommandSequence );

--- a/code/game/NPC.cpp
+++ b/code/game/NPC.cpp
@@ -2579,7 +2579,7 @@ void NPC_InitAnimTable( void )
 	}
 }
 
-extern int G_ParseAnimFileSet( const char *skeletonName, const char *modelName=0);
+extern int G_ParseAnimFileSet( const char *skeletonName, const char *modelName=0, const char *npcType=0);
 void NPC_InitGame( void )
 {
 //	globals.NPCs = (gNPC_t *) gi.TagMalloc(game.maxclients * sizeof(game.bots[0]), TAG_GAME);

--- a/code/game/NPC_stats.cpp
+++ b/code/game/NPC_stats.cpp
@@ -790,7 +790,7 @@ This file's presence is not required
 ======================
 */
 static
-void G_ParseAnimationEvtFile(int glaIndex, const char* eventsDirectory, int fileIndex, int iRealGLAIndex = -1, bool modelSpecific = false)
+void G_ParseAnimationEvtFile(int glaIndex, const char* eventsDirectory, int fileIndex, int iRealGLAIndex = -1, bool modelSpecific = false, const char* npcType=0)
 {
 	int				len;
 	const char*		token;
@@ -837,7 +837,7 @@ void G_ParseAnimationEvtFile(int glaIndex, const char* eventsDirectory, int file
 
 	if (modelSpecific)
 	{
-		hstring		modelName(eventsDirectory);
+		hstring		modelName(!npcType ? eventsDirectory : npcType);
 		modelIndex = modelName.handle();
 	}
 
@@ -1037,7 +1037,7 @@ qboolean G_ParseAnimationFile(int glaIndex, const char *skeletonName, int fileIn
 // the animation event file.
 //
 ////////////////////////////////////////////////////////////////////////
-int		G_ParseAnimFileSet(const char *skeletonName, const char *modelName=0)
+int		G_ParseAnimFileSet(const char *skeletonName, const char *modelName=0, const char *npcType=0)
 {
 	int			fileIndex=0;
 
@@ -1161,10 +1161,18 @@ int		G_ParseAnimFileSet(const char *skeletonName, const char *modelName=0)
 	//--------------------------------------
 	if (modelName)
 	{
+		char		npcTypeLwr[MAX_QPATH];
+
+		if (npcType)
+		{
+			Q_strncpyz(npcTypeLwr, npcType, sizeof(npcTypeLwr));
+			Q_strlwr(npcTypeLwr);
+		}
+
 		// Quick Search To See If We've Already Loaded This Model
 		//--------------------------------------------------------
 		int			curModel=0;
-		hstring		curModelName(modelName);
+		hstring		curModelName(!npcTypeLwr ? modelName : npcTypeLwr);
 		while (curModel<MAX_MODELS_PER_LEVEL && !modelsAlreadyDone[curModel].empty())
 		{
 			if (modelsAlreadyDone[curModel]==curModelName)
@@ -1189,7 +1197,7 @@ int		G_ParseAnimFileSet(const char *skeletonName, const char *modelName=0)
 		{
 			const int iGLAIndexToCheckForSkip = (Q_stricmp(skeletonName, "_humanoid")?-1:gi.G2API_PrecacheGhoul2Model("models/players/_humanoid/_humanoid.gla")); // ;-)
 
-			G_ParseAnimationEvtFile(0, modelName, fileIndex, iGLAIndexToCheckForSkip, true);
+			G_ParseAnimationEvtFile(0, modelName, fileIndex, iGLAIndexToCheckForSkip, true, npcTypeLwr);
 		}
 	}
 
@@ -1197,7 +1205,7 @@ int		G_ParseAnimFileSet(const char *skeletonName, const char *modelName=0)
 }
 
 extern cvar_t	*g_char_model;
-void G_LoadAnimFileSet( gentity_t *ent, const char *pModelName )
+void G_LoadAnimFileSet( gentity_t *ent, const char *pModelName, const char *npcType=0 )
 {
 //load its animation config
 	char	animName[MAX_QPATH];
@@ -1237,7 +1245,7 @@ void G_LoadAnimFileSet( gentity_t *ent, const char *pModelName )
 	}
 
 	//now load and parse the animation.cfg, animevents.cfg and set the animFileIndex
-	ent->client->clientInfo.animFileIndex = G_ParseAnimFileSet(strippedName, modelName);
+	ent->client->clientInfo.animFileIndex = G_ParseAnimFileSet(strippedName, modelName, npcType);
 
 	if (ent->client->clientInfo.animFileIndex<0)
 	{
@@ -1353,7 +1361,7 @@ void NPC_PrecacheAnimationCFG( const char *NPC_type )
 					//must copy data out of this pointer into a different part of memory because the funcs we're about to call will call COM_ParseExt
 					Q_strncpyz( filename, value, sizeof( filename ) );
 
-					G_ParseAnimFileSet(strippedName, filename);
+					G_ParseAnimFileSet(strippedName, filename, NPC_type);
 					COM_EndParseSession(  );
 					return;
 				}

--- a/code/game/g_client.cpp
+++ b/code/game/g_client.cpp
@@ -1111,7 +1111,7 @@ void G_BoneOrientationsForClass( int NPC_class, const char *boneName, Eorientati
 	}
 }
 
-extern void G_LoadAnimFileSet( gentity_t *ent, const char *modelName );
+extern void G_LoadAnimFileSet( gentity_t *ent, const char *modelName, const char *npcType=0 );
 qboolean G_SetG2PlayerModelInfo( gentity_t *ent, const char *modelName, const char *customSkin, const char *surfOff, const char *surfOn )
 {
 	if ( ent->playerModel != -1 )
@@ -1159,7 +1159,7 @@ qboolean G_SetG2PlayerModelInfo( gentity_t *ent, const char *modelName, const ch
 			gi.G2API_SetSurfaceOnOff( &ent->ghoul2[ent->playerModel], "l_arm_key", 0 );
 		}
 
-		G_LoadAnimFileSet( ent, modelName );
+		G_LoadAnimFileSet( ent, modelName, ent->NPC_type );
 
 		ent->headBolt = ent->cervicalBolt = ent->torsoBolt = ent->gutBolt = ent->chestBolt =
 			ent->crotchBolt = ent->elbowLBolt = ent->elbowRBolt = ent->handLBolt =

--- a/code/game/g_misc_model.cpp
+++ b/code/game/g_misc_model.cpp
@@ -151,7 +151,7 @@ void CrystalAmmoSettings(gentity_t *ent)
 */
 //------------------------------------------------------------
 #include "anims.h"
-extern int G_ParseAnimFileSet( const char *skeletonName, const char *modelName=0);
+extern int G_ParseAnimFileSet( const char *skeletonName, const char *modelName=0, const char *npcType=0);
 int temp_animFileIndex;
 void set_MiscAnim( gentity_t *ent)
 {


### PR DESCRIPTION
The original code works off the assumption that `NPC_type` will always match the `playerModel`. This is okay for most cases, but obviously doesn't work for the stormtrooper variants (e.g. `NPC_type` `stormtrooper2` does not match `playerModel` `stormtrooper`). Because of this, the variants do not get stormtrooper `animevents` applied to them. Passing along the `NPC_type` to `G_ParseAnimationEvtFile` to record as the `modelIndex` fixes this (`NPC_type.handle()` will then correctly equal the `modelOnly` short).

PR #1310 does not fix the issue, and in fact breaks the `animevents` for the non-variant `stormtrooper`.

Fixes #1287