### PR TITLE
Fix portable build crash log

### DIFF
--- a/shared/sys/sys_main.cpp
+++ b/shared/sys/sys_main.cpp
@@ -196,11 +196,13 @@ static void Sys_ErrorDialog( const char *error )
 
 	time( &rawtime );
 	strftime( timeStr, sizeof( timeStr ), "%Y-%m-%d_%H-%M-%S", localtime( &rawtime ) ); // or gmtime
+	const char *homePath = Sys_DefaultHomePath();
+	const char *logPath = ( homePath && homePath[0] ) ? homePath : Sys_DefaultInstallPath();
 	Com_sprintf( crashLogPath, sizeof( crashLogPath ),
 					"%s%ccrashlog-%s.txt",
-					Sys_DefaultHomePath(), PATH_SEP, timeStr );
+					logPath, PATH_SEP, timeStr );
 
-	Sys_Mkdir( Sys_DefaultHomePath() );
+	Sys_Mkdir( logPath );
 
 	FILE *fp = fopen( crashLogPath, "w" );
 	if ( fp )


### PR DESCRIPTION
Sys_DefaultHomePath() returns NULL on portable builds, causing logfiles to have an invalid path previously. Sys_ErrorDialog passed that straight into Com_sprintf("%s") and Sys_Mkdir without a check, which is undefined behaviour.

Fall back to the install path (Sys_DefaultInstallPath) when homepath is unavailable, mirroring the homepath/basepath fallback the FS already uses for fs_homepath.