### PR TITLE
[CG] Fix cg_fovViewModel when cg_fovAspectAdjust

### DIFF
--- a/code/cgame/cg_weapons.cpp
+++ b/code/cgame/cg_weapons.cpp
@@ -1126,9 +1126,10 @@ void CG_AddViewWeapon( playerState_t *ps )
 	AnglesToAxis( angles, hand.axis );
 
 
-	if ( cg_fovViewmodel.integer ) {
-		float fracDistFOV = tanf( cg.refdef.fov_x * ( M_PI/180 ) * 0.5f );
-		float fracWeapFOV = (1.0f / fracDistFOV) * tanf( actualFOV * (M_PI / 180) * 0.5f );
+	if ( cg_fovViewmodel.integer )
+	{
+		float fracDistFOV = tanf( cg_fov.value  * ( M_PI/180 ) * 0.5f );
+		float fracWeapFOV = (1.0f / fracDistFOV) * tanf( cg_fovViewmodel.value * (M_PI / 180) * 0.5f );
 		VectorScale( hand.axis[0], fracWeapFOV, hand.axis[0] );
 	}
 

--- a/codeJK2/cgame/cg_weapons.cpp
+++ b/codeJK2/cgame/cg_weapons.cpp
@@ -1039,8 +1039,8 @@ void CG_AddViewWeapon( playerState_t *ps )
 
 	if ( cg_fovViewmodel.integer )
 	{
-		float fracDistFOV = tanf( cg.refdef.fov_x * ( M_PI/180 ) * 0.5f );
-		float fracWeapFOV = ( 1.0f / fracDistFOV ) * tanf( cgFov * ( M_PI/180 ) * 0.5f );
+		float fracDistFOV = tanf( cg_fov.value * ( M_PI/180 ) * 0.5f );
+		float fracWeapFOV = ( 1.0f / fracDistFOV ) * tanf( cg_fovViewmodel.value * ( M_PI/180 ) * 0.5f );
 		VectorScale( hand.axis[0], fracWeapFOV, hand.axis[0] );
 	}
 

--- a/codemp/cgame/cg_weapons.c
+++ b/codemp/cgame/cg_weapons.c
@@ -848,8 +848,8 @@ void CG_AddViewWeapon( playerState_t *ps ) {
 
 	if ( cg_fovViewmodel.integer )
 	{
-		float fracDistFOV = tanf( cg.refdef.fov_x * ( M_PI/180 ) * 0.5f );
-		float fracWeapFOV = ( 1.0f / fracDistFOV ) * tanf( cgFov * ( M_PI/180 ) * 0.5f );
+		float fracDistFOV = tanf( cg_fov.value * ( M_PI/180 ) * 0.5f );
+		float fracWeapFOV = ( 1.0f / fracDistFOV ) * tanf( cg_fovViewmodel.value * ( M_PI/180 ) * 0.5f );
 		VectorScale( hand.axis[0], fracWeapFOV, hand.axis[0] );
 	}
 


### PR DESCRIPTION
The scaling factor should always be the same and based on the difference of the set fov and the wanted fov. All fov effects can work properly now and arent overwritten and it works with aspect correction.