### PR TITLE
[SP/MP] Fix mangling of non-dynamic background music file path from pointer overlap

### DIFF
--- a/code/client/snd_dma.cpp
+++ b/code/client/snd_dma.cpp
@@ -4085,7 +4085,12 @@ static qboolean S_StartBackgroundTrack_Actual( MusicInfo_t *pMusicInfo, qboolean
 	char	dump[16];
 	char	name[MAX_QPATH];
 
-	Q_strncpyz( sMusic_BackgroundLoop, loop, sizeof( sMusic_BackgroundLoop ));
+	char	*bgLoop = sMusic_BackgroundLoop;
+
+	if ( bgLoop != loop )
+	{// don't copy into yourself
+		Q_strncpyz( sMusic_BackgroundLoop, loop, sizeof( sMusic_BackgroundLoop ));
+	}
 
 	Q_strncpyz( name, intro, sizeof( name ) - 4 );	// this seems to be so that if the filename hasn't got an extension
 													//	but doesn't have the room to append on either then you'll just

--- a/codemp/client/snd_dma.cpp
+++ b/codemp/client/snd_dma.cpp
@@ -4093,7 +4093,12 @@ static qboolean S_StartBackgroundTrack_Actual( MusicInfo_t *pMusicInfo, qboolean
 	char	dump[16];
 	char	name[MAX_QPATH];
 
-	Q_strncpyz( sMusic_BackgroundLoop, loop, sizeof( sMusic_BackgroundLoop ));
+	char	*bgLoop = sMusic_BackgroundLoop;
+
+	if ( bgLoop != loop )
+	{// don't copy into yourself
+		Q_strncpyz( sMusic_BackgroundLoop, loop, sizeof( sMusic_BackgroundLoop ));
+	}
 
 	Q_strncpyz( name, intro, sizeof( name ) - 4 );	// this seems to be so that if the filename hasn't got an extension
 													//	but doesn't have the room to append on either then you'll just


### PR DESCRIPTION
Non-dynamic background music (such as in JO's `yavin_temple` map) is unable to loop after playing once due to file path mangling.

`sMusic_BackgroundLoop` is passed to `S_StartBackgroundTrack_Actual` as argument `loop` (fourth arg) here (line 4815):
https://github.com/JACoders/OpenJK/blob/8cce3ea23125f56200b553cd0b149af617adf397/code/client/snd_dma.cpp#L4813-L4816

This causes a pointer overlap (`sMusic_BackgroundLoop` and `loop` point to the same memory address) in `Q_Strncpyz` in `S_StartBackgroundTrack_Actual` here (line 4088):
https://github.com/JACoders/OpenJK/blob/8cce3ea23125f56200b553cd0b149af617adf397/code/client/snd_dma.cpp#L4082-L4088

This mangles the path and prevents the music file from being looped (as it can't be found). Adding a pointer comparison stops the overlap operation from mangling the path.