### PR TITLE
Patched performance bug in quickload behaviour

### DIFF
--- a/codeJK2/cgame/cg_main.cpp
+++ b/codeJK2/cgame/cg_main.cpp
@@ -752,7 +752,7 @@ static void CG_RegisterSounds( void ) {
 		if ( soundName[0] == '*' ) {
 			continue;	// custom sound
 		}
-		if (i&31) {
+		if ((i & 31) == 0 ) {
 			CG_LoadingString( soundName );
 		}
 		cgs.sound_precache[i] = cgi_S_RegisterSound( soundName );


### PR DESCRIPTION
This fixes what appears to be a quickload performance bug in Jedi Outcast single player.

During JK2 SP sound precache, the loading screen text was updated for nearly every sound entry :

```cpp
if (i&31) {
    CG_LoadingString( soundName );
}
```

I believe this was just a long standing bug as the Jedi Academy code has similar code but it is written like so.

```cpp
if (!(i&7)) {
      CG_LoadingString( soundName );
}
```


In my local testing, it resulted in a **20-25%** reduction in quickload times and **2-5%** for cold loads.