### PR TITLE
Fix accessing deleted memory in OpenJO g_navigator.cpp

### DIFF
--- a/codeJK2/game/g_navigator.cpp
+++ b/codeJK2/game/g_navigator.cpp
@@ -556,6 +556,9 @@ void CNavigator::Free( void )
 	{
 		delete (*ni);
 	}
+
+	m_nodes.clear();
+	m_edgeLookupMap.clear();
 }
 
 /*


### PR DESCRIPTION
Have CNavigator::Free() in codeJK2 call m_nodes.clear() and m_edgeLookupMap.clear().  This fixes a bug on single player level end where the CNode * pointers were being deleted in Free() but not removed from m_nodes, so the next iteration of m_nodes would access deleted memory.  This also aligns codeJK2/g_navigator.cpp with codemp/navigator.cpp.