### PR TITLE
Fix bundle SDL2 for macOS releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
           if [ "${{ matrix.portable }}" == "Portable" ]; then
             OPTIONS+=" -DUseInternalLibs=ON -DBuildPortableVersion=ON"
           else
-            OPTIONS+=" -DUseInternalLibs=ON -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DUseInternalLibs=OFF -DUseInternalSDL2=ON -DBuildPortableVersion=OFF"
           fi
           OPTIONS+=" -DBuildJK2SPEngine=ON -DBuildJK2SPGame=ON -DBuildJK2SPRdVanilla=ON"
           cmake $GITHUB_WORKSPACE $OPTIONS

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Create Build Environment
         run: |
-          brew install zlib libjpeg libpng sdl2
+          brew install zlib libjpeg libpng sdl2-compat sdl3
           cmake -E make_directory ${{ github.workspace }}/build
 
       - name: Configure CMake
@@ -242,6 +242,58 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         shell: bash
         run: cmake --install .
+
+      - name: Bundle SDL runtime
+        if: ${{ matrix.build_type == 'Release' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SDL3_DYLIB="$(brew --prefix sdl3)/lib/libSDL3.dylib"
+
+          if [ ! -f "$SDL3_DYLIB" ]; then
+            echo "SDL3 library not found: $SDL3_DYLIB"
+            exit 1
+          fi
+
+          find "${{ github.workspace }}/install" -type d -name "*.app" -print0 |
+          while IFS= read -r -d '' APP; do
+            FRAMEWORKS="$APP/Contents/Frameworks"
+
+            echo "Bundling SDL3 into: $APP"
+
+            mkdir -p "$FRAMEWORKS"
+            cp -L "$SDL3_DYLIB" "$FRAMEWORKS/libSDL3.dylib"
+
+            codesign --force --deep --sign - "$APP"
+          done
+
+      - name: Verify SDL runtime
+        if: ${{ matrix.build_type == 'Release' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          find "${{ github.workspace }}/install" -type d -name "*.app" -print0 |
+          while IFS= read -r -d '' APP; do
+            FRAMEWORKS="$APP/Contents/Frameworks"
+
+            echo "Checking: $APP"
+
+            test -f "$FRAMEWORKS/libSDL2-2.0.0.dylib"
+            test -f "$FRAMEWORKS/libSDL3.dylib"
+
+            file "$FRAMEWORKS/libSDL2-2.0.0.dylib"
+            file "$FRAMEWORKS/libSDL3.dylib"
+
+            echo "SDL2:"
+            otool -L "$FRAMEWORKS/libSDL2-2.0.0.dylib"
+
+            echo "SDL3:"
+            otool -L "$FRAMEWORKS/libSDL3.dylib"
+
+            codesign --verify --deep --strict "$APP"
+          done
 
       - name: Create OpenJK binary archive
         if: ${{ matrix.build_type == 'Release' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,19 +215,53 @@ jobs:
           fetch-tags: true
 
       - name: Create Build Environment
+        shell: bash
         run: |
-          brew install zlib libjpeg libpng
+          set -euo pipefail
+
+          brew install libjpeg libpng
+
           cmake -E make_directory "${{ github.workspace }}/build"
+          cmake -E make_directory "${{ github.workspace }}/sdl-build"
+          cmake -E make_directory "${{ github.workspace }}/sdl-prefix"
+
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            SDL_DEPLOYMENT_TARGET="11.0"
+          else
+            SDL_DEPLOYMENT_TARGET="10.9"
+          fi
+
+          git clone \
+            --branch release-2.32.10 \
+            --depth 1 \
+            https://github.com/libsdl-org/SDL.git \
+            "${{ github.workspace }}/SDL2-source"
+
+          cmake \
+            -S "${{ github.workspace }}/SDL2-source" \
+            -B "${{ github.workspace }}/sdl-build" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/sdl-prefix" \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET="$SDL_DEPLOYMENT_TARGET" \
+            -DSDL_SHARED=ON \
+            -DSDL_STATIC=OFF \
+            -DSDL_TEST=OFF
+
+          cmake --build "${{ github.workspace }}/sdl-build" \
+            --parallel "$(sysctl -n hw.logicalcpu)"
+
+          cmake --install "${{ github.workspace }}/sdl-build"
 
       - name: Configure CMake
         shell: bash
         working-directory: ${{ github.workspace }}/build
         run: |
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
+          OPTIONS+=" -DCMAKE_PREFIX_PATH=${{ github.workspace }}/sdl-prefix"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DUseInternalLibs=ON -DBuildPortableVersion=ON"
+            OPTIONS+=" -DUseInternalLibs=ON -DUseInternalSDL2=OFF -DBuildPortableVersion=ON"
           else
-            OPTIONS+=" -DUseInternalLibs=OFF -DUseInternalSDL2=ON -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DUseInternalLibs=OFF -DUseInternalSDL2=OFF -DBuildPortableVersion=OFF"
           fi
           OPTIONS+=" -DBuildJK2SPEngine=ON -DBuildJK2SPGame=ON -DBuildJK2SPRdVanilla=ON"
           cmake $GITHUB_WORKSPACE $OPTIONS
@@ -242,6 +276,22 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         shell: bash
         run: cmake --install .
+
+      - name: Verify macOS dependencies
+        if: ${{ matrix.build_type == 'Release' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          find "${{ github.workspace }}/install" -name '*.app' -type d -print
+
+          find "${{ github.workspace }}/install" -type f -perm +111 -print0 |
+            while IFS= read -r -d '' binary; do
+              if file "$binary" | grep -q 'Mach-O'; then
+                echo "Dependencies for $binary:"
+                otool -L "$binary"
+              fi
+            done
 
       - name: Create OpenJK binary archive
         if: ${{ matrix.build_type == 'Release' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,41 +216,78 @@ jobs:
 
       - name: Create Build Environment
         shell: bash
+        env:
+          SDL2_VERSION: "2.32.10"
         run: |
           set -euo pipefail
 
           brew install libjpeg libpng
 
-          cmake -E make_directory "${{ github.workspace }}/build"
-          cmake -E make_directory "${{ github.workspace }}/sdl-build"
-          cmake -E make_directory "${{ github.workspace }}/sdl-prefix"
+          BUILD_DIR="${{ github.workspace }}/build"
+          SDL_PREFIX="${{ github.workspace }}/sdl-prefix"
+          SDL_DMG="${{ runner.temp }}/SDL2-${SDL2_VERSION}.dmg"
+          SDL_MOUNT="${{ runner.temp }}/SDL2-${SDL2_VERSION}"
 
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            SDL_DEPLOYMENT_TARGET="11.0"
-          else
-            SDL_DEPLOYMENT_TARGET="10.9"
-          fi
+          cmake -E make_directory "$BUILD_DIR"
+          cmake -E make_directory "$SDL_PREFIX/include/SDL2"
+          cmake -E make_directory "$SDL_PREFIX/lib"
+          cmake -E make_directory "$SDL_MOUNT"
 
-          git clone \
-            --branch release-2.32.10 \
-            --depth 1 \
-            https://github.com/libsdl-org/SDL.git \
-            "${{ github.workspace }}/SDL2-source"
+          echo "Downloading official SDL2 ${SDL2_VERSION} framework..."
+          curl --fail --location --show-error \
+            "https://www.libsdl.org/release/SDL2-${SDL2_VERSION}.dmg" \
+            --output "$SDL_DMG"
 
-          cmake \
-            -S "${{ github.workspace }}/SDL2-source" \
-            -B "${{ github.workspace }}/sdl-build" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/sdl-prefix" \
-            -DCMAKE_OSX_DEPLOYMENT_TARGET="$SDL_DEPLOYMENT_TARGET" \
-            -DSDL_SHARED=ON \
-            -DSDL_STATIC=OFF \
-            -DSDL_TEST=OFF
+          cleanup() {
+            hdiutil detach "$SDL_MOUNT" -quiet 2>/dev/null || true
+          }
+          trap cleanup EXIT
 
-          cmake --build "${{ github.workspace }}/sdl-build" \
-            --parallel "$(sysctl -n hw.logicalcpu)"
+          hdiutil attach "$SDL_DMG" \
+            -mountpoint "$SDL_MOUNT" \
+            -nobrowse \
+            -readonly \
+            -quiet
 
-          cmake --install "${{ github.workspace }}/sdl-build"
+          SDL_FRAMEWORK="$SDL_MOUNT/SDL2.framework"
+          SDL_FRAMEWORK_BINARY="$SDL_FRAMEWORK/Versions/A/SDL2"
+
+          test -d "$SDL_FRAMEWORK"
+          test -f "$SDL_FRAMEWORK_BINARY"
+          test -d "$SDL_FRAMEWORK/Headers"
+
+          echo "Official SDL framework architectures:"
+          lipo -archs "$SDL_FRAMEWORK_BINARY"
+
+          lipo -verify_arch x86_64 arm64 "$SDL_FRAMEWORK_BINARY"
+
+          echo "Extracting the ${{ matrix.arch }} SDL2 library..."
+          lipo "$SDL_FRAMEWORK_BINARY" \
+            -thin "${{ matrix.arch }}" \
+            -output "$SDL_PREFIX/lib/libSDL2-2.0.0.dylib"
+
+          cp -R "$SDL_FRAMEWORK/Headers/." "$SDL_PREFIX/include/SDL2/"
+
+          install_name_tool \
+            -id "@rpath/libSDL2-2.0.0.dylib" \
+            "$SDL_PREFIX/lib/libSDL2-2.0.0.dylib"
+
+          ln -s "libSDL2-2.0.0.dylib" \
+            "$SDL_PREFIX/lib/libSDL2-2.0.dylib"
+
+          ln -s "libSDL2-2.0.0.dylib" \
+            "$SDL_PREFIX/lib/libSDL2.dylib"
+
+          codesign --force --sign - \
+            "$SDL_PREFIX/lib/libSDL2-2.0.0.dylib"
+
+          echo "Prepared SDL2 library:"
+          file "$SDL_PREFIX/lib/libSDL2-2.0.0.dylib"
+          lipo -archs "$SDL_PREFIX/lib/libSDL2-2.0.0.dylib"
+          otool -D "$SDL_PREFIX/lib/libSDL2-2.0.0.dylib"
+
+          cleanup
+          trap - EXIT
 
       - name: Configure CMake
         shell: bash
@@ -283,15 +320,46 @@ jobs:
         run: |
           set -euo pipefail
 
-          find "${{ github.workspace }}/install" -name '*.app' -type d -print
+          APP_LIST="${{ runner.temp }}/openjk-apps.txt"
 
-          find "${{ github.workspace }}/install" -type f -perm +111 -print0 |
-            while IFS= read -r -d '' binary; do
-              if file "$binary" | grep -q 'Mach-O'; then
-                echo "Dependencies for $binary:"
-                otool -L "$binary"
+          find "${{ github.workspace }}/install" \
+            -type d \
+            -name '*.app' \
+            -print > "$APP_LIST"
+
+          if [ ! -s "$APP_LIST" ]; then
+            echo "No macOS app bundles were found"
+            exit 1
+          fi
+
+          while IFS= read -r APP; do
+            FRAMEWORKS="$APP/Contents/Frameworks"
+            SDL_DYLIB="$FRAMEWORKS/libSDL2-2.0.0.dylib"
+
+            echo "Checking $APP"
+
+            test -f "$SDL_DYLIB"
+            lipo -verify_arch "${{ matrix.arch }}" "$SDL_DYLIB"
+
+            file "$SDL_DYLIB"
+            otool -D "$SDL_DYLIB"
+
+            find "$APP/Contents/MacOS" -type f -print0 |
+            while IFS= read -r -d '' BINARY; do
+              if file "$BINARY" | grep -q 'Mach-O'; then
+                echo "Dependencies for $BINARY:"
+                otool -L "$BINARY"
+
+                if otool -L "$BINARY" |
+                  grep -E '/opt/homebrew|/usr/local|/Users/runner|sdl-prefix'; then
+                  echo "Found a non-portable dependency in $BINARY"
+                  exit 1
+                fi
               fi
             done
+
+            codesign --verify --deep --strict "$APP"
+          done < "$APP_LIST"
 
       - name: Create OpenJK binary archive
         if: ${{ matrix.build_type == 'Release' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,8 +216,8 @@ jobs:
 
       - name: Create Build Environment
         run: |
-          brew install zlib libjpeg libpng sdl2-compat sdl3
-          cmake -E make_directory ${{ github.workspace }}/build
+          brew install zlib libjpeg libpng
+          cmake -E make_directory "${{ github.workspace }}/build"
 
       - name: Configure CMake
         shell: bash
@@ -227,7 +227,7 @@ jobs:
           if [ "${{ matrix.portable }}" == "Portable" ]; then
             OPTIONS+=" -DUseInternalLibs=ON -DBuildPortableVersion=ON"
           else
-            OPTIONS+=" -DUseInternalLibs=OFF -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DUseInternalLibs=ON -DBuildPortableVersion=OFF"
           fi
           OPTIONS+=" -DBuildJK2SPEngine=ON -DBuildJK2SPGame=ON -DBuildJK2SPRdVanilla=ON"
           cmake $GITHUB_WORKSPACE $OPTIONS
@@ -242,58 +242,6 @@ jobs:
         working-directory: ${{ github.workspace }}/build
         shell: bash
         run: cmake --install .
-
-      - name: Bundle SDL runtime
-        if: ${{ matrix.build_type == 'Release' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          SDL3_DYLIB="$(brew --prefix sdl3)/lib/libSDL3.dylib"
-
-          if [ ! -f "$SDL3_DYLIB" ]; then
-            echo "SDL3 library not found: $SDL3_DYLIB"
-            exit 1
-          fi
-
-          find "${{ github.workspace }}/install" -type d -name "*.app" -print0 |
-          while IFS= read -r -d '' APP; do
-            FRAMEWORKS="$APP/Contents/Frameworks"
-
-            echo "Bundling SDL3 into: $APP"
-
-            mkdir -p "$FRAMEWORKS"
-            cp -L "$SDL3_DYLIB" "$FRAMEWORKS/libSDL3.dylib"
-
-            codesign --force --deep --sign - "$APP"
-          done
-
-      - name: Verify SDL runtime
-        if: ${{ matrix.build_type == 'Release' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          find "${{ github.workspace }}/install" -type d -name "*.app" -print0 |
-          while IFS= read -r -d '' APP; do
-            FRAMEWORKS="$APP/Contents/Frameworks"
-
-            echo "Checking: $APP"
-
-            test -f "$FRAMEWORKS/libSDL2-2.0.0.dylib"
-            test -f "$FRAMEWORKS/libSDL3.dylib"
-
-            file "$FRAMEWORKS/libSDL2-2.0.0.dylib"
-            file "$FRAMEWORKS/libSDL3.dylib"
-
-            echo "SDL2:"
-            otool -L "$FRAMEWORKS/libSDL2-2.0.0.dylib"
-
-            echo "SDL3:"
-            otool -L "$FRAMEWORKS/libSDL3.dylib"
-
-            codesign --verify --deep --strict "$APP"
-          done
 
       - name: Create OpenJK binary archive
         if: ${{ matrix.build_type == 'Release' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,8 +221,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          brew install libjpeg libpng
-
           BUILD_DIR="${{ github.workspace }}/build"
           SDL_PREFIX="${{ github.workspace }}/sdl-prefix"
           SDL_DMG="${{ runner.temp }}/SDL2-${SDL2_VERSION}.dmg"
@@ -335,10 +333,13 @@ jobs:
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
           OPTIONS+=" -DCMAKE_PREFIX_PATH=${{ github.workspace }}/sdl-prefix"
           OPTIONS+=" -DSDL2_DIR=${{ github.workspace }}/sdl-prefix/lib/cmake/SDL2"
+          OPTIONS+=" -DUseInternalLibs=ON"
+          OPTIONS+=" -DUseInternalSDL2=OFF"
+
           if [ "${{ matrix.portable }}" == "Portable" ]; then
-            OPTIONS+=" -DUseInternalLibs=ON -DUseInternalSDL2=OFF -DBuildPortableVersion=ON"
+            OPTIONS+=" -DBuildPortableVersion=ON"
           else
-            OPTIONS+=" -DUseInternalLibs=OFF -DUseInternalSDL2=OFF -DBuildPortableVersion=OFF"
+            OPTIONS+=" -DBuildPortableVersion=OFF"
           fi
           OPTIONS+=" -DBuildJK2SPEngine=ON -DBuildJK2SPGame=ON -DBuildJK2SPRdVanilla=ON"
           cmake $GITHUB_WORKSPACE $OPTIONS
@@ -391,6 +392,7 @@ jobs:
                 otool -L "$BINARY"
 
                 if otool -L "$BINARY" |
+                  tail -n +2 |
                   grep -E '/opt/homebrew|/usr/local|/Users/runner|sdl-prefix'; then
                   echo "Found a non-portable dependency in $BINARY"
                   exit 1
@@ -398,6 +400,7 @@ jobs:
               fi
             done
 
+            codesign --force --deep --sign - "$APP"
             codesign --verify --deep --strict "$APP"
           done < "$APP_LIST"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,6 +221,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          brew install libjpeg libpng
+
           BUILD_DIR="${{ github.workspace }}/build"
           SDL_PREFIX="${{ github.workspace }}/sdl-prefix"
           SDL_DMG="${{ runner.temp }}/SDL2-${SDL2_VERSION}.dmg"
@@ -333,7 +335,7 @@ jobs:
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
           OPTIONS+=" -DCMAKE_PREFIX_PATH=${{ github.workspace }}/sdl-prefix"
           OPTIONS+=" -DSDL2_DIR=${{ github.workspace }}/sdl-prefix/lib/cmake/SDL2"
-          OPTIONS+=" -DUseInternalLibs=ON"
+          OPTIONS+=" -DUseInternalLibs=OFF"
           OPTIONS+=" -DUseInternalSDL2=OFF"
 
           if [ "${{ matrix.portable }}" == "Portable" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,42 @@ jobs:
           ln -s "libSDL2-2.0.0.dylib" \
             "$SDL_PREFIX/lib/libSDL2.dylib"
 
+          cmake -E make_directory "$SDL_PREFIX/lib/cmake/SDL2"
+
+          cat > "$SDL_PREFIX/lib/cmake/SDL2/SDL2Config.cmake" <<'EOF'
+          get_filename_component(SDL2_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+          if(NOT TARGET SDL2::SDL2)
+            add_library(SDL2::SDL2 SHARED IMPORTED)
+            set_target_properties(SDL2::SDL2 PROPERTIES
+              IMPORTED_LOCATION "${SDL2_PREFIX}/lib/libSDL2-2.0.0.dylib"
+              INTERFACE_INCLUDE_DIRECTORIES "${SDL2_PREFIX}/include/SDL2"
+            )
+          endif()
+
+          if(NOT TARGET SDL2::SDL2main)
+            add_library(SDL2::SDL2main INTERFACE IMPORTED)
+          endif()
+
+          set(SDL2_FOUND TRUE)
+          set(SDL2_INCLUDE_DIRS "${SDL2_PREFIX}/include/SDL2")
+          set(SDL2_LIBRARIES SDL2::SDL2)
+          EOF
+
+          cat > "$SDL_PREFIX/lib/cmake/SDL2/SDL2ConfigVersion.cmake" <<EOF
+          set(PACKAGE_VERSION "${SDL2_VERSION}")
+
+          if(PACKAGE_FIND_VERSION VERSION_GREATER PACKAGE_VERSION)
+            set(PACKAGE_VERSION_COMPATIBLE FALSE)
+          else()
+            set(PACKAGE_VERSION_COMPATIBLE TRUE)
+
+            if(PACKAGE_FIND_VERSION VERSION_EQUAL PACKAGE_VERSION)
+              set(PACKAGE_VERSION_EXACT TRUE)
+            endif()
+          endif()
+          EOF
+
           codesign --force --sign - \
             "$SDL_PREFIX/lib/libSDL2-2.0.0.dylib"
 
@@ -295,6 +331,7 @@ jobs:
         run: |
           OPTIONS="-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install"
           OPTIONS+=" -DCMAKE_PREFIX_PATH=${{ github.workspace }}/sdl-prefix"
+          OPTIONS+=" -DSDL2_DIR=${{ github.workspace }}/sdl-prefix/lib/cmake/SDL2"
           if [ "${{ matrix.portable }}" == "Portable" ]; then
             OPTIONS+=" -DUseInternalLibs=ON -DUseInternalSDL2=OFF -DBuildPortableVersion=ON"
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,7 +259,7 @@ jobs:
           echo "Official SDL framework architectures:"
           lipo -archs "$SDL_FRAMEWORK_BINARY"
 
-          lipo -verify_arch x86_64 arm64 "$SDL_FRAMEWORK_BINARY"
+          lipo "$SDL_FRAMEWORK_BINARY" -verify_arch x86_64 arm64
 
           echo "Extracting the ${{ matrix.arch }} SDL2 library..."
           lipo "$SDL_FRAMEWORK_BINARY" \
@@ -339,7 +339,7 @@ jobs:
             echo "Checking $APP"
 
             test -f "$SDL_DYLIB"
-            lipo -verify_arch "${{ matrix.arch }}" "$SDL_DYLIB"
+            lipo "$SDL_DYLIB" -verify_arch "${{ matrix.arch }}"
 
             file "$SDL_DYLIB"
             otool -D "$SDL_DYLIB"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,7 +287,7 @@ jobs:
             add_library(SDL2::SDL2 SHARED IMPORTED)
             set_target_properties(SDL2::SDL2 PROPERTIES
               IMPORTED_LOCATION "${SDL2_PREFIX}/lib/libSDL2-2.0.0.dylib"
-              INTERFACE_INCLUDE_DIRECTORIES "${SDL2_PREFIX}/include/SDL2"
+              INTERFACE_INCLUDE_DIRECTORIES "${SDL2_PREFIX}/include;${SDL2_PREFIX}/include/SDL2"
             )
           endif()
 
@@ -296,7 +296,10 @@ jobs:
           endif()
 
           set(SDL2_FOUND TRUE)
-          set(SDL2_INCLUDE_DIRS "${SDL2_PREFIX}/include/SDL2")
+          set(SDL2_INCLUDE_DIRS
+            "${SDL2_PREFIX}/include"
+            "${SDL2_PREFIX}/include/SDL2"
+          )
           set(SDL2_LIBRARIES SDL2::SDL2)
           EOF
 


### PR DESCRIPTION
Build SDL2 2.32.10 from source for macOS release builds and bundle it inside each generated application bundle.

- Build a pinned SDL2 release during CI
- Link OpenJK against the source-built SDL2
- Bundle libSDL2-2.0.0.dylib into each .app
- Preserve internal libraries for portable builds while excluding the Windows-only bundled SDL2 libraries
- Verify the bundled SDL runtime during CI