### PR TITLE
Implement hw independent overbrightbits support

### DIFF
--- a/code/rd-vanilla/tr_backend.cpp
+++ b/code/rd-vanilla/tr_backend.cpp
@@ -1521,6 +1521,31 @@ void RB_ShowImages( void ) {
 	//ri.Printf( PRINT_ALL, "%i msec to draw all images\n", end - start );
 }
 
+const void RB_EmulateOBB( void )
+{
+	if ( !backEnd.projection2D ) {
+		RB_SetGL2D();
+	}
+
+	GL_Bind( tr.whiteImage );
+	GL_State(
+		GLS_DEPTHTEST_DISABLE
+		| GLS_DSTBLEND_SRC_COLOR
+		| GLS_SRCBLEND_DST_COLOR
+	);
+	GL_Cull(CT_TWO_SIDED);
+
+	for (int i = 0; i < tr.overbrightBits; i++)
+	{
+		qglBegin (GL_TRIANGLES);
+			qglTexCoord2f( 0.5f, 0.5f );
+			qglColor3ub( 255, 255, 255);
+			qglVertex2f( 0, 0 );
+			qglVertex2f( 2 * glConfig.vidWidth, 0 );
+			qglVertex2f( 0, 2 * glConfig.vidHeight );
+		qglEnd();
+	}
+}
 
 /*
 =============
@@ -1540,6 +1565,10 @@ const void	*RB_SwapBuffers( const void *data ) {
 	// texture swapping test
 	if ( r_showImages->integer ) {
 		RB_ShowImages();
+	}
+
+	if ( tr.overbrightBitsEmulation ) {
+		RB_EmulateOBB();
 	}
 
 	cmd = (const swapBuffersCommand_t *)data;

--- a/code/rd-vanilla/tr_image.cpp
+++ b/code/rd-vanilla/tr_image.cpp
@@ -1408,14 +1408,17 @@ void R_SetColorMappings( void ) {
 
 	// setup the overbright lighting
 	tr.overbrightBits = r_overBrightBits->integer;
+	tr.overbrightBitsEmulation = qfalse;
 	if ( !glConfig.deviceSupportsGamma ) {
-		tr.overbrightBits = 0;		// need hardware gamma for overbright
+		tr.overbrightBitsEmulation = qtrue;
+		//tr.overbrightBits = 0;		// need hardware gamma for overbright
 	}
 
 	// never overbright in windowed mode
 	if ( !glConfig.isFullscreen )
 	{
-		tr.overbrightBits = 0;
+		tr.overbrightBitsEmulation = qtrue;
+		//tr.overbrightBits = 0;
 	}
 
 	if ( tr.overbrightBits > 1 ) {
@@ -1441,7 +1444,7 @@ void R_SetColorMappings( void ) {
 
 	g = r_gamma->value;
 
-	shift = tr.overbrightBits;
+	shift = tr.overbrightBitsEmulation ? 0 : tr.overbrightBits;
 
 	for ( i = 0; i < 256; i++ ) {
 		if ( g == 1 ) {
@@ -1467,7 +1470,7 @@ void R_SetColorMappings( void ) {
 		s_intensitytable[i] = j;
 	}
 
-	if ( glConfig.deviceSupportsGamma )
+	if ( !tr.overbrightBitsEmulation )
 	{
 		ri.WIN_SetGamma( &glConfig, s_gammatable, s_gammatable, s_gammatable );
 	}

--- a/code/rd-vanilla/tr_init.cpp
+++ b/code/rd-vanilla/tr_init.cpp
@@ -1536,8 +1536,13 @@ void R_Register( void )
 	r_detailTextures = ri.Cvar_Get( "r_detailtextures", "1", CVAR_ARCHIVE_ND | CVAR_LATCH );
 	r_texturebits = ri.Cvar_Get( "r_texturebits", "0", CVAR_ARCHIVE_ND | CVAR_LATCH );
 	r_texturebitslm = ri.Cvar_Get( "r_texturebitslm", "0", CVAR_ARCHIVE_ND | CVAR_LATCH );
+#ifdef JK2_MODE
+	r_overBrightBits = ri.Cvar_Get ("r_overBrightBits", "1", CVAR_ARCHIVE_ND | CVAR_LATCH );
+	r_mapOverBrightBits = ri.Cvar_Get( "r_mapOverBrightBits", "1", CVAR_ARCHIVE_ND|CVAR_LATCH );
+#else
 	r_overBrightBits = ri.Cvar_Get ("r_overBrightBits", "0", CVAR_ARCHIVE_ND | CVAR_LATCH );
 	r_mapOverBrightBits = ri.Cvar_Get( "r_mapOverBrightBits", "0", CVAR_ARCHIVE_ND|CVAR_LATCH );
+#endif
 	r_simpleMipMaps = ri.Cvar_Get( "r_simpleMipMaps", "1", CVAR_ARCHIVE_ND | CVAR_LATCH );
 	r_vertexLight = ri.Cvar_Get( "r_vertexLight", "0", CVAR_ARCHIVE | CVAR_LATCH );
 	r_subdivisions = ri.Cvar_Get ("r_subdivisions", "4", CVAR_ARCHIVE_ND | CVAR_LATCH);

--- a/code/rd-vanilla/tr_local.h
+++ b/code/rd-vanilla/tr_local.h
@@ -1016,6 +1016,7 @@ typedef struct {
 	float					identityLight;		// 1.0 / ( 1 << overbrightBits )
 	int						identityLightByte;	// identityLight * 255
 	int						overbrightBits;		// r_overbrightBits->integer, but set to 0 if no hw gamma
+	qboolean				overbrightBitsEmulation;
 
 	orientationr_t			ori;					// for current entity
 


### PR DESCRIPTION
And fix defaults for overbrightbits cvars in the vanilla openjo renderer.

We should probably implement the gammaShader thing from MP in SP as well and make it default to be on. Just thought this is nice to document as an alternative to implementing overbrightbits.